### PR TITLE
Lower α_default from 1.0 to 0.9

### DIFF
--- a/src/solidmodels/render.jl
+++ b/src/solidmodels/render.jl
@@ -428,7 +428,7 @@ samplingrate(path::Paths.Node, local_size) =
     Base.@kwdef struct MeshingParameters
         mesh_scale::Float64 = 1.0
         mesh_order::Int = 1
-        α_default::Float64 = 1.0
+        α_default::Float64 = 0.9
         apply_size_to_surfaces::Bool = false
         high_order_optimize::Int = 1
         surface_mesh_algorithm::Int = 6
@@ -450,7 +450,8 @@ fields throughout the domain.
     difficult (and prone to errors).
   - `α_default` specifies the default value of `α` to use for `MeshSized` entities where `α`
     is set to less than 0, `α_default ∈ (0, 1]` is particularly used for the default grading
-    of `Path` entities.
+    of `Path` entities. A value closer to 1 can result in an unstable meshing algorithm in gmsh,
+    particularly for complex geometries.
   - `apply_size_to_surfaces=true` will cause the mesh sizing field to specify the size within
     any sized entities, as opposed to only along the perimeter of the entity if
     `apply_size_to_surfaces=false`. Setting `apply_size_to_surfaces=true` will result in a
@@ -470,7 +471,7 @@ fields throughout the domain.
 Base.@kwdef struct MeshingParameters
     mesh_scale::Float64 = 1.0
     mesh_order::Int = 1
-    α_default::Float64 = 1.0
+    α_default::Float64 = 0.9
     apply_size_to_surfaces::Bool = false
     high_order_optimize::Int = 1
     surface_mesh_algorithm::Int = 6

--- a/test/test_solidmodel.jl
+++ b/test/test_solidmodel.jl
@@ -672,10 +672,10 @@ import DeviceLayout.SolidModels.STP_UNIT
     @test SolidModels.meshgrading(rsr) == 1.1
 
     # Optional sizing field.
-    sty = OptionalStyle(MeshSized(1μm, 0.9), :refine, false_style=MeshSized(0.5μm, 0.6))
+    sty = OptionalStyle(MeshSized(1μm, 0.8), :refine, false_style=MeshSized(0.5μm, 0.6))
     rs = styled(r, sty)
     @test SolidModels.meshsize(rs, refine=true) == Unitful.ustrip(STP_UNIT, 1μm)
-    @test SolidModels.meshgrading(rs, refine=true) == 0.9
+    @test SolidModels.meshgrading(rs, refine=true) == 0.8
     @test SolidModels.meshsize(rs, refine=false) == Unitful.ustrip(STP_UNIT, 0.5μm)
     @test SolidModels.meshgrading(rs, refine=false) == 0.6
 
@@ -683,7 +683,7 @@ import DeviceLayout.SolidModels.STP_UNIT
     rr = Polygons.Rounded(rs, 1μm)
     rrs = styled(rr, sty)
     @test SolidModels.meshsize(rrs, refine=true) == Unitful.ustrip(STP_UNIT, 1μm)
-    @test SolidModels.meshgrading(rrs, refine=true) == 0.9
+    @test SolidModels.meshgrading(rrs, refine=true) == 0.8
     @test SolidModels.meshsize(rrs, refine=false) == Unitful.ustrip(STP_UNIT, 0.5μm)
     @test SolidModels.meshgrading(rrs, refine=false) == 0.6
 
@@ -691,7 +691,7 @@ import DeviceLayout.SolidModels.STP_UNIT
     rr = OptionalStyle(Polygons.Rounded(0.5μm), :round, false_style=sty)(r)
     @test SolidModels.meshsize(rr, refine=true, round=false) ==
           Unitful.ustrip(STP_UNIT, 1μm)
-    @test SolidModels.meshgrading(rr, refine=true, round=false) == 0.9
+    @test SolidModels.meshgrading(rr, refine=true, round=false) == 0.8
     @test SolidModels.meshsize(rr, refine=false, round=false) ==
           Unitful.ustrip(STP_UNIT, 0.5μm)
     @test SolidModels.meshgrading(rr, refine=false, round=false) == 0.6
@@ -705,7 +705,7 @@ import DeviceLayout.SolidModels.STP_UNIT
     ds = OptionalStyle(Polygons.Rounded(0.5μm), :round, false_style=sty, default=false)(d)
     @test SolidModels.meshsize(ds, refine=true, round=false) ==
           Unitful.ustrip(STP_UNIT, 1μm)
-    @test SolidModels.meshgrading(ds, refine=true, round=false) == 0.9
+    @test SolidModels.meshgrading(ds, refine=true, round=false) == 0.8
     @test SolidModels.meshsize(ds, refine=false, round=false) ==
           Unitful.ustrip(STP_UNIT, 0.5μm)
     @test SolidModels.meshgrading(ds, refine=false, round=false) == 0.6
@@ -716,11 +716,11 @@ import DeviceLayout.SolidModels.STP_UNIT
 
     # Styled Ellipse
     e = Ellipse(2 .* Point(2.0μm, 1.0μm), (2.0μm, 1.0μm), 45°)
-    sty = OptionalStyle(MeshSized(0.5μm, 0.9), :refine, false_style=MeshSized(1.0μm, 0.6))
+    sty = OptionalStyle(MeshSized(0.5μm, 0.8), :refine, false_style=MeshSized(1.0μm, 0.6))
     es = styled(e, sty)
     @test SolidModels.to_primitives(sm, es) == es.ent
     @test SolidModels.meshsize(es, refine=true) == Unitful.ustrip(STP_UNIT, 0.5μm)
-    @test SolidModels.meshgrading(es, refine=true) == 0.9
+    @test SolidModels.meshgrading(es, refine=true) == 0.8
     @test SolidModels.meshsize(es, refine=false) == Unitful.ustrip(STP_UNIT, 1.0μm)
     @test SolidModels.meshgrading(es, refine=false) == 0.6
 


### PR DESCRIPTION
Default of 1.0 can result in gmsh returning very poor quality meshes due to the aggressive gradation of the sizing field. This is particularly problematic for complex and curved geometries. Lowering the default to 0.9 improves robustness.
