### PR TITLE
Check overlap of SolidModel physical groups

### DIFF
--- a/src/solidmodels/postrender.jl
+++ b/src/solidmodels/postrender.jl
@@ -1001,25 +1001,22 @@ Intersections (if any) for entities of dimension dim should have dim-1. Otherwis
 Return the overlapping groups as a vector of `(group1, group2, dimension)` `Tuple`s.
 """
 function check_overlap(sm::SolidModel)
-    overlapping_groups = []
-    for dim in [1, 2, 3]
+    overlapping_groups = Tuple{String, String, Int}[]
+    for dim = 1:3
         for (name1, _) in SolidModels.dimgroupdict(sm, dim)
             for (name2, _) in SolidModels.dimgroupdict(sm, dim)
-                name1 == name2 && continue
+                name1 >= name2 && continue
                 intersections = intersect_geom!(sm, name1, name2, dim, dim)
                 for intersection in intersections
                     if intersection[1] > dim - 1
                         @warn "Overlap of SolidModel groups $name1 and $name2 of dimension $dim."
-                        push!(
-                            overlapping_groups,
-                            (min(name1, name2), max(name1, name2), dim)
-                        )
+                        push!(overlapping_groups, (name1, name2, dim))
                     end
                 end
             end
         end
     end
-    return unique(overlapping_groups)
+    return overlapping_groups
 end
 
 """

--- a/src/solidmodels/postrender.jl
+++ b/src/solidmodels/postrender.jl
@@ -1002,7 +1002,7 @@ Return the overlapping groups as a vector of `(group1, group2, dimension)` `Tupl
 """
 function check_overlap(sm::SolidModel)
     overlapping_groups = Tuple{String, String, Int}[]
-    for dim = 1:3
+    for dim in 1:3
         for (name1, _) in SolidModels.dimgroupdict(sm, dim)
             for (name2, _) in SolidModels.dimgroupdict(sm, dim)
                 name1 >= name2 && continue

--- a/src/solidmodels/postrender.jl
+++ b/src/solidmodels/postrender.jl
@@ -1002,7 +1002,7 @@ Return the overlapping groups as a vector of `(group1, group2, dimension)` `Tupl
 """
 function check_overlap(sm::SolidModel)
     overlapping_groups = Tuple{String, String, Int}[]
-    for dim in 1:3
+    for dim = 1:3
         for (name1, _) in SolidModels.dimgroupdict(sm, dim)
             for (name2, _) in SolidModels.dimgroupdict(sm, dim)
                 name1 >= name2 && continue

--- a/src/solidmodels/postrender.jl
+++ b/src/solidmodels/postrender.jl
@@ -993,6 +993,34 @@ function remove_group!(group::PhysicalGroup; recursive=true, remove_entities=fal
 end
 
 """
+    check_overlap(sm::SolidModel; strict=:error)
+
+Check for overlap/intersections between SolidModel groups of the same dimension.
+Intersections (if any) for entities of dimension dim should have dim-1. Otherwise it means there is overlap.
+
+End in error if `strict` is `:error`, display a warning if `strict` is `:warn`, skip the check if `strict` is `:no`.
+"""
+function check_overlap(sm::SolidModel; strict=:error)
+    if strict ∉ [:error, :warn, :no]
+        @warn "Keyword `strict` in `check_overlap` should be `:error`, `:warn`, or `:no` (got `:$strict`). Proceeding as though `strict=:no` were used."
+    end
+    strict == :no && return
+    for dim in [1, 2, 3]
+        for (name1, _) in SolidModels.dimgroupdict(sm, dim)
+            for (name2, _) in SolidModels.dimgroupdict(sm, dim)
+                name1 == name2 && continue
+                intersections = intersect_geom!(sm, name1, name2, dim, dim)
+                error_msg = "Overlap of SolidModel groups $name1 and $name2."
+                for intersection in intersections
+                    intersection[1] > dim - 1 && strict == :warn && @warn error_msg
+                    intersection[1] > dim - 1 && strict == :error && @error error_msg
+                end
+            end
+        end
+    end
+end
+
+"""
     staple_bridge_postrendering(; levels=[], base, bridge, bridge_height=1μm, output="bridge_metal")
 
 Returns a vector of postrendering operations for creating air bridges from a `base` and

