### PR TITLE
docs: Note FileIO must be added

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pkg> add DeviceLayout # Adds DeviceLayout.jl to the environment
 
 We recommend [using an environment for each project](https://julialang.github.io/Pkg.jl/v1/environments/) rather than installing packages in the default environment.
 
-The [DeviceLayout.jl documentation](https://aws-cqc.github.io/DeviceLayout.jl/) will help you get started. Examples can be found in the `examples` directory, with full walkthroughs in the docs, including a [17-qubit quantum processor](https://aws-cqc.github.io/DeviceLayout.jl/dev/examples/qpu17/) and [simulation of a transmon and resonator with Palace](https://aws-cqc.github.io/DeviceLayout.jl/dev/examples/singletransmon/).
+The [DeviceLayout.jl documentation](https://aws-cqc.github.io/DeviceLayout.jl/) will help you get started with a [quick-start tutorial](https://aws-cqc.github.io/DeviceLayout.jl/stable/#Quick-start). Examples can be found in the `examples` directory, with full walkthroughs in the docs, including a [17-qubit quantum processor](https://aws-cqc.github.io/DeviceLayout.jl/stable/examples/qpu17/) and [simulation of a transmon and resonator with Palace](https://aws-cqc.github.io/DeviceLayout.jl/stable/examples/singletransmon/).
 
 ## Performance and workflow tips
 

--- a/docs/src/geometrylevel.md
+++ b/docs/src/geometrylevel.md
@@ -15,8 +15,8 @@ To be more concrete, let's take a look at some examples that showcase different 
 Starting with a rectangle, let's demonstrate [transformations](./transformations.md), [polygon clipping](./polygons.md#Clipping), and a [style](./entitystyles.md).
 
 ```@example 1
-using DeviceLayout, FileIO
-import DeviceLayout: μm, nm
+using DeviceLayout, DeviceLayout.PreferredUnits
+using FileIO # You will have to add FileIO to the environment if you haven't already
 
 r = centered(Rectangle(20μm, 40μm))
 # Create a second rectangle rotated by 90 degrees, positioned below the first
@@ -100,7 +100,7 @@ nothing; # hide
     
     The SVG backend only draws the top-level `Cell`, so it's necessary to [`flatten`](./geometry.md#Flattening) the cell before saving. `flatten` traverses references to place all entities in a single `Cell`, applying transformations as necessary.
 
-(For further examples, we'll hide the line that saves to SVG just to display a cell.)
+(For further examples, we'll hide the line that flattens and saves to SVG just to display a cell.)
 
 Of course, we can also add `Cell` references directly to a `Cell`, for example to apply a global rotation:
 
@@ -161,10 +161,10 @@ Of course, eventually we'll want to turn this into a `Cell`. Since we were using
 layer_record = Dict(:bridge => GDSMeta(1), :metal_negative => GDSMeta())
 cell = Cell(cs; map_meta=m -> layer_record[layer(m)])
 # Could also say cell = render!(Cell("newcell", nm), cs; map_meta=...)
-save(
-    "cs_dogbone_path.svg",
-    flatten(cell);
-    layercolors=Dict(0 => (0, 0, 0, 1), 1 => (1, 0, 0, 1))
+save( # hide
+    "cs_dogbone_path.svg", # hide
+    flatten(cell); # hide
+    layercolors=Dict(0 => (0, 0, 0, 1), 1 => (1, 0, 0, 1)) # hide
 ); # hide
 nothing; # hide
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -39,13 +39,22 @@ pkg> add DeviceLayout # Adds DeviceLayout.jl to the environment
 
 We recommend [using an environment for each project](https://julialang.github.io/Pkg.jl/v1/environments/) rather than installing packages in the default environment.
 
+You will likely also want to add FileIO.jl to your environment:
+
+```r
+pkg> add FileIO
+```
+
+Then, after running `using FileIO`, you can use the `save` function to write output to a file with your chosen format, as in examples throughout the documentation.
+
 ## Quick start
 
 Let's mock up a transmission line with two launchers and some bridges across the
 transmission line. We begin by making a cell with a rectangle in it:
 
 ```@example 1
-using DeviceLayout, DeviceLayout.PreferredUnits, FileIO
+using DeviceLayout, DeviceLayout.PreferredUnits
+using FileIO # You will have to add FileIO to the environment if you haven't already
 
 cr = Cell("rect", nm)
 r = centered(Rectangle(20μm, 40μm))

--- a/docs/src/paths.md
+++ b/docs/src/paths.md
@@ -46,8 +46,7 @@ The following example illustrates the use of automatic tapering. First, we
 construct a taper with two different traces surrounding it:
 
 ```@example 1
-using DeviceLayout, FileIO;
-import DeviceLayout: nm, μm; # hide
+using DeviceLayout, DeviceLayout.PreferredUnits, FileIO
 
 p = Path(μm)
 straight!(p, 10μm, Paths.Trace(2.0μm))


### PR DESCRIPTION
In the installation instructions and at the start of basic tutorial examples, note that FileIO must be addded. Includes other minor fixes.