### PR TITLE
fix: Add or forward entity interface methods for StyledEntity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ The format of this changelog is based on
 ## Upcoming
 
   - Added `set_periodic!` to `SolidModels` to enable periodic meshes.
+  - Minor documentation improvements
 
 ### Fixed
 
   - `DecoratedStyle` and `CompoundStyle` are no longer missing any of the methods `width`, `trace`, or `gap` (forwarded to the underlying style)
+  - `GeometryEntity` interface methods (`lowerleft/upperright/bounds`, `footprint`, `halo`) for `StyledEntity` now fall back to underlying entity as documented;
+    specialized behavior for `NoRender` and `OptionalStyle` is preserved but now documented
 
 ## 1.2.0 (2025-04-28)
 

--- a/test/test_entity.jl
+++ b/test/test_entity.jl
@@ -87,6 +87,12 @@
         render!(c, ToTolerance(opt_round_plus, 0.01))
         @test length(points(last(elements(c)))) < length(points(to_polygons(pr)))
         @test length(points(last(elements(c)))) > length(points(to_polygons(plus)))
+        @test halo(opt_round_plus, 2) == halo(plus, 2) # forwarded to underlying ent
+        @test footprint(opt_round_plus) == footprint(plus)
+        # Other interface functions use default style; NoRender -> zero bounds
+        @test isempty(halo(opt_plus, 2))
+        @test !isproper(footprint(opt_plus))
+        @test !isproper(bounds(opt_plus))
     end
 
     @testset "Path Nodes" begin


### PR DESCRIPTION
According to the GeometryEntityStyle doctring, "Unless implemented by the style, `lowerleft` and `upperright` (and hence `bounds`) of a styled entity will use the underlying entity's bounds." This wasn't actually true, but now it is. The other GeometryInterface methods, `footprint` and `halo`, were not mentioned, but they now also forward to the underlying entity except where specialized on the style.

Previously, `to_polygons` was called first, meaning `NoRender` led to zero bounds / empty entity list and `OptionalStyle` applied its default style (most relevantly for NoRender). These are the correct behaviors, but because they are different from the fallback they are now implemented as specializations to the GeometryEntity interface methods.