--- a/test/test_solidmodel.jl
+++ b/test/test_solidmodel.jl
@@ -1053,6 +1053,13 @@ import DeviceLayout.SolidModels.STP_UNIT
     render!(sm, cs)
     @test isnothing(SolidModels.check_overlap(sm; strict=:error))
 
+    @test isnothing(
+        @test_logs (
+            :warn,
+            "Keyword `strict` in `check_overlap` should be `:error`, `:warn`, or `:no` (got `:bla`). Proceeding as though `strict=:no` were used."
+        ) SolidModels.check_overlap(sm; strict=:bla)
+    )
+
     # TODO: Composing OptionalStyle
 
     # Explicitly MeshSized Path.

--- a/test/test_solidmodel.jl
+++ b/test/test_solidmodel.jl
@@ -1033,10 +1033,13 @@ import DeviceLayout.SolidModels.STP_UNIT
     place!(cs, r2, SemanticMeta(Symbol("r2")))
     sm = test_sm()
     render!(sm, cs)
-    @test @test_logs (:warn, "Overlap of SolidModel groups r1 and r2 of dimension 2.") (
-        :warn,
-        "Overlap of SolidModel groups r2 and r1 of dimension 2."
-    ) SolidModels.check_overlap(sm) == [("r1", "r2", 2)]
+    @test @test_logs (:warn, "Overlap of SolidModel groups r1 and r2 of dimension 2.") SolidModels.check_overlap(
+        sm
+    ) == [(
+        "r1",
+        "r2",
+        2
+    )]
 
     cs = CoordinateSystem("test", nm)
     place!(cs, r1, SemanticMeta(Symbol("r1")))

--- a/test/test_solidmodel.jl
+++ b/test/test_solidmodel.jl
@@ -1033,32 +1033,17 @@ import DeviceLayout.SolidModels.STP_UNIT
     place!(cs, r2, SemanticMeta(Symbol("r2")))
     sm = test_sm()
     render!(sm, cs)
-    @test isnothing(
-        @test_logs (:error, "Overlap of SolidModel groups r1 and r2.") (
-            :error,
-            "Overlap of SolidModel groups r2 and r1."
-        ) SolidModels.check_overlap(sm; strict=:error)
-    )
-    @test isnothing(
-        @test_logs (:warn, "Overlap of SolidModel groups r1 and r2.") (
-            :warn,
-            "Overlap of SolidModel groups r2 and r1."
-        ) SolidModels.check_overlap(sm; strict=:warn)
-    )
+    @test @test_logs (:warn, "Overlap of SolidModel groups r1 and r2 of dimension 2.") (
+        :warn,
+        "Overlap of SolidModel groups r2 and r1 of dimension 2."
+    ) SolidModels.check_overlap(sm) == [("r1", "r2", 2)]
 
     cs = CoordinateSystem("test", nm)
     place!(cs, r1, SemanticMeta(Symbol("r1")))
     place!(cs, r3, SemanticMeta(Symbol("r3")))
     sm = test_sm()
     render!(sm, cs)
-    @test isnothing(SolidModels.check_overlap(sm; strict=:error))
-
-    @test isnothing(
-        @test_logs (
-            :warn,
-            "Keyword `strict` in `check_overlap` should be `:error`, `:warn`, or `:no` (got `:bla`). Proceeding as though `strict=:no` were used."
-        ) SolidModels.check_overlap(sm; strict=:bla)
-    )
+    @test isempty(SolidModels.check_overlap(sm))
 
     # TODO: Composing OptionalStyle
 


### PR DESCRIPTION
<!--
*Description of changes:*

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
-->
When rendering to SolidModel, it is possible to create models with overlapping entities. These can cause errors when meshing or in downstream uses. This method checks for overlaps and displays an error or warning informing the user of the overlapping physical groups.  
