### PR TITLE
Add trace method for decorated styles

### DIFF
--- a/src/paths/contstyles/compound.jl
+++ b/src/paths/contstyles/compound.jl
@@ -60,7 +60,7 @@ function makegrid(segments::AbstractVector{T}, styles) where {T <: Segment}
     return cumsum!(grid, grid)
 end
 
-for x in (:extent, :width)
+for x in (:extent, :width, :trace, :gap)
     @eval function ($x)(s::CompoundStyle, t)
         sty, teff = s(t)
         return ($x)(sty, teff)

--- a/src/paths/contstyles/decorated.jl
+++ b/src/paths/contstyles/decorated.jl
@@ -42,6 +42,8 @@ extent(s::AbstractDecoratedStyle, t...) = extent(undecorated(s), t...)
 
 isvirtual(s::AbstractDecoratedStyle) = isvirtual(undecorated(s))
 
+trace(s::AbstractDecoratedStyle, t...) = trace(undecorated(s).s, t...)
+
 """
     Base.copy(sty::DecoratedStyle)
 

--- a/src/paths/contstyles/decorated.jl
+++ b/src/paths/contstyles/decorated.jl
@@ -44,6 +44,10 @@ isvirtual(s::AbstractDecoratedStyle) = isvirtual(undecorated(s))
 
 trace(s::AbstractDecoratedStyle, t...) = trace(undecorated(s), t...)
 
+gap(s::AbstractDecoratedStyle, t...) = gap(undecorated(s), t...)
+
+width(s::AbstractDecoratedStyle, t...) = width(undecorated(s), t...)
+
 """
     Base.copy(sty::DecoratedStyle)
 

--- a/src/paths/contstyles/decorated.jl
+++ b/src/paths/contstyles/decorated.jl
@@ -42,7 +42,7 @@ extent(s::AbstractDecoratedStyle, t...) = extent(undecorated(s), t...)
 
 isvirtual(s::AbstractDecoratedStyle) = isvirtual(undecorated(s))
 
-trace(s::AbstractDecoratedStyle, t...) = trace(undecorated(s).s, t...)
+trace(s::AbstractDecoratedStyle, t...) = trace(undecorated(s), t...)
 
 """
     Base.copy(sty::DecoratedStyle)

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -650,6 +650,29 @@ end
         @test_throws DimensionError launch!(pa, trace1=3.0)
     end
 
+    @testset "> Decorated Paths" begin
+        # Bumps
+        rr = centered(Rectangle(10μm, 10μm))
+        cs_rr = CoordinateSystem(uniquename("test"), nm)
+        place!(cs_rr, rr, SemanticMeta(:bump))
+
+        # Trace
+        pth = Path(Point(100μm, 100μm); α0=π / 2)
+        straight!(pth, 800μm, Paths.Trace(20.0μm))
+        attach!(pth, sref(cs_rr), (0μm):(50μm):(800μm))
+        @test Paths.trace(pth.nodes[1].sty) === 20.0μm
+        @test Paths.width(pth.nodes[1].sty) === 20.0μm
+        @test Paths.extent(pth.nodes[1].sty) === 10.0μm
+
+        # CPW
+        pth = Path(Point(100μm, 100μm); α0=π / 2)
+        straight!(pth, 800μm, Paths.SimpleCPW(10.0μm, 6.0μm))
+        attach!(pth, sref(cs_rr), (0μm):(50μm):(800μm))
+        @test Paths.trace(pth.nodes[1].sty) === 10.0μm
+        @test Paths.gap(pth.nodes[1].sty) === 6.0μm
+        @test Paths.extent(pth.nodes[1].sty) === 11.0μm
+    end
+
     @testset "> CompoundSegment" begin
         pa = Path{Float64}()
         straight!(pa, 200.0, Paths.Trace(10))


### PR DESCRIPTION
<!--
*Description of changes:*

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
-->
Add trace method for decorated styles