### PR TITLE
Periodic Path style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format of this changelog is based on
 
   - Changed default CPW mesh size to use `2 * min(trace, gap)` (higher element quality when trace and gap are very different)
   - Changed default global mesh grading from `0.9` to `0.75` (more robust meshing for complex geometries, relatively small cost)
+  - Added `PeriodicStyle`
 
 ## 1.8.0 (2026-01-05)
 

--- a/docs/src/paths.md
+++ b/docs/src/paths.md
@@ -374,4 +374,5 @@ nothing; # hide
     Paths.GeneralStrands
     Paths.CompoundStyle
     Paths.DecoratedStyle
+    Paths.PeriodicStyle
 ```

--- a/src/DeviceLayout.jl
+++ b/src/DeviceLayout.jl
@@ -468,6 +468,7 @@ import .Paths:
     launch!,
     meander!,
     next,
+    nextstyle,
     nodes,
     overlay!,
     p0,

--- a/src/paths/contstyles/compound.jl
+++ b/src/paths/contstyles/compound.jl
@@ -50,7 +50,7 @@ function _style1(s::CompoundStyle, T)
     # But just in case the user is manually adding a virtual style then simplifying
     # Similarly simplifying compound or decorated nodes is risky, but just in case
     i = findlast(x -> isa(x, T) && !isvirtual(x), s.styles)
-    return _style1(undecorated(s.styles[i]), T)
+    return _style1(without_attachments(s.styles[i]), T)
 end
 
 """

--- a/src/paths/contstyles/decorated.jl
+++ b/src/paths/contstyles/decorated.jl
@@ -26,6 +26,8 @@ Return the underlying, undecorated style if decorated; otherwise just return the
 """
 undecorated(s::Style) = s
 undecorated(s::AbstractDecoratedStyle) = undecorated(s.s)
+without_attachments(s::Style) = s
+without_attachments(s::DecoratedStyle) = s.s # Shallow and does not remove overlays
 # Nodes: Undecorating invalidates linked list (caller can reconcile if necessary), but
 # prev/next are still populated (!= n itself) so can still be used to check if node started/ended path
 function undecorated(n::Node{T}) where {T}

--- a/src/paths/contstyles/periodic.jl
+++ b/src/paths/contstyles/periodic.jl
@@ -1,5 +1,7 @@
-
-struct PeriodicStyle{T <: Coordinate} <: ContinuousStyle{false}
+"""
+    struct PeriodicStyle{T <: Coordinate} <: AbstractCompoundStyle
+"""
+struct PeriodicStyle{T <: Coordinate} <: AbstractCompoundStyle
     styles::Vector{Style}
     lengths::Vector{T}
     l0::T
@@ -7,12 +9,22 @@ end
 Base.copy(s::PeriodicStyle{T}) where {T} = PeriodicStyle{T}(copy(s.styles), copy(s.lengths), s.l0)
 summary(s::PeriodicStyle) = "Periodic style with $(length(s.styles)) substyles"
 
-function PeriodicStyle(styles, lengths::Vector{T}; l0=zero(T)) where {T}
-    return PeriodicStyle{T}(styles, lengths, l0)
+function PeriodicStyle(styles, lengths::Vector{T}, l0=zero(T)) where {T}
+    return new{float(T)}(styles, lengths, l0)
 end
 
-function PeriodicStyle(styles, period; weights=weights, l0=l0)
-    return PeriodicStyle(styles, period * ustrip(NoUnits, weights ./ sum(weights)), l0)
+function PeriodicStyle(styles; period, weights=ones(length(styles)), l0=zero(period))
+    return PeriodicStyle(styles, period * uconvert.(NoUnits, weights ./ sum(weights)), l0)
+end
+
+function PeriodicStyle(sty::CompoundStyle)
+    return PeriodicStyle(sty.styles, diff(sty.grid))
+end
+
+function PeriodicStyle(pa::Path)
+    pacopy = deepcopy(pa)
+    handle_generic_tapers!(pacopy)
+    return PeriodicStyle(simplify(pacopy).sty)
 end
 
 # Return style and length into style
@@ -30,22 +42,69 @@ function (s::PeriodicStyle)(t)
     return s.styles[end], dt - l0
 end
 
+function resolve_periodic(seg::Paths.Segment{T}, sty::PeriodicStyle) where {T}
+    # Accumulate subsegments and substyles
+    subsegs = Segment{T}[]
+    substys = Style[]
+    # remaining segment to render (will be updated iteratively)
+    remainder = seg
+    remaining_length = pathlength(seg)
+    # special handling for first segment in case of nonzero sty.l0
+    # Get starting style and remaining length based on sty.l0
+    ls = cumsum(sty.lengths) .- (sty.l0 % sum(sty.lengths))
+    next_style_idx = findfirst(x -> x > zero(x), ls)
+    next_style_length = ls[next_style_idx]
+    # distance into the style that the style starts
+    l_into_next_style = sty.lengths[next_style_idx] - next_style_length
+    # add subsegments iteratively
+    while next_style_length < remaining_length
+        # Get substyle
+        substy = sty.styles[next_style_idx]
+        # handle nonzero sty.l0
+        if !iszero(l_into_next_style)
+            substy = pin(substy, start=l_into_next_style)
+            l_into_next_style = zero(l_into_next_style)
+        end
+        # Get subsegment
+        subseg, remainder = split(remainder, next_style_length)
+        # Add to list
+        push!(subsegs, subseg)
+        push!(substys, substy)
+        # Update for next iteration
+        remaining_length = remaining_length - next_style_length
+        next_style_idx = mod1(next_style_idx + 1, length(sty.styles))
+        next_style_length = sty.lengths[next_style_idx]
+    end
+
+    # Add final section
+    if remaining_length > zero(remaining_length)
+        # Handle nonzero l_into_next_cycle (e.g., started midcycle and is too short for one segment)
+        start = iszero(l_into_next_style) ? nothing : l_into_next_style
+        substy = sty.styles[next_style_idx]
+        if remaining_length < next_style_length
+            substy = pin(substy, start=start, stop=l_into_next_style + remaining_length)
+        else
+            substy = pin(substy, start=start)
+        end
+        push!(subsegs, remainder)
+        push!(substys, substy)
+    end
+    return subsegs, substys
+end
+
+function _refs(seg::Paths.Segment{T}, sty::PeriodicStyle) where {T}
+    return vcat(_refs.(resolve_periodic(seg, sty)...)...)
+end
+
 function nextstyle(p::Path, sty::PeriodicStyle{T}) where {T}
-    if sty != p[end].sty # there is a virtual or non-continuous style, reset periodicity
-        return PeriodicStyle{T}(sty.styles, sty.period, sty.weights, zero(T))
+    if sty !== p[end].sty # there is a virtual or non-continuous style, reset periodicity
+        @show sty
+        return PeriodicStyle(sty.styles, sty.lengths, zero(T))
     end
     # Add last segment length to l0 so periodicity continues from there
-    return PeriodicStyle{T}(sty.styles, sty.period, sty.weights, sty.l0 + pathlength(p[end].seg))
+    return PeriodicStyle(sty.styles, sty.lengths, sty.l0 + pathlength(p[end].seg))
 end
 
 function translate(sty::PeriodicStyle, x)
-    return PeriodicStyle(sty.styles, sty.lengths, l0=sty.l0 + x)
-end
-
-# Forward other functions like we do with CompoundStyle
-for x in (:extent, :width, :trace, :gap)
-    @eval function ($x)(s::PeriodicStyle, t)
-        sty, teff = s(t)
-        return ($x)(sty, teff)
-    end
+    return PeriodicStyle(sty.styles, sty.lengths, sty.l0 + x)
 end

--- a/src/paths/contstyles/periodic.jl
+++ b/src/paths/contstyles/periodic.jl
@@ -1,5 +1,26 @@
 """
     struct PeriodicStyle{T <: Coordinate} <: AbstractCompoundStyle
+
+Continuous style repeating a series of underlying styles.
+
+When extending a path that ends in a `PeriodicStyle` without explicitly providing a new style,
+the periodicity will be resumed from where it ended on the final segment.
+
+    PeriodicStyle(styles::Vector{<:Style}, lengths::Vector{T}, l0=zero(T))
+
+Style for `Path` each style in `style` for the corresponding length in `lengths`, repeating
+after every `sum(lengths)`. Periodicity starts at `l0`.
+
+    PeriodicStyle(styles::Vector{<:Style}; period, weights=ones(length(styles)))
+
+Convenience constructor using a `period` keyword with `weights` rather than explicit `lengths`,
+such that the length for each style in a period is given by
+`lengths = period * weights/sum(weights)`.
+
+    PeriodicStyle(pa::Path)
+
+Convenience constructor for a periodic style cycling between the styles in `pa`, each for
+the length of the corresponding segment in `pa`.
 """
 struct PeriodicStyle{T <: Coordinate} <: AbstractCompoundStyle
     styles::Vector{Style}
@@ -11,7 +32,7 @@ Base.copy(s::PeriodicStyle{T}) where {T} =
 summary(s::PeriodicStyle) = "Periodic style with $(length(s.styles)) substyles"
 
 function PeriodicStyle(styles, lengths::Vector{T}, l0=zero(T)) where {T}
-    return new{float(T)}(styles, lengths, l0)
+    return PeriodicStyle{float(T)}(styles, lengths, l0)
 end
 
 function PeriodicStyle(styles; period, weights=ones(length(styles)), l0=zero(period))

--- a/src/paths/contstyles/periodic.jl
+++ b/src/paths/contstyles/periodic.jl
@@ -6,7 +6,8 @@ struct PeriodicStyle{T <: Coordinate} <: AbstractCompoundStyle
     lengths::Vector{T}
     l0::T
 end
-Base.copy(s::PeriodicStyle{T}) where {T} = PeriodicStyle{T}(copy(s.styles), copy(s.lengths), s.l0)
+Base.copy(s::PeriodicStyle{T}) where {T} =
+    PeriodicStyle{T}(copy(s.styles), copy(s.lengths), s.l0)
 summary(s::PeriodicStyle) = "Periodic style with $(length(s.styles)) substyles"
 
 function PeriodicStyle(styles, lengths::Vector{T}, l0=zero(T)) where {T}

--- a/src/paths/contstyles/periodic.jl
+++ b/src/paths/contstyles/periodic.jl
@@ -60,7 +60,7 @@ function (s::PeriodicStyle)(t)
         dt < l1 && return (s.styles[i], dt - l0)
         l0 = l1
     end
-    # Should be unreachable
+    # Unreachable
     return s.styles[end], dt - l0
 end
 
@@ -120,7 +120,6 @@ end
 
 function nextstyle(p::Path, sty::PeriodicStyle{T}) where {T}
     if sty !== p[end].sty # there is a virtual or non-continuous style, reset periodicity
-        @show sty
         return PeriodicStyle(sty.styles, sty.lengths, zero(T))
     end
     # Add last segment length to l0 so periodicity continues from there

--- a/src/paths/contstyles/periodic.jl
+++ b/src/paths/contstyles/periodic.jl
@@ -1,0 +1,51 @@
+
+struct PeriodicStyle{T <: Coordinate} <: ContinuousStyle{false}
+    styles::Vector{Style}
+    lengths::Vector{T}
+    l0::T
+end
+Base.copy(s::PeriodicStyle{T}) where {T} = PeriodicStyle{T}(copy(s.styles), copy(s.lengths), s.l0)
+summary(s::PeriodicStyle) = "Periodic style with $(length(s.styles)) substyles"
+
+function PeriodicStyle(styles, lengths::Vector{T}; l0=zero(T)) where {T}
+    return PeriodicStyle{T}(styles, lengths, l0)
+end
+
+function PeriodicStyle(styles, period; weights=weights, l0=l0)
+    return PeriodicStyle(styles, period * ustrip(NoUnits, weights ./ sum(weights)), l0)
+end
+
+# Return style and length into style
+function (s::PeriodicStyle)(t)
+    ls = s.lengths
+    dt = (t + s.l0) % sum(ls)
+    l0 = zero(t)
+    l1 = zero(t)
+    for i = 1:length(s.styles)
+        l1 = l1 + ls[i]
+        dt < l1 && return (s.styles[i], dt - l0)
+        l0 = l1
+    end
+    # Should be unreachable
+    return s.styles[end], dt - l0
+end
+
+function nextstyle(p::Path, sty::PeriodicStyle{T}) where {T}
+    if sty != p[end].sty # there is a virtual or non-continuous style, reset periodicity
+        return PeriodicStyle{T}(sty.styles, sty.period, sty.weights, zero(T))
+    end
+    # Add last segment length to l0 so periodicity continues from there
+    return PeriodicStyle{T}(sty.styles, sty.period, sty.weights, sty.l0 + pathlength(p[end].seg))
+end
+
+function translate(sty::PeriodicStyle, x)
+    return PeriodicStyle(sty.styles, sty.lengths, l0=sty.l0 + x)
+end
+
+# Forward other functions like we do with CompoundStyle
+for x in (:extent, :width, :trace, :gap)
+    @eval function ($x)(s::PeriodicStyle, t)
+        sty, teff = s(t)
+        return ($x)(sty, teff)
+    end
+end

--- a/src/paths/contstyles/tapers.jl
+++ b/src/paths/contstyles/tapers.jl
@@ -163,15 +163,15 @@ function handle_generic_tapers!(p)
 end
 
 function get_taper_style(prevnode, nextnode)
-    prevstyle = style(prevnode)
-    nextstyle = style(nextnode)
+    prevstyle = undecorated(style(prevnode))
+    nextstyle = undecorated(style(nextnode))
     beginof_next = zero(pathlength(segment(nextnode)))
     endof_prev = pathlength(segment(prevnode))
     # handle case of compound style (#39)
-    if prevstyle isa Paths.CompoundStyle
+    if prevstyle isa Paths.AbstractCompoundStyle
         prevstyle, endof_prev = prevstyle(endof_prev)
     end
-    if nextstyle isa Paths.CompoundStyle
+    if nextstyle isa Paths.AbstractCompoundStyle
         nextstyle, beginof_next = nextstyle(beginof_next)
     end
 

--- a/src/paths/paths.jl
+++ b/src/paths/paths.jl
@@ -97,6 +97,7 @@ export reconcile!,
     launch!,
     meander!,
     next,
+    nextstyle,
     nodes,
     overlay!,
     pathf,
@@ -390,6 +391,17 @@ end
 nodes(p::Path) = p.nodes
 name(p::Path) = p.name
 laststyle(p::Path) = isempty(nodes(p)) ? nothing : style1(p, ContinuousStyle)
+
+"""
+    nextstyle(p::Path)
+
+Return the style to be used if the path is extended without specifying a new style.
+
+In most cases this is the last continuous, non-virtual style. The exception is that
+a `PeriodicStyle` will start its periodicity where the last one ended.
+"""
+nextstyle(p::Path) = isempty(nodes(p)) ? nothing : nextstyle(p, laststyle(p))
+nextstyle(p::Path, sty::Style) = sty
 
 function DeviceLayout._geometry!(cs::CoordinateSystem, p::Path)
     return addref!(cs, p)

--- a/src/paths/paths.jl
+++ b/src/paths/paths.jl
@@ -636,7 +636,7 @@ function style1(p::Path, T)
     if isnothing(i)
         error("No $T found in the path.")
     else
-        s = undecorated(style(A[i]))
+        s = without_attachments(style(A[i]))
         return _style1(s, T) # could be compound style
     end
 end
@@ -700,9 +700,9 @@ include("contstyles/decorated.jl")
 include("contstyles/tapers.jl")
 include("contstyles/strands.jl")
 include("contstyles/termination.jl")
-include("contstyles/periodic.jl")
 include("discretestyles/simple.jl")
 include("norender.jl")
+include("contstyles/periodic.jl")
 
 include("segments/straight.jl")
 include("segments/turn.jl")

--- a/src/paths/paths.jl
+++ b/src/paths/paths.jl
@@ -700,6 +700,7 @@ include("contstyles/decorated.jl")
 include("contstyles/tapers.jl")
 include("contstyles/strands.jl")
 include("contstyles/termination.jl")
+include("contstyles/periodic.jl")
 include("discretestyles/simple.jl")
 include("norender.jl")
 
@@ -1312,7 +1313,7 @@ function split(n::Node, x::Coordinate)
 end
 
 function split(n::Node, x::AbstractVector{<:Coordinate}; issorted=false)
-    isempty(x) && throw(ArgumentError("List of positions to split at cannot be empty"))
+    isempty(x) && return Path([n])
     sortedx = issorted ? x : sort(x)
 
     i = 2

--- a/src/paths/routes.jl
+++ b/src/paths/routes.jl
@@ -9,7 +9,7 @@ of the following two methods:
 ```
 _route!(p::Path, p1::Point, α1, rule::MyRouteRule, sty, waypoints, waydirs)
 _route_leg!(p::Path, next::Point, rule::MyRouteRule,
-    sty::Paths.Style=Paths.contstyle1(p))
+    sty::Paths.Style=Paths.nextstyle(p))
 ```
 
 It may also implement
@@ -418,7 +418,7 @@ function Path(r::Route, sty)
 end
 
 """
-    function route!(path::Path{S}, p_end::Point, α_end, rule::RouteRule, sty=Paths.contstyle1(path);
+    function route!(path::Path{S}, p_end::Point, α_end, rule::RouteRule, sty=Paths.nextstyle(path);
                     waypoints=Point{S}[], waydirs=Vector{typeof(1.0°)}(undef, length(waypoints)))) where {S}
 
 Extend `path` to `p_end` with arrival angle `α_end` according to `RouteRule`. The default
@@ -436,7 +436,7 @@ function route!(
     p_end::Point,
     α_end,
     rule::RouteRule,
-    sty=Paths.contstyle1(path);
+    sty=Paths.nextstyle(path);
     waypoints=Point{S}[],
     waydirs=nothing,
     atol=1e-9 * DeviceLayout.onemicron(S)
@@ -509,7 +509,7 @@ function route!(
     p1::Point,
     α1,
     crr::CompoundRouteRule,
-    sty=fill(Paths.contstyle1(path), length(rules));
+    sty=fill(Paths.nextstyle(path), length(rules));
     waypoints=Point{S}[],
     waydirs=Vector{typeof(1.0°)}(undef, length(waypoints))
 ) where {S}
@@ -551,7 +551,7 @@ function _route_leg!(
     next::Point,
     nextdir,
     rule::StraightAnd90,
-    sty::Paths.Style=Paths.contstyle1(p)
+    sty::Paths.Style=Paths.nextstyle(p)
 ) where {S}
     dx = next.x - p1(p).x
     dy = next.y - p1(p).y
@@ -588,7 +588,7 @@ function _route_leg!(
     next::Point,
     nextdir,
     rule::StraightAnd45,
-    sty::Paths.Style=Paths.contstyle1(p)
+    sty::Paths.Style=Paths.nextstyle(p)
 ) where {S}
     dx = next.x - p1(p).x
     dy = next.y - p1(p).y

--- a/src/paths/segments/bspline.jl
+++ b/src/paths/segments/bspline.jl
@@ -350,7 +350,7 @@ function curvatureradius(b::BSpline{T}, s) where {T}
 end
 
 """
-    bspline!(p::Path{T}, nextpoints, α_end, sty::Style=contstyle1(p);
+    bspline!(p::Path{T}, nextpoints, α_end, sty::Style=nextstyle(p);
         endpoints_speed=2500μm,
         endpoints_curvature=nothing,
         auto_speed=false,
@@ -383,7 +383,7 @@ function bspline!(
     p::Path{T},
     nextpoints,
     α_end,
-    sty::Style=contstyle1(p);
+    sty::Style=nextstyle(p);
     endpoints_speed=2500.0 * DeviceLayout.onemicron(T),
     endpoints_curvature=nothing,
     auto_speed=false,

--- a/src/paths/segments/straight.jl
+++ b/src/paths/segments/straight.jl
@@ -63,12 +63,12 @@ setα0!(s::Straight, α0′) = s.α0 = α0′
 α1(s::Straight) = s.α0
 
 """
-    straight!(p::Path, l::Coordinate, sty::Style=contstyle1(p))
+    straight!(p::Path, l::Coordinate, sty::Style=nextstyle(p))
 
 Extend a path `p` straight by length `l` in the current direction. By default,
 we take the last continuous style in the path.
 """
-function straight!(p::Path, l::Coordinate, sty::Style=contstyle1(p))
+function straight!(p::Path, l::Coordinate, sty::Style=nextstyle(p))
     T = coordinatetype(p)
     dimension(T) != dimension(typeof(l)) && throw(DimensionError(T(1), l))
     l < zero(l) && throw(ArgumentError("Tried to go straight by a negative amount."))

--- a/src/paths/segments/turn.jl
+++ b/src/paths/segments/turn.jl
@@ -79,12 +79,12 @@ setα0!(s::Turn, α0′) = s.α0 = α0′
 α1(s::Turn) = s.α0 + s.α
 
 """
-    turn!(p::Path, α, r::Coordinate, sty::Style=contstyle1(p))
+    turn!(p::Path, α, r::Coordinate, sty::Style=nextstyle(p))
 
 Turn a path `p` by angle `α` with a turning radius `r` in the current direction.
 Positive angle turns left. By default, we take the last continuous style in the path.
 """
-function turn!(p::Path, α, r::Coordinate, sty::Style=contstyle1(p))
+function turn!(p::Path, α, r::Coordinate, sty::Style=nextstyle(p))
     T = coordinatetype(p)
     dimension(T) != dimension(typeof(r)) && throw(DimensionError(T(1), r))
     !isempty(p) &&
@@ -96,7 +96,7 @@ function turn!(p::Path, α, r::Coordinate, sty::Style=contstyle1(p))
 end
 
 """
-    turn!(p::Path, str::String, r::Coordinate, sty::Style=contstyle1(p))
+    turn!(p::Path, str::String, r::Coordinate, sty::Style=nextstyle(p))
 
 Turn a path `p` with direction coded by string `str`:
 
@@ -106,7 +106,7 @@ Turn a path `p` with direction coded by string `str`:
 
 By default, we take the last continuous style in the path.
 """
-function turn!(p::Path, str::String, r::Coordinate, sty::Style=contstyle1(p))
+function turn!(p::Path, str::String, r::Coordinate, sty::Style=nextstyle(p))
     T = coordinatetype(p)
     dimension(T) != dimension(typeof(r)) && throw(DimensionError(T(1), r))
     !isempty(p) &&

--- a/src/render/periodic.jl
+++ b/src/render/periodic.jl
@@ -1,50 +1,5 @@
 function to_polygons(seg::Paths.Segment{T}, sty::Paths.PeriodicStyle; kwargs...) where {T}
-    # Accumulate subsegments and substyles
-    subsegs = Segment{T}[]
-    substys = Style{T}[]
-    # remaining segment to render (will be updated iteratively)
-    remainder = seg
-    seglength = pathlength(seg)
-    remaining_length = seglength
-    # special handling for first segment in case of nonzero sty.l0
-    # Get starting style and remaining length based on sty.l0
-    ls = cumsum(sty.lengths) .- (sty.l0 % sum(sty.lengths))
-    next_style_idx = findfirst(x -> x > zero(x), ls)
-    next_style_length = ls[next_style_idx]
-    # distance into the style that the style starts
-    l_into_next_style = sty.lengths(next_style_idx) - next_style_length
-    # add subsegments iteratively
-    while next_style_length > remaining_length
-        # Get substyle
-        substy = styles[next_style_idx]
-        # handle nonzero sty.l0
-        if !iszero(l_into_next_style)
-            substy = pin(substy, start=l_into_next_style)
-            l_into_next_style = zero(l_into_next_style)
-        end
-        # Get subsegment
-        subseg, remainder = split(remainder, next_style_length)
-        # Add to list
-        push!(subsegs, subseg)
-        push!(substys, substy)
-        # Update for next iteration
-        remaining_length = remaining_length - next_style_length
-        next_style_idx = mod1(next_style_idx + 1, length(sty.styles))
-        next_style_length = sty.lengths[next_style_idx]
-    end
+    subsegs, substys = Paths.resolve_periodic(seg, sty)
 
-    # Add final section
-    if remaining_length > zero(remaining_length)
-        # Handle nonzero l_into_next_cycle (e.g., started midcycle and is too short for one segment)
-        start = iszero(l_into_next_style) ? nothing : l_into_next_style
-        if remaining_length < next_style_length
-            substy = pin(substy, start=start, stop=l_into_next_style + remaining_length)
-        else
-            substy = pin(substy, start=start)
-        end
-        push!(subsegs, remainder)
-        push!(substys, substy)
-    end
-
-    return reduce(vcat, to_polygons.(subsegs, substys; kwargs...), init=Polygon{T}[])
+    return reduce(vcat, to_polygons.(subsegs, undecorated.(substys); kwargs...), init=Polygon{T}[])
 end

--- a/src/render/periodic.jl
+++ b/src/render/periodic.jl
@@ -1,0 +1,50 @@
+function to_polygons(seg::Paths.Segment{T}, sty::Paths.PeriodicStyle; kwargs...) where {T}
+    # Accumulate subsegments and substyles
+    subsegs = Segment{T}[]
+    substys = Style{T}[]
+    # remaining segment to render (will be updated iteratively)
+    remainder = seg
+    seglength = pathlength(seg)
+    remaining_length = seglength
+    # special handling for first segment in case of nonzero sty.l0
+    # Get starting style and remaining length based on sty.l0
+    ls = cumsum(sty.lengths) .- (sty.l0 % sum(sty.lengths))
+    next_style_idx = findfirst(x -> x > zero(x), ls)
+    next_style_length = ls[next_style_idx]
+    # distance into the style that the style starts
+    l_into_next_style = sty.lengths(next_style_idx) - next_style_length
+    # add subsegments iteratively
+    while next_style_length > remaining_length
+        # Get substyle
+        substy = styles[next_style_idx]
+        # handle nonzero sty.l0
+        if !iszero(l_into_next_style)
+            substy = pin(substy, start=l_into_next_style)
+            l_into_next_style = zero(l_into_next_style)
+        end
+        # Get subsegment
+        subseg, remainder = split(remainder, next_style_length)
+        # Add to list
+        push!(subsegs, subseg)
+        push!(substys, substy)
+        # Update for next iteration
+        remaining_length = remaining_length - next_style_length
+        next_style_idx = mod1(next_style_idx + 1, length(sty.styles))
+        next_style_length = sty.lengths[next_style_idx]
+    end
+
+    # Add final section
+    if remaining_length > zero(remaining_length)
+        # Handle nonzero l_into_next_cycle (e.g., started midcycle and is too short for one segment)
+        start = iszero(l_into_next_style) ? nothing : l_into_next_style
+        if remaining_length < next_style_length
+            substy = pin(substy, start=start, stop=l_into_next_style + remaining_length)
+        else
+            substy = pin(substy, start=start)
+        end
+        push!(subsegs, remainder)
+        push!(substys, substy)
+    end
+
+    return reduce(vcat, to_polygons.(subsegs, substys; kwargs...), init=Polygon{T}[])
+end

--- a/src/render/periodic.jl
+++ b/src/render/periodic.jl
@@ -7,3 +7,17 @@ function to_polygons(seg::Paths.Segment{T}, sty::Paths.PeriodicStyle; kwargs...)
         init=Polygon{T}[]
     )
 end
+
+function to_polygons(
+    seg::DeviceLayout.Paths.CompoundSegment{T},
+    sty::DeviceLayout.Paths.PeriodicStyle;
+    kwargs...
+) where {T}
+    subsegs, substys = Paths.resolve_periodic(seg, sty)
+
+    return reduce(
+        vcat,
+        to_polygons.(subsegs, undecorated.(substys); kwargs...),
+        init=Polygon{T}[]
+    )
+end

--- a/src/render/periodic.jl
+++ b/src/render/periodic.jl
@@ -1,5 +1,9 @@
 function to_polygons(seg::Paths.Segment{T}, sty::Paths.PeriodicStyle; kwargs...) where {T}
     subsegs, substys = Paths.resolve_periodic(seg, sty)
 
-    return reduce(vcat, to_polygons.(subsegs, undecorated.(substys); kwargs...), init=Polygon{T}[])
+    return reduce(
+        vcat,
+        to_polygons.(subsegs, undecorated.(substys); kwargs...),
+        init=Polygon{T}[]
+    )
 end

--- a/src/render/periodic.jl
+++ b/src/render/periodic.jl
@@ -1,11 +1,7 @@
 function to_polygons(seg::Paths.Segment{T}, sty::Paths.PeriodicStyle; kwargs...) where {T}
     subsegs, substys = Paths.resolve_periodic(seg, sty)
 
-    return reduce(
-        vcat,
-        to_polygons.(subsegs, undecorated.(substys); kwargs...),
-        init=Polygon{T}[]
-    )
+    return reduce(vcat, to_polygons.(subsegs, substys; kwargs...), init=Polygon{T}[])
 end
 
 function to_polygons(
@@ -15,9 +11,5 @@ function to_polygons(
 ) where {T}
     subsegs, substys = Paths.resolve_periodic(seg, sty)
 
-    return reduce(
-        vcat,
-        to_polygons.(subsegs, undecorated.(substys); kwargs...),
-        init=Polygon{T}[]
-    )
+    return reduce(vcat, to_polygons.(subsegs, substys; kwargs...), init=Polygon{T}[])
 end

--- a/src/render/render.jl
+++ b/src/render/render.jl
@@ -8,6 +8,7 @@ include("compound.jl")
 include("tapers.jl")
 include("strands.jl")
 include("termination.jl")
+include("periodic.jl")
 
 function uniquepoints(pts)
     return pts[.![i == 1 ? false : (pts[i] ≈ pts[max(1, i - 1)]) for i = 1:size(pts, 1)]]

--- a/test/test_pathstyles.jl
+++ b/test/test_pathstyles.jl
@@ -1,7 +1,6 @@
-@testset "Periodic Path styles" setup = [CommonTestSetup] begin
+@testitem "Periodic Path styles" setup = [CommonTestSetup] begin
     import .Paths: PeriodicStyle, Trace, CPW
 
-    pa = Path(0nm, 0nm)
     sty1 = Paths.CPW(10μm, 6μm)
     sty2 = Paths.Trace(2μm)
 
@@ -21,6 +20,16 @@
     @test psty_nested(15μm) === (psty, 5.0μm)
     @test Paths.gap(psty_nested, 65μm) == 6.0μm
     @test Paths.trace(psty_nested, 75μm) == 2.0μm
+
+    # Over compound segment
+    pa = Path(0nm, 0nm)
+    straight!(pa, 10μm, Paths.Trace(10μm))
+    turn!(pa, 90°, 10μm)
+    bspline!(pa, [Point(1, 1)mm], 90°)
+    simplify!(pa)
+    Paths.setstyle!(pa[1], psty)
+    c = Cell("test")
+    render!(c, pa, GDSMeta())
 
     # General, Taper, NoRender, Termination
     pa = Path(0nm, 0nm)

--- a/test/test_pathstyles.jl
+++ b/test/test_pathstyles.jl
@@ -5,7 +5,7 @@
     sty2 = Paths.Trace(2μm)
 
     psty = PeriodicStyle([sty1, sty2], [20μm, 10μm], 5μm)
-    with_period = PeriodicStyle([sty1, sty2], 30μm; weights=[2, 1], l0=5μm)
+    with_period = PeriodicStyle([sty1, sty2]; period=30μm, weights=[2, 1], l0=5μm)
     @test with_period.lengths == psty.lengths
     @test psty(0μm) === (sty1, 5.0μm)
     @test psty(18μm) === (sty2, 3.0μm)
@@ -16,7 +16,7 @@
 
     # Various combinations work
     # Nested
-    psty_nested = PeriodicStyle([sty1, psty, sty2], 50μm; weights=[1, 3, 1])
+    psty_nested = PeriodicStyle([sty1, psty, sty2]; period=50μm, weights=[1, 3, 1])
     @test psty_nested(15μm) === (psty, 5.0μm)
     @test Paths.gap(psty_nested, 65μm) == 6.0μm
     @test Paths.trace(psty_nested, 75μm) == 2.0μm
@@ -34,7 +34,7 @@
     # General, Taper, NoRender, Termination
     pa = Path(0nm, 0nm)
     straight!(pa, 4μm, Paths.CPW(x -> 10μm, x -> 6μm))
-    turn!(pa, 90°, 10μm / (pi / 4), Paths.TaperCPW(10μm, 6μm, 2μm, 1μm))
+    turn!(pa, 90°, 10μm / (pi / 2), Paths.TaperCPW(10μm, 6μm, 2μm, 1μm))
     terminate!(pa; initial=true, rounding=3μm)
     terminate!(pa; rounding=0.5μm, gap=0μm)
     straight!(pa, 10μm, Paths.NoRender())
@@ -49,9 +49,9 @@
     # But constructor based on a path handles generic tapers
 
     # Termination, CPW straight, turn, termination; NoRender, Trace, Taper, Trace
-    @test psty_complex.lengths ≈ [9μm, 1μm, 19.5μm, 0.5μm, 10μm, 10μm, 10μm, 10μm]
+    @test psty_complex.lengths ≈ [9μm, 1μm, 9.5μm, 0.5μm, 10μm, 10μm, 10μm, 10μm]
     pa2 = Path(0nm, 0nm)
-    straight!(pa2, 9 * 70μm + 64μm, psty_complex) # Stop just before attachment in last segment
+    straight!(pa2, 9 * 60μm + 54μm, psty_complex) # Stop just before attachment in last segment
     straight!(pa2, 2μm)
     c = Cell("test")
     render!(c, pa2, GDSMeta(1)) # Runs without error

--- a/test/test_pathstyles.jl
+++ b/test/test_pathstyles.jl
@@ -1,0 +1,54 @@
+@testset "Periodic Path styles" setup = [CommonTestSetup] begin
+    import .Paths: PeriodicStyle, Trace, CPW
+
+    pa = Path(0nm, 0nm)
+    sty1 = Paths.CPW(10μm, 6μm)
+    sty2 = Paths.Trace(2μm)
+
+    psty = PeriodicStyle([sty1, sty2], [20μm, 10μm], 5μm)
+    with_period = PeriodicStyle([sty1, sty2], 30μm; weights=[2, 1], l0=5μm)
+    @test with_period.lengths == psty.lengths
+    @test psty(0μm) === (sty1, 5.0μm)
+    @test psty(18μm) === (sty2, 3.0μm)
+    @test psty(37μm) === (sty1, 12.0μm)
+    @test psty(46μm) === (sty2, 1.0μm)
+    @test Paths.extent(psty, 0μm) == 11μm
+    @test Paths.width(psty, 18μm) == 2μm
+    
+    # Various combinations work
+    # Nested
+    psty_nested = PeriodicStyle([sty1, psty, sty2], 50μm; weights=[1, 3, 1])
+    @test psty_nested(15μm) === (psty, 5.0μm)
+    @test Paths.gap(psty_nested, 65μm) == 6.0μm
+    @test Paths.trace(psty_nested, 75μm) == 2.0μm
+
+    # General, Taper, NoRender, Termination
+    pa = Path(0nm, 0nm)
+    straight!(pa, 4μm, Paths.CPW(x -> 10μm, x -> 6μm))
+    turn!(pa, 90°, 10μm/(pi/4), Paths.TaperCPW(10μm, 6μm, 2μm, 1μm))
+    terminate!(pa; initial=true, rounding=3μm)
+    terminate!(pa; rounding=0.5μm, gap=0μm)
+    straight!(pa, 10μm, Paths.NoRender())
+    straight!(pa, 10μm, Paths.Trace(1μm))
+    straight!(pa, 10μm, Paths.Taper())
+    straight!(pa, 10μm, Paths.Trace(2μm))
+    cs = CoordinateSystem("test", nm)
+    place!(cs, Rectangle(10μm, 10μm), GDSMeta())
+    attach!(pa, sref(cs), 5μm)
+    psty_complex = PeriodicStyle(pa)
+    # Note: PeriodicStyle doesn't work with generic taper; same as CompoundStyle issue #13
+    # But constructor based on a path handles generic tapers
+
+    # Termination, CPW straight, turn, termination; NoRender, Trace, Taper, Trace
+    @test psty_complex.lengths ≈ [9μm, 1μm, 19.5μm, 0.5μm, 10μm, 10μm, 10μm, 10μm]
+    pa2 = Path(0nm, 0nm)
+    straight!(pa2, 9*70μm + 64μm, psty_complex) # Stop just before attachment in last segment
+    straight!(pa2, 2μm)
+    c = Cell("test")
+    render!(c, pa2, GDSMeta(1)) # Runs without error
+    @test length(c.refs) == 10 # Attachment appears in second segment
+    @test length(c.elements) == 101 # 10 * (1 + 2 + 2 + 2 + 0 + 1 + 1 + 1) + 1
+    # Note: Attachment will be duplicated if it's at the exact end and start of a segment!
+    @test split(pa2[1], 100μm)[2].sty.l0 == 100μm
+end
+

--- a/test/test_pathstyles.jl
+++ b/test/test_pathstyles.jl
@@ -14,7 +14,7 @@
     @test psty(46μm) === (sty2, 1.0μm)
     @test Paths.extent(psty, 0μm) == 11μm
     @test Paths.width(psty, 18μm) == 2μm
-    
+
     # Various combinations work
     # Nested
     psty_nested = PeriodicStyle([sty1, psty, sty2], 50μm; weights=[1, 3, 1])
@@ -25,7 +25,7 @@
     # General, Taper, NoRender, Termination
     pa = Path(0nm, 0nm)
     straight!(pa, 4μm, Paths.CPW(x -> 10μm, x -> 6μm))
-    turn!(pa, 90°, 10μm/(pi/4), Paths.TaperCPW(10μm, 6μm, 2μm, 1μm))
+    turn!(pa, 90°, 10μm / (pi / 4), Paths.TaperCPW(10μm, 6μm, 2μm, 1μm))
     terminate!(pa; initial=true, rounding=3μm)
     terminate!(pa; rounding=0.5μm, gap=0μm)
     straight!(pa, 10μm, Paths.NoRender())
@@ -42,7 +42,7 @@
     # Termination, CPW straight, turn, termination; NoRender, Trace, Taper, Trace
     @test psty_complex.lengths ≈ [9μm, 1μm, 19.5μm, 0.5μm, 10μm, 10μm, 10μm, 10μm]
     pa2 = Path(0nm, 0nm)
-    straight!(pa2, 9*70μm + 64μm, psty_complex) # Stop just before attachment in last segment
+    straight!(pa2, 9 * 70μm + 64μm, psty_complex) # Stop just before attachment in last segment
     straight!(pa2, 2μm)
     c = Cell("test")
     render!(c, pa2, GDSMeta(1)) # Runs without error
@@ -51,4 +51,3 @@
     # Note: Attachment will be duplicated if it's at the exact end and start of a segment!
     @test split(pa2[1], 100μm)[2].sty.l0 == 100μm
 end
-

--- a/test/test_pathstyles.jl
+++ b/test/test_pathstyles.jl
@@ -14,6 +14,17 @@
     @test Paths.extent(psty, 0μm) == 11μm
     @test Paths.width(psty, 18μm) == 2μm
 
+    # Unit tests
+    @test copy(psty).styles !== psty.styles
+    @test contains(Paths.summary(psty), "2 substyles")
+    pa = Path()
+    straight!(pa, 10μm, psty)
+    straight!(pa, 1μm, Paths.SimpleNoRender(10μm, virtual=true))
+    @test Paths.nextstyle(pa).l0 == 0μm # Same style, restarted periodicity l0 == 0
+    straight!(pa, 20μm) # Exact length of substyle
+    segs, stys = Paths.resolve_periodic(pa[end].seg, pa[end].sty)
+    @test length(segs) == 1
+
     # Various combinations work
     # Nested
     psty_nested = PeriodicStyle([sty1, psty, sty2]; period=50μm, weights=[1, 3, 1])
@@ -56,7 +67,7 @@
     c = Cell("test")
     render!(c, pa2, GDSMeta(1)) # Runs without error
     @test length(c.refs) == 10 # Attachment appears in second segment
-    @test length(c.elements) == 101 # 10 * (1 + 2 + 2 + 2 + 0 + 1 + 1 + 1) + 1
     # Note: Attachment will be duplicated if it's at the exact end and start of a segment!
+    @test length(c.elements) == 101 # 10 * (1 + 2 + 2 + 2 + 0 + 1 + 1 + 1) + 1
     @test split(pa2[1], 100μm)[2].sty.l0 == 100μm
 end

--- a/test/test_render.jl
+++ b/test/test_render.jl
@@ -555,6 +555,7 @@ end
         straight!(pa, 20μm, Paths.Trace(15μm))
         straight!(pa, 20μm, Paths.Trace(20μm))
         simplify!(pa)
+        @test Paths.nextstyle(pa) == Paths.Trace(20μm)
 
         pa2 = split(pa[1], 20μm)
         @test length(pa2) == 2


### PR DESCRIPTION
[Updated description] Adds a periodic style as described in #22, allowing cycling between different styles each for a fixed length. This also can be used to draw a path with periodic attachments without a performance penalty relative to the usual `attach!` method that requires knowing the pathlength ahead of time.

Example:
```jl
    pa = Path()
    straight!(pa, 30μm, Paths.CPW(10μm, 6μm))
    cs = CoordinateSystem("attachment", nm)
    place!(cs, centered(Rectangle(5μm, 5μm)), GDSMeta())
    attach!(pa, sref(cs), 5μm)
    terminate!(pa; initial=true, rounding=3μm)
    terminate!(pa; rounding=3μm, gap=0μm)
    straight!(pa, 10μm, Paths.NoRender())
    psty = Paths.PeriodicStyle(pa, l0=21μm)

    pa2 = Path()
    straight!(pa2, 95μm, psty)
    turn!(pa2, pi/2, 200μm)

    c = Cell("test")
    render!(c, pa2, GDSMeta(1))
```

<img width="446" height="318" alt="image" src="https://github.com/user-attachments/assets/e2035305-3448-4ebc-a789-8b8f5d3f737c" />

Would also be nice to be able to `terminate!`, but that will be added in a separate PR.

This PR also introduces `nextstyle`, which is based on but distinct from `laststyle` to allow periodic styles to continue where they left off. To do this, `laststyle` and `nextstyle` are changed to use without_attachments rather than undecorated -- a shallow version of undecorated that allows periodic attachments to work. It also means that overlay styles are continued when they previously were not -- this was considered a bug.

A current limitation is that the periodic style cannot start or end in a termination. This is because you can't split a termination, but the error message is unclear (no `translate` method). This will be fixed in a separate PR.