### PR TITLE
Improve B-spline approximations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format of this changelog is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## Upcoming
+
+  - Improved B-spline approximations
+
+### Fixed
+
+  - `atol` is now used for B-spline approximation of arbitrary curves when rendering to `SolidModel`
+
 ## 1.3.0 (2025-06-06)
 
   - Added `set_periodic!` to `SolidModels` to enable periodic meshes

--- a/src/curvilinear.jl
+++ b/src/curvilinear.jl
@@ -89,7 +89,11 @@ end
 CurvilinearPolygon(p::Polygon{T}) where {T} = CurvilinearPolygon{T}(points(p))
 
 ### Conversion methods
-function to_polygons(e::CurvilinearPolygon{T}; kwargs...) where {T}
+function to_polygons(
+    e::CurvilinearPolygon{T};
+    atol=DeviceLayout.onenanometer(T),
+    kwargs...
+) where {T}
     i = 1
     p = Point{T}[]
 

--- a/src/paths/segments/bspline.jl
+++ b/src/paths/segments/bspline.jl
@@ -299,7 +299,7 @@ end
 
 # positive curvature radius is a left handed turn, negative right handed.
 function curvatureradius(b::BSpline{T}, s) where {T}
-    t = arclength_to_t(b, s)
+    t = clamp(arclength_to_t(b, s), 0.0, 1.0)
     g = Interpolations.gradient(b.r, t)[1]
     h = Interpolations.hessian(b.r, t)[1]
     return (g[1]^2 + g[2]^2)^(3 // 2) / (g[1] * h[2] - g[2] * h[1])

--- a/src/paths/segments/bspline_approximation.jl
+++ b/src/paths/segments/bspline_approximation.jl
@@ -1,65 +1,28 @@
-# Calculate approximation error
-function _approximation_error(
-    f::Paths.Segment{T},
-    f_approx::Paths.BSpline,
-    testvals=nothing
-) where {T}
-    # In this case, testvals are chosen based on f_approx, so they will be different every iteration
-    tgrid, exact, exact_normal, _ = _testvals(f, f_approx)
-    approx = f_approx.r.(tgrid)
-    # f_approx may not be arclength-parameterized
-    # but each exact point should be within 1nm of some line segment on
-    # the discretization of f_approx
-    idx_0 = 1
-    maxerr = zero(T)
-    for (p, normal) in zip(exact, exact_normal) # For each exact point, project it onto the approximate segments        
-        # Find the first approx segment where the projection lies on that segment
-        # (Starting with the approximate segment previously found)
-        for idx = idx_0:(length(approx) - 1)
-            intersects, ixn = Polygons.intersection(
-                Polygons.Ray(p, p + normal),
-                Polygons.LineSegment(approx[idx], approx[idx + 1])
-            )
-            if !intersects # Maybe we checked the ray in the wrong direction
-                intersects, ixn = Polygons.intersection(
-                    Polygons.Ray(p, p - normal),
-                    Polygons.LineSegment(approx[idx], approx[idx + 1])
-                )
-            end
-            if intersects # We found a projection that lies on the approximation
-                idx_0 = idx
-                maxerr = max(maxerr, norm(p - ixn))
-                break
-            end
-        end
-    end
-    return maxerr
-end
-
+# Arbitrary segment: Discretize according to approximation's curvature
 function _testvals(f::Paths.Segment{T}, f_approx::Paths.BSpline) where {T}
     l = Paths.pathlength(f)
-    h(t) = Paths.Interpolations.hessian(f_approx.r, t)[1]
-    tgrid = DeviceLayout.discretization_grid(h, _default_curve_atol(T))
-    exact = f.(tgrid * l)
-    dir = direction.(Ref(f), tgrid * l)
+    tgrid = DeviceLayout.discretization_grid(f, _default_curve_atol(T))
+    sgrid = tgrid * l
+    offsets = fill(zero(T), length(tgrid))
+    exact = f.(sgrid)
+    dir = direction.(Ref(f), sgrid)
     normal = oneunit(T) * Point.(-sin.(dir), cos.(dir))
-    return tgrid, exact, normal, nothing
+    return tgrid, exact, normal, offsets
 end
 
-function _testvals(
-    f::Paths.ConstantOffset{T, BSpline{T}},
-    f_approx::Paths.BSpline
-) where {T}
-    h(t) = Paths.Interpolations.hessian(f.seg.r, t)[1]
-    tgrid = DeviceLayout.discretization_grid(h, _default_curve_atol(T))
-    off = abs(getoffset(f))
+function _testvals(f::Paths.OffsetSegment{T}, f_approx::Paths.BSpline) where {T}
+    l = Paths.pathlength(f)
+    tgrid = DeviceLayout.discretization_grid(f, _default_curve_atol(T))
+    sgrid = tgrid * l
     # Don't actually calculate the exact curve, we'll only check that the offset is correct
-    exact = f.seg.r.(tgrid)
-    tangent = first.(Paths.Interpolations.gradient.(Ref(f.seg.r), tgrid))
-    normal = Point.(-gety.(tangent), getx.(tangent))
-    return tgrid, exact, normal, off
+    offsets = abs.(getoffset.(Ref(f), sgrid))
+    exact = f.seg.(sgrid)
+    dir = direction.(Ref(f.seg), sgrid)
+    normal = oneunit(T) * Point.(-sin.(dir), cos.(dir))
+    return tgrid, exact, normal, offsets
 end
 
+# Offset bsplines use tgrid directly to calculate a bit faster
 function _testvals(f::Paths.GeneralOffset{T, BSpline{T}}, f_approx::Paths.BSpline) where {T}
     h(t) = Paths.Interpolations.hessian(f.seg.r, t)[1]
     tgrid = DeviceLayout.discretization_grid(h, _default_curve_atol(T))
@@ -72,46 +35,52 @@ function _testvals(f::Paths.GeneralOffset{T, BSpline{T}}, f_approx::Paths.BSplin
     return tgrid, exact, normal, offsets
 end
 
-# For BSpline offsets, use t parameterization rather than arclength (much faster)
-function _approximation_error(
+# don't even need to calculate sgrid for constant offset BSpline
+function _testvals(
     f::Paths.ConstantOffset{T, BSpline{T}},
-    f_approx::Paths.BSpline{T},
-    testvals=_testvals(f, f_approx)
+    f_approx::Paths.BSpline
 ) where {T}
-    tgrid, exact, exact_normal, off = testvals
-    approx = f_approx.r.(tgrid)
-    # f_approx may not be arclength-parameterized
-    # but each exact point should be within 1nm of some line segment on
-    # the discretization of f_approx
-    idx_0 = 1
-    maxerr = zero(T)
-    for (p, normal) in zip(exact, exact_normal) # For each exact point, project it onto the approximate segments        
-        # Find the first approx segment where the projection lies on that segment
-        # (Starting with the approximate segment previously found)
-        for idx = idx_0:(length(approx) - 1)
-            intersects, ixn = Polygons.intersection(
-                Polygons.Ray(p, p + normal),
-                Polygons.LineSegment(approx[idx], approx[idx + 1])
-            )
-            if !intersects # Maybe we checked the ray in the wrong direction
-                intersects, ixn = Polygons.intersection(
-                    Polygons.Ray(p, p - normal),
-                    Polygons.LineSegment(approx[idx], approx[idx + 1])
-                )
-            end
-            if intersects # We found a projection that lies on the approximation
-                idx_0 = idx
-                maxerr = max(maxerr, abs(norm(p - ixn) - off))
-                break
-            end
-        end
-    end
-    return maxerr
+    h(t) = Paths.Interpolations.hessian(f.seg.r, t)[1]
+    tgrid = DeviceLayout.discretization_grid(h, _default_curve_atol(T))
+    off = abs(getoffset(f))
+    # Don't actually calculate the exact curve, we'll only check that the offset is correct
+    exact = f.seg.r.(tgrid)
+    tangent = first.(Paths.Interpolations.gradient.(Ref(f.seg.r), tgrid))
+    normal = Point.(-gety.(tangent), getx.(tangent))
+    return tgrid, exact, normal, fill(off, length(tgrid))
 end
 
-# For BSpline variable offsets, we need arclength-parameterized offsets for every test point
+_t_halflength(::Segment) = 0.5
+_t_halflength(seg::OffsetSegment) = _t_halflength(seg.seg)
+_t_halflength(seg::BSpline) = arclength_to_t(seg, pathlength(seg) / 2)
+
+function _split_testvals(testvals, seg::Segment{T}) where {T}
+    tgrid, exact, normal, offset = testvals
+    t_half = _t_halflength(seg)
+    idx_h2 = findfirst(t -> t > t_half, tgrid)
+    isnothing(idx_h2) &&
+        error("B-spline approximation of $seg is not converging; try increasing `atol`.")
+    t_h1 = tgrid[1:(idx_h2 - 1)]
+    t_h2 = tgrid[idx_h2:end]
+    new_tgrid_h1 = t_h1 / t_half
+    new_tgrid_h2 = (t_h2 .- t_half) / (1 - t_half)
+    return (
+        new_tgrid_h1,
+        (@view exact[1:(idx_h2 - 1)]),
+        (@view normal[1:(idx_h2 - 1)]),
+        (@view offset[1:(idx_h2 - 1)])
+    ),
+    (
+        new_tgrid_h2,
+        (@view exact[idx_h2:end]),
+        (@view normal[idx_h2:end]),
+        (@view offset[idx_h2:end])
+    )
+end
+
+# For offsets, we use the underlying curve and check that the approximation is offset away
 function _approximation_error(
-    f::Paths.GeneralOffset{T, BSpline{T}},
+    f::Paths.Segment{T},
     f_approx::Paths.BSpline{T},
     testvals=_testvals(f, f_approx)
 ) where {T}
@@ -146,67 +115,18 @@ function _approximation_error(
     return maxerr
 end
 
-function _sample_points(f::Paths.Segment{T}, num_points) where {T}
-    s = range(zero(T), pathlength(f), length=num_points)
-    return [p0(f), (f.(s[2:(end - 1)]))..., p1(f)]
-end
-
-function _sample_points(b::Paths.BSpline{T}, num_points) where {T}
-    t = range(0.0, 1.0, length=num_points)
-    return [p0(b), (b.r.(t[2:(end - 1)]))..., p1(b)]
-end
-
-function _sample_points(f::Paths.ConstantOffset{T, BSpline{T}}, num_points) where {T}
-    b = f.seg
-    t = range(0.0, 1.0, length=num_points)[2:(end - 1)]
-    G = StaticArrays.@MVector [zero(Point{T})]
-    perp(t) = begin
-        Interpolations.gradient!(G, b.r, t)
-        return Point(-G[1].y, G[1].x) / norm(G[1])
-    end
-    return [p0(f), (b.r.(t) .+ (f.offset * perp.(t)))..., p1(f)]
-end
-
-function _sample_points(f::Paths.GeneralOffset{T, BSpline{T}}, num_points) where {T}
-    b = f.seg
-    t = range(0.0, 1.0, length=num_points)[2:(end - 1)]
-    G = StaticArrays.@MVector [zero(Point{T})]
-    perp(t) = begin
-        Interpolations.gradient!(G, b.r, t)
-        return Point(-G[1].y, G[1].x) / norm(G[1])
-    end
-    return [
-        p0(f),
-        (b.r.(t) .+ (getoffset(f).(t_to_arclength.(Ref(b), t)) .* perp.(t)))...,
-        p1(f)
-    ]
-end
-
-function _initial_guess(f::Paths.Segment{T}) where {T}
-    # Scaling tangents by pathlength/2 seems to improve convergence
-    # (compared with scaling by pathlength)
-    l = pathlength(f)
-    t0 = Point(cos(α0(f)), sin(α0(f))) * l / 2
-    t1 = Point(cos(α1(f)), sin(α1(f))) * l / 2
+function _initial_guess(f::Paths.Segment{T}; len=nothing) where {T}
+    l = arclength(f) # *Not* pathlength!
+    t0 = Point(cos(α0(f)), sin(α0(f))) * l
+    t1 = Point(cos(α1(f)), sin(α1(f))) * l
     return BSpline{T}([p0(f), p1(f)], t0, t1)
 end
 
-function _initial_guess(f::Paths.ConstantOffset{T, BSpline{T}}) where {T}
-    # Original bspline has points evenly spaced in t from 0 to 1
-    # If these were important for defining the original, the offset curve might need them
-    b = f.seg
-    pts = _sample_points(f, length(b.p))
-    return BSpline{T}(pts, f.seg.t0, f.seg.t1) # tangents are the same
-end
-
-function _initial_guess(f::Paths.GeneralOffset{T, BSpline{T}}) where {T}
-    # Original bspline has points evenly spaced in t from 0 to 1
-    b = f.seg
-    pts = _sample_points(f, length(b.p))
-    # Non-constant offset means endpoint tangents may be different
-    t0 = Point(cos(α0(f)), sin(α0(f))) * norm(f.seg.t0)
-    t1 = Point(cos(α1(f)), sin(α1(f))) * norm(f.seg.t1)
-    return BSpline{T}(pts, t0, t1)
+function _initial_guess(f::Paths.OffsetSegment{T, BSpline{T}}; len=pathlength(f)) where {T}
+    # Can do a little better with BSpline offsets by taking into account non-arclength parameterization
+    t0 = tangent(f, zero(T)) * dsdt(0.0, f.seg.r)
+    t1 = tangent(f, len) * dsdt(1.0, f.seg.r)
+    return BSpline{T}([p0(f), p1(f)], t0, t1) # Don't even worry about original knots
 end
 
 _default_curve_atol(::Type{<:Real}) = 1e-3
@@ -216,7 +136,7 @@ _default_curve_atol(::Type{<:Length}) = 1nm
 function bspline_approximation(
     f::Paths.Segment{T};
     atol=_default_curve_atol(T),
-    maxits=20
+    maxits=10
 ) where {T}
     # Sample points from f and use them to create the BSpline interpolation
     approx = _initial_guess(f)
@@ -228,20 +148,45 @@ function bspline_approximation(
     err = _approximation_error(f, approx, testvals)
     # Double the number of interpolation points until the error is below tolerance
     refine = 1
+    segs = Segment{T}[f]
+    approxs = BSpline{T}[approx]
+    seg_errs = T[err]
+    split_tv = [testvals]
     while err > atol
-        refine > maxits && error(
-            "Maximum iterations $maxits reached for B-spline approximation: Error $err > $atol"
-        )
-        # Double the number of interpolation segments with equal lengths in t
-        npoints = 2 * length(approx.p) - 1
-        approx.p = _sample_points(f, npoints)
-        approx.t0 = approx.t0 / 2 # Halve the endpoint tangents when doubling the npoints
-        approx.t1 = approx.t1 / 2
-        Paths._update_interpolation!(approx)
-        err = _approximation_error(f, approx, testvals)
+        if refine > maxits
+            @warn "Maximum error $err > tolerance $atol with $(refine-1) refinement iterations. Increase `maxits` to refine further or increase `atol` to relax tolerance."
+            break
+        end
+        err = 0.0 * oneunit(T)
+        idx = 1
+        while idx <= length(segs)
+            if seg_errs[idx] > atol # Only split if tolerance is not yet met
+                seg = segs[idx]
+                approx = approxs[idx]
+                tv = split_tv[idx]
+                # Split segment and corresponding testvals in half by pathlength
+                # (for offset paths this splits by underlying pathlength, not arclength of offset)
+                halfseg_length = pathlength(seg) / 2
+                subsegs = split(seg, halfseg_length)
+                sub_tvs = _split_testvals(tv, seg)
+                # Get approximation and estimate error for each subsegment
+                approx_and_err = map(zip(subsegs, sub_tvs)) do (subseg, sub_tv)
+                    approx = _initial_guess(subseg; len=halfseg_length)
+                    seg_err = _approximation_error(subseg, approx, sub_tv)
+                    return approx, seg_err
+                end
+                splice!(segs, idx, subsegs)
+                splice!(approxs, idx, first.(approx_and_err))
+                splice!(seg_errs, idx, last.(approx_and_err))
+                splice!(split_tv, idx, sub_tvs)
+                idx += 1 # Extra increment because we increased length(segs) by 1
+            end
+            idx += 1
+        end
+        err = maximum(seg_errs)
         refine = refine + 1
     end
-    return approx
+    return CompoundSegment(convert(Vector{Segment{T}}, approxs))
 end
 
 bspline_approximation(b::Paths.BSpline; kwargs...) = copy(b)

--- a/src/paths/segments/compound.jl
+++ b/src/paths/segments/compound.jl
@@ -42,7 +42,7 @@ function subsegment(s::CompoundSegment{T}, t) where {T}
         t < l1 && return seg, t - l0
         l0 = l1
     end
-    return last(s.segments), t - l0
+    return last(s.segments), t - l0 + pathlength(last(s.segments))
 end
 
 function curvatureradius(s::CompoundSegment, t)
@@ -66,24 +66,17 @@ function (s::CompoundSegment{T})(t) where {T}
         a0 = p0(c[1])
         x = a0 + Point(D0x * t, D0y * t)
         return x::Point{R}
+    elseif t > L
+        h = c[end]
+        h′ = ForwardDiff.derivative(h, pathlength(h))::Point{Float64}
+        D1x, D1y = getx(h′), gety(h′)
+        a = p1(c[end])
+        x = a + Point(D1x * (t - L), D1y * (t - L))
+        return x::Point{R}
     end
 
-    for i = 1:length(c)
-        seg = c[i]
-        l1 = l0 + pathlength(seg)
-        if t < l1
-            x = (seg)(t - l0)
-            return x::Point{R}
-        end
-        l0 = l1
-    end
-
-    h = c[end]
-    h′ = ForwardDiff.derivative(h, pathlength(h))::Point{Float64}
-    D1x, D1y = getx(h′), gety(h′)
-    a = p1(c[end])
-    x = a + Point(D1x * (t - L), D1y * (t - L))
-    return x::Point{R}
+    seg, dt = subsegment(s, t)
+    return seg(dt)::Point{R}
 end
 
 function _split(seg::CompoundSegment{T}, x, tag1=gensym(), tag2=gensym()) where {T}
@@ -135,10 +128,7 @@ end
 function direction(seg::CompoundSegment{T}, t) where {T}
     l0 = zero(T)
     t < l0 && return α0(seg.segments[1])
-    for se in seg.segments
-        l = l0 + pathlength(se)
-        t < l && return direction(se, t - l0)
-        l0 = l
-    end
-    return α1(seg.segments[end])
+    s, dt = subsegment(seg, t)
+    dt > pathlength(s) && return α1(s)
+    return direction(s, dt)
 end

--- a/src/paths/segments/compound.jl
+++ b/src/paths/segments/compound.jl
@@ -35,6 +35,20 @@ convert(::Type{CompoundSegment{T}}, x::CompoundSegment) where {T} =
     CompoundSegment{T}(convert.(Segment{T}, x.segments), x.tag)
 convert(::Type{Segment{T}}, x::CompoundSegment) where {T} = convert(CompoundSegment{T}, x)
 
+function subsegment(s::CompoundSegment{T}, t) where {T}
+    l0 = zero(T)
+    for seg in s.segments
+        l1 = l0 + pathlength(seg)
+        t < l1 && return seg, t - l0
+        l0 = l1
+    end
+    return last(s.segments), t - l0
+end
+
+function curvatureradius(s::CompoundSegment, t)
+    return curvatureradius(subsegment(s, t)...)
+end
+
 # Parametric function over the domain [zero(T),pathlength(c)] that represents the
 # compound segments.
 function (s::CompoundSegment{T})(t) where {T}

--- a/src/paths/segments/offset.jl
+++ b/src/paths/segments/offset.jl
@@ -24,7 +24,7 @@ struct ConstantOffset{T, S} <: OffsetSegment{T, S}
 end
 
 """
-    struct ConstantOffset{T,S} <: OffsetSegment{T,S}
+    struct GeneralOffset{T,S} <: OffsetSegment{T,S}
 """
 struct GeneralOffset{T, S} <: OffsetSegment{T, S}
     seg::S
@@ -67,7 +67,7 @@ end
 
 function tangent(s::OffsetSegment, t)
     # calculate derivative w.r.t. s.seg arclength
-    # d/dt (s(t) + offset(t) * normal(t))
+    # d/dt (s.seg(t) + offset(s, t) * normal(s.seg, t))
     base_dir = direction(s.seg, t)
     base_tangent = Point(cos(base_dir), sin(base_dir))
     base_normal = Point(-base_tangent.y, base_tangent.x)
@@ -84,38 +84,46 @@ function signed_curvature(seg::Segment, s)
 end
 
 function curvatureradius(seg::ConstantOffset, s)
-    r = curvatureradius(seg.seg, s)
+    r = curvatureradius(seg.seg, s) # Ignore offset * dκds term
     return r - getoffset(seg, s)
 end
 
 function curvatureradius(seg::GeneralOffset, s)
-    # This one is only approximate for BSpline offsets
-    # let s be seg.seg arclength, let t be seg arclength
-    # tangent(seg, s) defined above is dseg/ds
-    # ||d^2/dt^2 seg(s)|| = ||d/dt tangent(seg, s) ds/dt||
-    # ||d/ds tangent(seg, s)|| ||ds/dt||^2
-    # Where ||ds/dt|| = ||tangent(seg, s)|| = 1 for non-offset segments
+    # Only approximate for BSpline offsets (ignores offset * dκds term)
+    # let s (above argument) be seg.seg arclength, let l be seg arclength
+    # g is dseg/ds, defined above as `tangent(seg, s)`
+    # ||d^2/dl^2 seg(s)|| = ||d/dl (g ds/dl)||
+    # ||(d/ds g) (ds/dl)^2 + g d^2s/dl^2||
+    # Where ||ds/dl|| = 1/||g|| = 1 for non-offset segments
     # But needs a correction for offsets
-    # dt/ds = κ n # Sorry t is tangent for the rest of this comment
+    # dt/ds = κ n # t is tangent, n normal, κ curvature of base curve
     # dn/ds = -κ t
-    # || κ n + (d2_offset n - κ t d_offset) - d_offset κ t - offset κ^2 n - offset t dκ/ds ||
+    # ||(κ n + (d2_offset n - κ t d_offset) - d_offset κ t - offset κ^2 n - offset t dκ/ds)(ds/dl)^2 + tangent(seg, s) d^2s/dl^2||
 
     r = curvatureradius(seg.seg, s)
-    reparam = 1 / (sqrt((1 - getoffset(seg, s) / r)^2 + offset_derivative(seg, s)^2))
+    ds_dl = 1 / (sqrt((1 - getoffset(seg, s) / r)^2 + offset_derivative(seg, s)^2))
     base_dir = direction(seg.seg, s)
     base_tangent = Point(cos(base_dir), sin(base_dir)) # True for non-offset segments (arclength parameterized)
     base_normal = Point(-base_tangent.y, base_tangent.x)
 
     d_offset = offset_derivative(seg, s)
     d2_offset = ForwardDiff.derivative(s_ -> offset_derivative(seg, s_), s)
+    d2s_dl2 =
+        (-1 / 2) *
+        ds_dl^3 *
+        (
+            -2 * (offset_derivative(seg, s) / r) * (1 - getoffset(seg, s) / r) +
+            2 * offset_derivative(seg, s) * d2_offset
+        )
+
     d2_seg =
         (
             (1 / r) * base_normal +
             d2_offset * base_normal +
             -2 * (1 / r) * base_tangent * d_offset +
             -((1 / r) * base_normal) * ((1 / r) * getoffset(seg, s))
-            # - getoffset(seg, s) * base_tangent * dκds # Nonzero for BSplines but basically fine to ignore
-        ) * reparam^2
+            #- getoffset(seg, s) * base_tangent * dκds(seg.seg, s) # Nonzero for BSplines but basically fine to ignore
+        ) * ds_dl^2 + tangent(seg, s) * d2s_dl2
     return sign(r) / norm(d2_seg)
 end
 
@@ -174,6 +182,8 @@ end
 function arclength(f::ConstantOffset{T, BSpline{T}}, t1::Real=1.0; t0::Real=0.0) where {T}
     check_interval(f, t0, t1)
     l_orig = arclength(f.seg, t1; t0=t0)
+    # Constant offset just changes tangent component of gradient
+    # So we can just add the extra contribution due to curvature
     G = StaticArrays.@MVector [zero(Point{T})]
     H = StaticArrays.@MVector [zero(Point{T})]
     l_extra = f.offset * quadgk(t -> _curvature_arclength!(f.seg, G, H, t), t0, t1)[1]
@@ -183,23 +193,23 @@ end
 # For general offsets we also have to add the contribution from varying offset
 function arclength(f::GeneralOffset{T, BSpline{T}}, t1::Real=1.0; t0::Real=0.0) where {T}
     check_interval(f, t0, t1)
-    # If we unwind the curvature, each offset segment will have length (sqrt(1+x^2) ds)
-    # where x is the derivative of the offset
-    l_orig = quadgk(
-        s -> sqrt(1 + (ForwardDiff.derivative(f.offset, s))^2),
-        t_to_arclength(f.seg, t0),
-        t_to_arclength(f.seg, t1)
-    )[1]
-    # Now add curvature contribution as usual
     G = StaticArrays.@MVector [zero(Point{T})]
     H = StaticArrays.@MVector [zero(Point{T})]
-    l_extra = quadgk(
+    # Each offset segment will have length (sqrt(s′^2 +x^2) ds)
+    # where x is the derivative of the offset (normal component of arclength)
+    # and s′ is the curvature*offset contribution (tangent arclength)
+    l = quadgk(
         t ->
-            _curvature_arclength!(f.seg, G, H, t) * getoffset(f, t_to_arclength(f.seg, t)),
+            sqrt(
+                (
+                    1 -
+                    _curvature!(f.seg, G, H, t) * getoffset(f, t_to_arclength(f.seg, t))
+                )^2 + (offset_derivative(f, t_to_arclength(f.seg, t)))^2
+            ) * dsdt(t, f.seg.r),
         t0,
         t1
     )[1]
-    return l_orig + l_extra # + because of _curvature_arclength! sign convention
+    return l
 end
 
 function _curvature_arclength!(b::BSpline, G, H, t)
@@ -209,6 +219,13 @@ function _curvature_arclength!(b::BSpline, G, H, t)
     Paths.Interpolations.gradient!(G, b.r, t)
     Paths.Interpolations.hessian!(H, b.r, t)
     return uconvert(NoUnits, (G[1].y * H[1].x - G[1].x * H[1].y) / norm(G[1])^2)
+end
+
+function _curvature!(b::BSpline, G, H, t)
+    Paths.Interpolations.gradient!(G, b.r, t)
+    Paths.Interpolations.hessian!(H, b.r, t)
+    return uconvert(NoUnits, (G[1].x * H[1].y - G[1].y * H[1].x) / norm(G[1])^2) /
+           norm(G[1])
 end
 
 function _split(seg::ConstantOffset, x)

--- a/src/paths/segments/offset.jl
+++ b/src/paths/segments/offset.jl
@@ -11,7 +11,7 @@ corresponds to the "left-hand side" of the curve.
 Note that `pathlength(seg::OffsetSegment)` is the length of the original curve, and that
 the offset segment is parameterized by the arclength of the original curve.
 
-Used internally during SolidModel rendering. Not appropriate for use in Paths.
+Used internally during SolidModel rendering. Not fully featured for general use in Paths.
 """
 abstract type OffsetSegment{T, S <: Segment{T}} <: ContinuousSegment{T} end
 
@@ -26,15 +26,18 @@ end
 """
     struct ConstantOffset{T,S} <: OffsetSegment{T,S}
 """
-struct GeneralOffset{T, S, U} <: OffsetSegment{T, S}
+struct GeneralOffset{T, S} <: OffsetSegment{T, S}
     seg::S
-    offset::U
+    offset
 end
 
 copy(s::OffsetSegment) = OffsetSegment(copy(s.seg), s.offset)
 getoffset(s::ConstantOffset, l...) = s.offset
 getoffset(s::GeneralOffset{T}) where {T} = l -> uconvert(unit(T), s.offset(l))
 getoffset(s::GeneralOffset, l) = getoffset(s)(l)
+getoffset(s::Segment{T}, l...) where {T} = zero(T)
+offset_derivative(seg::ConstantOffset, s) = 0.0
+offset_derivative(seg::GeneralOffset, s) = ForwardDiff.derivative(seg.offset, s)
 
 # "Pathlength" is length of underlying segment!
 # That's one reason OffsetSegments are not part of the public API.
@@ -58,16 +61,63 @@ direction(s::ConstantOffset, t) = direction(s.seg, t)
 p0(s::GeneralOffset{T}) where {T} =
     p0(s.seg) + getoffset(s, zero(T)) * Point(-sin(α0(s.seg)), cos(α0(s.seg)))
 α0(s::GeneralOffset{T}) where {T} = direction(s, zero(T))
-direction(s::GeneralOffset, t) =
-    direction(s.seg, t) + atan(ForwardDiff.derivative(s.offset, t))
+function direction(s::GeneralOffset{T}, t) where {T}
+    tang = tangent(s, t)
+    return uconvert(°, atan(tang.y, tang.x))
+end
+
+function tangent(s::OffsetSegment, t)
+    # calculate derivative w.r.t. s.seg arclength
+    # d/dt (s(t) + offset(t) * normal(t))
+    base_dir = direction(s.seg, t)
+    base_tangent = Point(cos(base_dir), sin(base_dir))
+    base_normal = Point(-base_tangent.y, base_tangent.x)
+    doff_ds = offset_derivative(s, t)
+
+    curv = signed_curvature(s.seg, t)
+    off_tangent =
+        base_tangent + doff_ds * base_normal - getoffset(s, t) * curv * base_tangent
+    return off_tangent
+end
+
+function signed_curvature(seg::Segment, s)
+    return 1 / curvatureradius(seg, s)
+end
+
+function curvatureradius(seg::ConstantOffset, s)
+    r = curvatureradius(seg.seg, s)
+    return r - getoffset(seg, s)
+end
+
+function curvatureradius(seg::GeneralOffset, s)
+    # This is not exactly right, particularly when the curvature is changing?
+    r = curvatureradius(seg.seg, s)
+    reparam = 1 / (sqrt(1 + offset_derivative(seg, s)^2) * (1 - getoffset(seg, s) / r))
+    base_dir = direction(seg.seg, s)
+    base_tangent = Point(cos(base_dir), sin(base_dir))
+    base_normal = Point(-base_tangent.y, base_tangent.x)
+
+    dn = -(1 / r) * base_tangent
+    ddn = -(1 / r)^2 * [base_normal.x, base_normal.y]
+
+    d_offset = offset_derivative(seg, s)
+    d2_offset = ForwardDiff.derivative(s_ -> offset_derivative(seg, s_), s)
+    d2_seg =
+        (
+            (1 / r) * base_normal +
+            ddn * getoffset(seg, s) +
+            2 * dn * d_offset +
+            base_normal * d2_offset
+        ) * reparam^2
+    return sign(r) / norm(d2_seg)
+end
 
 summary(s::OffsetSegment) = summary(s.seg) * " offset by $(s.offset)"
 
 # Methods for creating offset segments
 OffsetSegment(seg::S, offset::Coordinate) where {T, S <: Segment{T}} =
     ConstantOffset{T, S}(seg, offset)
-OffsetSegment(seg::S, offset::U) where {T, S <: Segment{T}, U} =
-    GeneralOffset{T, S, U}(seg, offset)
+OffsetSegment(seg::S, offset) where {T, S <: Segment{T}} = GeneralOffset{T, S}(seg, offset)
 offset(seg::Segment, s) = OffsetSegment(seg, s)
 offset(seg::ConstantOffset, s::Coordinate) = offset(seg.seg, s + seg.offset)
 offset(seg::ConstantOffset, s) = offset(seg.seg, t -> s(t) + seg.offset)
@@ -142,13 +192,24 @@ function arclength(f::GeneralOffset{T, BSpline{T}}, t1::Real=1.0; t0::Real=0.0) 
         t0,
         t1
     )[1]
-    return l_orig + l_extra
+    return l_orig + l_extra # + because of _curvature_arclength! sign convention
 end
 
 function _curvature_arclength!(b::BSpline, G, H, t)
     # Curvature for arbitrary parameterization divides by another norm(g)
+    # (and has opposite sign)
     # But when integrating over arclength we need to multiply by norm(g)
     Paths.Interpolations.gradient!(G, b.r, t)
     Paths.Interpolations.hessian!(H, b.r, t)
     return uconvert(NoUnits, (G[1].y * H[1].x - G[1].x * H[1].y) / norm(G[1])^2)
+end
+
+function _split(seg::ConstantOffset, x)
+    segs = split(seg.seg, x)
+    return offset(segs[1], seg.offset), offset(segs[2], seg.offset)
+end
+
+function _split(seg::GeneralOffset, x)
+    segs = split(seg.seg, x)
+    return offset(segs[1], seg.offset), offset(segs[2], t -> seg.offset(t + x))
 end

--- a/test/test_bspline.jl
+++ b/test/test_bspline.jl
@@ -136,15 +136,15 @@ end
         g = g_fd(c, s, ds)
         h = h_fd(c, s, ds)
         ((g.x^2 + g.y^2)^(3 // 2)) / (g.x * h.y - g.y * h.x)
-    end
+    end # assumes constant d(arclength)/ds
     # For BSplines, curvature radius calculation is only approximate, but not bad
     c = curv[1].curves[1] # ConstantOffset BSpline
     @test abs(curvatureradius_fd(c, 10μm) - Paths.curvatureradius(c, 10μm)) < 1nm
     c = curv[3].curves[1] # GeneralOffset BSpline
     @test abs(curvatureradius_fd(c, 10μm) - Paths.curvatureradius(c, 10μm)) < 50nm
     c = curv[5].curves[1] # GeneralOffset Turn
-    # Paths.curvatureradius is exact for Turn offsets, the finite difference is wrong
-    @test abs(curvatureradius_fd(c, 10μm) - Paths.curvatureradius(c, 10μm)) < 600nm
+    # Paths.curvatureradius is exact for Turn offsets
+    @test abs(curvatureradius_fd(c, 10μm) - Paths.curvatureradius(c, 10μm)) < 1nm
     approx = Paths.bspline_approximation(c, atol=100.0nm)
     pts = DeviceLayout.discretize_curve(c, 100.0nm)
     pts_approx = DeviceLayout.discretize_curve(approx, 100.0nm)

--- a/test/test_bspline.jl
+++ b/test/test_bspline.jl
@@ -147,7 +147,7 @@ end
     @test abs(curvatureradius_fd(c, 10μm) - Paths.curvatureradius(c, 10μm)) < 1nm
     approx = Paths.bspline_approximation(c, atol=100.0nm)
     pts = DeviceLayout.discretize_curve(c, 100.0nm)
-    pts_approx = DeviceLayout.discretize_curve(approx, 100.0nm)
+    pts_approx = vcat(DeviceLayout.discretize_curve.(approx.segments, 100.0nm)...)
     area(p) =
         sum(
             (gety.(p.p) + gety.(circshift(p.p, -1))) .*


### PR DESCRIPTION
Implements #23.

Using multiple B-splines (and so setting tangents at intermediate points) works much better than creating extra waypoints. Haven't benchmarked time but the goal was to reduce entity counts, and for typical curves this is down to 20 segments from over 100, with typical times around 10ms on my laptop. It's still possible to get very slow (1s) approximations with 50 or 60 segments with tight turns on offsets of long B-splines. That may be because calculations (like approximation error) tend to be easiest and most accurate when the curves are roughly arclength parameterized and have slowly-varying curvature, which isn't so true when the radius of curvature is comparable to the offset.