### PR TITLE
ci: use minimal GITHUB_TOKEN Permissions for docs cleanup workflow

### DIFF
--- a/.github/workflows/Docs-Cleanup.yml
+++ b/.github/workflows/Docs-Cleanup.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   cleanup-preview-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
<!--
*Description of changes:*

Use minimal GITHUB_TOKEN Permissions for docs cleanup workflow

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
-->
