### PR TITLE
Fix initial termination starting point, behavior on curves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format of this changelog is based on
 ### Fixed
 
   - `launch!` without rounding now has the correct gap behind the pad
+  - `terminate!` with `initial=true` appends the termination before the `Path` start as documented (previously incorrectly kept `p0(path)` constant, shifting the rest of the `Path` forward)
+  - `terminate!` with rounding on a curve is still drawn as straight but keeps the full underlying segment (previously consumed some turn angle to replace with straight segment including rounding length)
 
 ## 1.0.0 (2025-02-27)
 

--- a/src/solidmodels/render.jl
+++ b/src/solidmodels/render.jl
@@ -327,8 +327,13 @@ end
 # Note: this is called during SolidModel rendering after flattening, so we don't worry about decorations
 # Similarly generic tapers have been resolved
 
-# Fallback: use to_polygons
-function to_primitives(::SolidModel, f::Paths.Segment, s::Paths.Style; kwargs...)
+# Fallback: use pathtopolys to get CurvilinearPolygons
+function to_primitives(
+    ::SolidModel,
+    f::Paths.Segment{T},
+    s::Paths.Style;
+    kwargs...
+) where {T}
     return pathtopolys(f, s; kwargs...)
 end
 
@@ -342,10 +347,10 @@ function to_primitives(
     return vcat(to_primitives.(sm, f.segments, s.styles; kwargs...)...)
 end
 
-# Terminations are only used with Straight and generate one or two [Rounded] Polygons
+# Terminations generate up to two [Rounded] Polygons
 function to_primitives(
     sm::SolidModel,
-    seg::Paths.Straight{T},
+    seg::Paths.Segment{T},
     sty::Union{Paths.TraceTermination, Paths.CPWOpenTermination, Paths.CPWShortTermination};
     kwargs...
 ) where {T}

--- a/test/test_solidmodel.jl
+++ b/test/test_solidmodel.jl
@@ -189,6 +189,16 @@ import DeviceLayout.SolidModels.STP_UNIT
         isapprox.([x0, y0, x1, y1], ustrip.(STP_UNIT, [x0d, y0d, x1d, y1d]), atol=1e-6)
     )
 
+    # Termination on curve is still drawn with circular arcs
+    cs = CoordinateSystem("test", nm)
+    pa = Path(0nm, 0nm)
+    turn!(pa, 90°, 10μm, Paths.SimpleCPW(5μm, 2μm))
+    terminate!(pa; rounding=2.5μm)
+    place!(cs, pa, SemanticMeta(:test))
+    sm = SolidModel("test"; overwrite=true)
+    render!(sm, cs)
+    @test length(SolidModels.gmsh.model.occ.getEntities(0)) < 20 # would be >100 points if discretized
+
     # Compound segment/style
     cs = CoordinateSystem("test", nm)
     pa = Path(0nm, 0nm)

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -633,6 +633,7 @@ end
         @test Paths.gap(sty) === 6000.0nm
         @test Paths.trace(sty) === 10000.0nm
         @test pa[1].sty isa Paths.CPWOpenTermination
+        @test bounds(pa).ll ≈ -Point(pa[1].sty.gap, Paths.extent(pa[1].sty))
 
         pa = Path(μm)
         sty = launch!(pa, trace1=4.2μm, gap1=3801nm)


### PR DESCRIPTION
- `terminate!` with `initial=true` was written to append the termination before the path, but because `pa.p0` was not being updated, it was being reconciled such that the rest of the `Path` was shifted forward. This bug did not affect usage as long as relative positioning (e.g., relative to `p0(pa)` or hooks) was used.
- `terminate!` on a curve with rounding would previously eat some of the turn angle then go straight by the rounding length plus termination gap. This caused the final direction to change (or caused the entire path to rotate slightly when `initial=true`). Now it finishes out the underlying curve and only goes straight by the termination gap afterward, keeping the final direction the same. (This is the second item in #22.) The termination is still drawn as though straight, allowing rounding to be represented with exact circular arcs.