### PR TITLE
Log instead of throw routing errors so best-effort route is drawn

### DIFF
--- a/test/test_routes.jl
+++ b/test/test_routes.jl
@@ -26,7 +26,9 @@
         α_start,
         α_end
     )
-    @test_throws ErrorException pa = Path(r, sty)
+    @test_logs (:error, r"Could not automatically route") match_mode = :any pa =
+        Path(r, sty)
+    @test length(pa) > 0 # Partial/best-effort route was drawn
 
     r = Route(
         Paths.StraightAnd90(min_bend_radius=20, max_bend_radius=200),
@@ -35,7 +37,7 @@
         α_start,
         pi
     )
-    @test_throws ErrorException (pa = Path(r, sty))
+    @test_logs (:error, r"Could not automatically route") (pa = Path(r, sty))
 
     r = Route(
         Paths.StraightAnd90(min_bend_radius=20, max_bend_radius=200),
@@ -126,7 +128,7 @@
         α_end,
         waypoints=waypoints
     )
-    @test_throws ErrorException (pa = Path(r4, sty))
+    @test_logs (:error, r"can't be reached") (pa = Path(r4, sty))
 
     # Use StraightAnd45
     p_end = Point(200, 150)

--- a/test/test_schematicdriven.jl
+++ b/test/test_schematicdriven.jl
@@ -215,6 +215,12 @@ end
     @test transformation(floorplan2, z_node2) == transformation(floorplan, z_node)
     @test transformation(floorplan2, xy_node2) == transformation(floorplan, xy_node)
 
+    # Reset matching hooks to something that returns original error
+    SchematicDrivenLayout.matching_hook(t1::TestComponent, s::Symbol, ::TestComponent) =
+        SchematicDrivenLayout.matching_hook(t1, s, Spacer())
+    SchematicDrivenLayout.matching_hooks(t1::TestComponent, ::TestComponent) =
+        SchematicDrivenLayout.matching_hooks(t1, Spacer())
+
     @testset "Replace" begin
         append_x(tc, p) =
             TestComponent(name=(tc.name * "$(ustrip(mm, p.x))"), hooks=tc.hooks)
@@ -302,7 +308,7 @@ end
         @test SchematicDrivenLayout.max_level_logged(floorplan, :build) == Logging.Error
         @test contains(
             read(floorplan.logger.logname, String),
-            "Failed to build RouteComponent"
+            "Could not automatically route"
         )
     end
 


### PR DESCRIPTION
Failed routes no longer throw exceptions during path construction. Instead, they log errors and attempt to draw the route anyway. This should make debugging a bit easier.

Also fixes an angle comparison in `routes.jl` to use `isapprox_angle` (allows mixed units, no chance of error due to epsilon difference at +/-pi).