### PR TITLE
Skip physical groups with no entities in check_overlap

### DIFF
--- a/src/solidmodels/postrender.jl
+++ b/src/solidmodels/postrender.jl
@@ -1003,9 +1003,13 @@ Return the overlapping groups as a vector of `(group1, group2, dimension)` `Tupl
 function check_overlap(sm::SolidModel)
     overlapping_groups = Tuple{String, String, Int}[]
     for dim = 1:3
-        for (name1, _) in SolidModels.dimgroupdict(sm, dim)
-            for (name2, _) in SolidModels.dimgroupdict(sm, dim)
+        for (name1, pg1) in SolidModels.dimgroupdict(sm, dim)
+            for (name2, pg2) in SolidModels.dimgroupdict(sm, dim)
                 name1 >= name2 && continue
+                (
+                    isempty(SolidModels.entitytags(pg1)) ||
+                    isempty(SolidModels.entitytags(pg2))
+                ) && continue
                 intersections = intersect_geom!(sm, name1, name2, dim, dim)
                 for intersection in intersections
                     if intersection[1] > dim - 1

--- a/test/test_solidmodel.jl
+++ b/test/test_solidmodel.jl
@@ -1048,6 +1048,20 @@ import DeviceLayout.SolidModels.STP_UNIT
     render!(sm, cs)
     @test isempty(SolidModels.check_overlap(sm))
 
+    cs = CoordinateSystem("test", nm)
+    place!(cs, r1, SemanticMeta(Symbol("r1")))
+    place!(cs, r2, SemanticMeta(Symbol("r2")))
+    postrender_ops = [(
+        "r2",
+        SolidModels.difference_geom!,
+        ("r2", "r2", 2, 2),
+        :remove_object => true,
+        :remove_tool => true
+    )]
+    sm = test_sm()
+    render!(sm, cs; postrender_ops=postrender_ops)
+    @test isempty(SolidModels.check_overlap(sm))
+
     # TODO: Composing OptionalStyle
 
     # Explicitly MeshSized Path.


### PR DESCRIPTION
<!--
*Description of changes:*

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
-->
The `check_overlap` function previously assumed that all physical groups contain entities and would error out if there were empty physical groups. This fix only considers physical groups that contain entities, skipping the overlap check for empty physical groups.