### PR TITLE
fix: Remove invalid keyword constructor from compdef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format of this changelog is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## Upcoming
+
+  - Remove invalid keyword constructor without type parameters for `@compdef`-ed components with type parameters, so it can be overridden without warnings
+
 ## 1.4.1 (2025-07-08)
 
   - `SolidModels.check_overlap` now skips empty groups

--- a/src/schematics/components/compdef.jl
+++ b/src/schematics/components/compdef.jl
@@ -83,20 +83,17 @@ macro compdef(expr)
                 )
             )
         elseif Base.Meta.isexpr(T, :curly)
-            # if T == S{A<:AA,B<:BB}, define two methods
-            #   S(...) = ...
+            # if T == S{A<:AA,B<:BB}, define one method
+            #   S(...) undefined, unlike with Base.@kwdef
             #   S{A,B}(...) where {A<:AA,B<:BB} = ...
             S = T.args[1]
             P = T.args[2:end]
             Q = Any[Base.Meta.isexpr(U, :<:) ? U.args[1] : U for U in P]
             SQ = :($S{$(Q...)})
-            body1 = Expr(:block, __source__, :(($(esc(S)))($(call_args...))))
-            sig1 = :(($(esc(S)))($params_ex))
-            def1 = Expr(:function, sig1, body1)
             body2 = Expr(:block, __source__, :(($(esc(SQ)))($(call_args...))))
             sig2 = :(($(esc(SQ)))($params_ex) where {$(esc.(P)...)})
             def2 = Expr(:function, sig2, body2)
-            kwdefs = Expr(:block, def1, def2)
+            kwdefs = def2
 
             # Define default_parameters method to return NamedTuple of keywords with defaults
             defbody = Expr(


### PR DESCRIPTION
If you write
```jl
Base.@kwdef struct MyStruct{T}
    a = zero(T)
end
```
then you get two constructors:
```jl
MyStruct(; a=zero(T)) = ...
MyStruct{T}(; a = zero(T)) where {T} = ...
```
The first one doesn't work because `T` is undefined (no `where` clause). In other words, you can't use `T` in an expression for a default and expect the no-type-parameter constructor to work. I think that constructor exists for a good reason where typical structs are concerned, since it allows writing things like
```jl
Base.@kwdef struct MyStruct{T <: Real}
    a::T = 0
end
```
so that `T` can be inferred by the type of `my_a` in `MyStruct(; a=my_a)`.

However, for `@compdef struct MyComp{T}`, we automatically generate a default containing `T` like ` _geometry = CoordinateSystem{T}(...)`, so that constructor will never work. This PR removes it.

Another option could have been to default to `MyComp(; kwargs...) = MyComp{typeof(1.0UPREFERRED)}(; kwargs...)`, but `T` is not even guaranteed to be the coordinate type of `MyComp` (and in fact it's unlikely to be the coordinate type in user code, since user components should generally inherit from `Component`, not `AbstractComponent{T}`). (Also that's unhelpful if we have multiple type parameters.)

A final option would be to detect whether the coordinate type is free according to the supertype, and if it is, use the preferred unit in the no-type-parameter constructor. This seems difficult to do in a macro.

In the end it seems best to let users implement a no-type-parameter outer constructor according to their needs. So we remove the invalid constructor to avoid warnings about overriding it (which happens with built-in components `WeatherVane` etc in v1.4.0).

(OK, more options: We could reconsider how we initialize `_geometry`. I can see a bit of a hack with `convert` for coordinate systems of different types working when there aren't any other fields that are typed using `T`, but I'm not sure it's worth it. Or we could rethink caching altogether, which really doesn't seem worth it for a tiny bit of convenience.)