### PR TITLE
Add unfold function for point arrays

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ To send us a pull request, please:
  5. Send us a pull request, answering any default questions in the pull request interface.
  6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
-GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
+GitHub provides additional documentation on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
 ## Finding contributions to work on

--- a/src/DeviceLayout.jl
+++ b/src/DeviceLayout.jl
@@ -383,6 +383,7 @@ import .Polygons:
     radius,
     rounded_corner,
     sweep_poly,
+    unfold,
     union2d
 export Polygons,
     Polygon,
@@ -405,6 +406,7 @@ export Polygons,
     radius,
     rounded_corner,
     sweep_poly,
+    unfold,
     union2d
 
 include("align.jl")

--- a/src/polygons.jl
+++ b/src/polygons.jl
@@ -78,6 +78,7 @@ export circle,
     radius,
     rounded_corner,
     sweep_poly,
+    unfold,
     union2d
 
 const USCALE = 1.0 * Unitful.fm
@@ -1525,6 +1526,28 @@ function uniqueray(v::Vector{Point{T}}) where {T <: Real}
     minx, indx = findmin(xarr)
     indv = findall(x -> x == Point(minx, miny), v)[1]
     return Ray(Point(minx, miny), Point(minx, miny - 1)), indv
+end
+
+"""
+    unfold(v::Vector{Point{T}}, dir::Point{U}) where {T, U}
+
+Return a vector of twice the length of `v`, where the first half is `v` and the second half
+is `v` in reverse order and reflected about `dir`.
+
+This can be used to construct polygons that have a mirror symmetry about the axis defined
+by `dir`. As a trivial example, to draw a centered square:
+
+```julia
+uy = Point(0μm, 1μm)
+pts = [Point(-1μm, -1μm), Point(-1μm, 1μm)]
+square = Polygon(unfold(pts, uy))
+```
+"""
+function unfold(v::Vector{Point{T}}, dir::Point{U}) where {T, U}
+    N = length(v)
+    _reflect = Reflection(dir)
+    v_ref = [_reflect(v[N - i + 1]) for i in eachindex(v)]
+    return vcat(v, v_ref)
 end
 
 """

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -263,6 +263,30 @@ end
     @test iszero(@allocated tr2 = convert(ScaledIsometry{Nothing}, tr))
     @test convert(ScaledIsometry{Point{Int}}, tr).origin isa Point{Int}
     @test hash(ScaledIsometry()) == hash(ScaledIsometry(Point(0, 0)))
+
+    # Point vector unfolding
+    ux = Point(1, 0)
+    uy = Point(0, 1)
+    # Ints
+    pts = [Point(-1, 0), Point(-1, 1)]
+    @test unfold(pts, uy) ≈ [Point(-1, 0), Point(-1, 1), Point(1, 1), Point(1, 0)]
+    # Floats
+    pts = [Point(-1.0, 0.0), Point(-1.0, 1.0)]
+    @test unfold(pts, uy) ≈
+          [Point(-1.0, 0.0), Point(-1.0, 1.0), Point(1.0, 1.0), Point(1.0, 0.0)]
+    # Mixed Ints/Floats
+    pts = [Point(-1, 0), Point(-1, 1)]
+    @test unfold(pts, Point(0.0, 1.0)) ≈
+          [Point(-1.0, 0.0), Point(-1.0, 1.0), Point(1.0, 1.0), Point(1.0, 0.0)]
+    # x-axis reflection
+    pts = [Point(-1, -1), Point(1, -1)]
+    @test unfold(pts, ux) ≈ [Point(-1, -1), Point(1, -1), Point(1, 1), Point(-1, 1)]
+    # With units
+    pts = [Point(-1μm, 0μm), Point(-1μm, 1μm)]
+    @test unfold(pts, uy) ≈
+          [Point(-1μm, 0μm), Point(-1μm, 1μm), Point(1μm, 1μm), Point(1μm, 0μm)]
+    @test unfold(pts, uy * μm) ≈
+          [Point(-1μm, 0μm), Point(-1μm, 1μm), Point(1μm, 1μm), Point(1μm, 0μm)]
 end
 
 @testset "Polygon rendering" begin


### PR DESCRIPTION
*Description of changes:*
Added an `unfold` function to the `Polygons` module. This can be used to make it easier to construct polygons that have a mirror symmetry. I have found this utility quite useful in my work so I figure I'd add it to the package.

*Issue #, if available:*
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
