### PR TITLE
Fix typos

### DIFF
--- a/benchmark/polygons.jl
+++ b/benchmark/polygons.jl
@@ -23,7 +23,7 @@ function rectangles_units(n, unit; output_dir=nothing)
 end
 
 # Render circles using `circle_polygon` to calculate polygon points directly
-# (use ~maxiumum number of points for single GDSII polygon -- other extreme from rectangles)
+# (use ~maximum number of points for single GDSII polygon -- other extreme from rectangles)
 function circles_direct(n; output_dir=nothing)
     c = Cell{Float64}("circles")
     for i = 1:n

--- a/docs/src/examples/singletransmon.md
+++ b/docs/src/examples/singletransmon.md
@@ -231,7 +231,7 @@ function configfile(sm::SolidModel; palace_build=nothing, solver_order=2, amr=0)
         "Domains" => Dict(
             "Materials" => [
                 Dict(
-                    # Vaccuum
+                    # Vacuum
                     "Attributes" => [attributes["vacuum"]],
                     "Permeability" => 1.0,
                     "Permittivity" => 1.0

--- a/docs/src/geometrylevel.md
+++ b/docs/src/geometrylevel.md
@@ -26,7 +26,7 @@ dogbone = union2d([r, r2, r3]) # Boolean union of the three rectangles as a sing
 rounded_dogbone = Rounded(4μm)(dogbone) # Apply the Rounded style
 ```
 
-The printed output above is a bit hard to read, and it's not necessary to understand it in detail to get started. The most important information here is that `rounded_dogbone` is a certain kind of `GeometryEntity` that only describes the vertices of the dogbone polygon and the rounding radius—in particular, we have not discretized the rounded corners to represent the result as a polygon. In more detail, `rounded_dogbone` is a `StyledEntity{T,U,S}` with three type parameters: the coordinate type `T = typeof(1.0μm}`, the underlying entity type `U = ClippedPolygon{T}`, and the style `S = Rounded{T}`—that is, it is a `GeometryEntity` that composes the result of a polygon clipping (Boolean) operation with a `GeometryEntityStyle` specifying rules for rounding that entity.
+The printed output above is a bit hard to read, and it's not necessary to understand it in detail to get started. The most important information here is that `rounded_dogbone` is a certain kind of `GeometryEntity` that only describes the vertices of the dogbone polygon and the rounding radius—in particular, we have not discretized the rounded corners to represent the result as a polygon. In more detail, `rounded_dogbone` is a `StyledEntity{T,U,S}` with three type parameters: the coordinate type `T = typeof(1.0μm)`, the underlying entity type `U = ClippedPolygon{T}`, and the style `S = Rounded{T}`—that is, it is a `GeometryEntity` that composes the result of a polygon clipping (Boolean) operation with a `GeometryEntityStyle` specifying rules for rounding that entity.
 
 ## Cells and Rendering
 

--- a/examples/SingleTransmon/SingleTransmon.jl
+++ b/examples/SingleTransmon/SingleTransmon.jl
@@ -209,7 +209,7 @@ function configfile(sm::SolidModel; palace_build=nothing, solver_order=2, amr=0)
         "Domains" => Dict(
             "Materials" => [
                 Dict(
-                    # Vaccuum
+                    # Vacuum
                     "Attributes" => [attributes["vacuum"]],
                     "Permeability" => 1.0,
                     "Permittivity" => 1.0

--- a/src/backends/dxf.jl
+++ b/src/backends/dxf.jl
@@ -96,7 +96,7 @@ function save(file::File{format"DXF"}, c::Cell, python::String)
         println(f, "msp = doc.modelspace()")
         for (poly, meta) in zip(cflat.elements, cflat.element_metadata)
             pts = [ustrip.(μm, (point.x, point.y)) for point in points(poly)]
-            #TODO work with units propertly. Just strips µm right now.
+            #TODO work with units properly. Just strips µm right now.
             println(
                 f,
                 "polyline = msp.add_lwpolyline($(pts),

--- a/src/entities.jl
+++ b/src/entities.jl
@@ -239,7 +239,7 @@ reflect_across_line(geom, p0, p1) = Reflection(p0, p1)(geom)
 Return the lower-left-most corner of a rectangle bounding `ent` or `ents`.
 Note that this point doesn't have to be in `ent`.
 
-For iterable `ents`, entities with bounding rectanges of zero width and height
+For iterable `ents`, entities with bounding rectangles of zero width and height
 will be excluded.
 """
 lowerleft(ent::GeometryEntity) = lowerleft(to_polygons(ent))
@@ -260,7 +260,7 @@ end
 Return the upper-right-most corner of a rectangle bounding `ent` or `ents`.
 Note that this point doesn't have to be in `ent`.
 
-For iterable `ents`, entities with bounding rectanges of zero width and height
+For iterable `ents`, entities with bounding rectangles of zero width and height
 will be excluded.
 """
 upperright(ent::GeometryEntity) = upperright(to_polygons(ent))

--- a/src/paths/contstyles/compound.jl
+++ b/src/paths/contstyles/compound.jl
@@ -8,7 +8,7 @@ Combines styles together, typically for use with a [`CompoundSegment`](@ref).
 
   - `styles`: Array of styles making up the object. This is deep-copied by the outer
     constructor.
-  - `grid`: An array of `t` values needed for rendering the parameteric path.
+  - `grid`: An array of `t` values needed for rendering the parametric path.
 """
 struct CompoundStyle{T <: FloatCoordinate} <: ContinuousStyle{false}
     styles::Vector{Style}

--- a/src/paths/contstyles/interface.jl
+++ b/src/paths/contstyles/interface.jl
@@ -11,7 +11,7 @@ function extent end
 """
     width(s::Style, t)
 
-For a style `s` and parameteric argument `t`, returns the width of paths rendered.
+For a style `s` and parametric argument `t`, returns the width of paths rendered.
 """
 function width end
 

--- a/src/render/polygons.jl
+++ b/src/render/polygons.jl
@@ -9,7 +9,7 @@ then it is partitioned into smaller polygons which are then rendered.
 Environment variable `ENV["GDS_POLYGON_MAX"]` will override this constant.
 The partitioning algorithm implements guillotine cutting, that goes through
 at least one existing vertex and in manhattan directions.
-Cuts are selected by ad hoc optimzation for "nice" partitions.
+Cuts are selected by ad hoc optimization for "nice" partitions.
 """
 function render!(c::Cell{S}, p::Polygon, meta::GDSMeta=GDSMeta(); kwargs...) where {S}
     if length(points(p)) <= (

--- a/src/schematics/ExamplePDK/components/Transmons/star_island.jl
+++ b/src/schematics/ExamplePDK/components/Transmons/star_island.jl
@@ -71,7 +71,7 @@ function SchematicDrivenLayout._geometry!(cs::CoordinateSystem, isl::ExampleStar
         ]...
     )
     island = Polygon(island_pts)
-    positive_polys = [island] # We'll accumlate all the positive metal shapes here
+    positive_polys = [island] # We'll accumulate all the positive metal shapes here
     ## Draw the outer triangular coupling pads
     dθ_coupler_pad =
         π / 5 - asin((star_tip_width / 2 + island_coupler_gap) / (island_outer_radius))

--- a/src/solidmodels/postrender.jl
+++ b/src/solidmodels/postrender.jl
@@ -1035,7 +1035,7 @@ end
 Returns a vector of postrendering operations for creating air bridges from a `base` and
 `bridge` group. `levels` specifies the indices of levelwise layers to build bridges upon,
 for examples `levels = [1,2]` will attempt to form airbridges on the L1 and L2 layers.
-Representing air bridges as a metalic staple is a basic modeling simplification made for
+Representing air bridges as a metallic staple is a basic modeling simplification made for
 purposes of simulation. The support and bridge shapes are intersected to form a bridge
 platform which is then connected to the underlying surface with legs which run parallel to
 the path.

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -42,7 +42,7 @@ The default is a global counter that persists until the end of the Julia session
 [`reset_uniquename!`](@ref) is called.
 """
 function uniquename(str, dlm='\$'; modify_first=false, counter=GLOBAL_NAME_COUNTER)
-    # if format is already str0 * dlm * n, count it like the (>=n)th occurence of str0  
+    # if format is already str0 * dlm * n, count it like the (>=n)th occurrence of str0  
     substrings = split(str, dlm)
     if !isnothing(tryparse(Int, last(substrings)))
         n0 = parse(Int, last(substrings))


### PR DESCRIPTION
I was reading the documentation and the single transmon example, and I found a couple of typos. I took the opportunity to fix a bunch of other typos in comments across the codebase.
