### PR TITLE
Fix bug where map_metadata! could map a structure more than once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format of this changelog is based on
 
   - Added `SchematicDrivenLayout.filter_parameters` for sharing parameters between composite components and subcomponents
   - Added component style guide to docs
+  - Fixed bug where `map_metadata!` would map multiply-referenced structures multiple times
 
 ## 1.9.0 (2026-02-09)
 

--- a/src/paths/paths.jl
+++ b/src/paths/paths.jl
@@ -678,15 +678,23 @@ function discretization(seg::Paths.Segment; kwargs...)
 end
 
 function DeviceLayout.map_metadata!(path::Path, map_meta)
+    visited = Set{Any}()
+    return map_metadata!(path, map_meta, visited)
+end
+
+function DeviceLayout.map_metadata!(path::Path, map_meta, visited::Set{Any})
+    path in visited && return nothing
+    push!(visited, path)
     path.metadata = map_meta(path.metadata)
     for s in structure.(refs(path))
-        map_metadata!(s, map_meta)
+        map_metadata!(s, map_meta, visited)
     end
     # Overlay styles store their own metadata
     overlay_inds = findall(x -> isa(style(x), Paths.OverlayStyle), path.nodes)
     for i in overlay_inds
         path[i].sty.overlay_metadata .= map_meta.(path[i].sty.overlay_metadata)
     end
+    return nothing
 end
 
 include("contstyles/trace.jl")

--- a/src/paths/paths.jl
+++ b/src/paths/paths.jl
@@ -677,12 +677,7 @@ function discretization(seg::Paths.Segment; kwargs...)
     return DeviceLayout.adapted_grid(t -> Paths.direction(seg, t), bnds)
 end
 
-function DeviceLayout.map_metadata!(path::Path, map_meta)
-    visited = Set{Any}()
-    return map_metadata!(path, map_meta, visited)
-end
-
-function DeviceLayout.map_metadata!(path::Path, map_meta, visited::Set{Any})
+function DeviceLayout.map_metadata!(path::Path, map_meta, visited::Set{Any}=Set{Any}())
     path in visited && return nothing
     push!(visited, path)
     path.metadata = map_meta(path.metadata)

--- a/src/schematics/schematics.jl
+++ b/src/schematics/schematics.jl
@@ -1179,7 +1179,7 @@ function index_layer!(
     ly,
     nextindex=1
 )
-    for (cs, trans) in traversal(comp_cs)
+    for (cs, trans) in DeviceLayout.traversal(comp_cs)
         for (idx, el, m) in zip(1:length(elements(cs)), elements(cs), element_metadata(cs))
             if layer(m) == ly
                 place!(parent_cs, trans(el), SemanticMeta(m, index=nextindex))
@@ -1189,14 +1189,6 @@ function index_layer!(
         end
     end
     return nextindex
-end
-
-function traversal(cs::GeometryStructure, trans=DeviceLayout.ScaledIsometry())
-    tv = [(cs, trans)]
-    for ref in refs(cs)
-        tv = vcat(tv, traversal(structure(ref), trans ∘ transformation(ref)))
-    end
-    return tv
 end
 
 """

--- a/src/schematics/targets.jl
+++ b/src/schematics/targets.jl
@@ -101,8 +101,11 @@ For every element in `geometry(comp)` with original meta `m`, set its metadata t
 
 Recursive on referenced structures.
 """
-DeviceLayout.map_metadata!(comp::AbstractComponent, map_meta) =
-    map_metadata!(geometry(comp), map_meta)
+DeviceLayout.map_metadata!(
+    comp::AbstractComponent,
+    map_meta,
+    visited::Set{Any}=Set{Any}()
+) = map_metadata!(geometry(comp), map_meta, visited)
 
 """
     flipchip!(geom::GeometryStructure)

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -195,12 +195,7 @@ multiply-referenced structures are not mapped multiple times.
 
 The `visited` argument is used internally to track structures already processed.
 """
-function map_metadata!(geom::GeometryStructure, map_meta)
-    visited = Set{Any}()
-    return map_metadata!(geom, map_meta, visited)
-end
-
-function map_metadata!(geom::GeometryStructure, map_meta, visited::Set{Any})
+function map_metadata!(geom::GeometryStructure, map_meta, visited::Set{Any}=Set{Any}())
     geom in visited && return nothing
     push!(visited, geom)
     geom.element_metadata .= map_meta.(geom.element_metadata)

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -168,15 +168,46 @@ lowerleft(s::GeometryStructure) = lowerleft(bounds(s))
 upperright(s::GeometryStructure) = upperright(bounds(s))
 
 """
-    function map_metadata!(geom::GeometryStructure, map_meta)
+    traversal(cs::GeometryStructure, trans=ScaledIsometry())
+
+Return a vector of `(structure, transformation)` tuples for `cs` and all structures in its
+reference hierarchy. The transformation is the global transformation from the root to the
+structure.
+
+Note: The same structure may appear multiple times with different transformations if it is
+referenced multiple times.
+"""
+function traversal(cs::GeometryStructure, trans=ScaledIsometry())
+    tv = [(cs, trans)]
+    for ref in refs(cs)
+        tv = vcat(tv, traversal(structure(ref), trans ∘ transformation(ref)))
+    end
+    return tv
+end
+
+"""
+    function map_metadata!(geom::GeometryStructure, map_meta, [visited])
 
 For every element in `geom` with original meta `m`, set its metadata to `map_meta(m)`.
 
-Recursive on referenced structures.
+Operates on all unique structures in the reference hierarchy exactly once, so that
+multiply-referenced structures are not mapped multiple times.
+
+The `visited` argument is used internally to track structures already processed.
 """
 function map_metadata!(geom::GeometryStructure, map_meta)
-    element_metadata(geom) .= map_meta.(geom.element_metadata)
-    return map_metadata!.(structure.(refs(geom)), map_meta)
+    visited = Set{Any}()
+    return map_metadata!(geom, map_meta, visited)
+end
+
+function map_metadata!(geom::GeometryStructure, map_meta, visited::Set{Any})
+    geom in visited && return nothing
+    push!(visited, geom)
+    geom.element_metadata .= map_meta.(geom.element_metadata)
+    for ref in refs(geom)
+        map_metadata!(structure(ref), map_meta, visited)
+    end
+    return nothing
 end
 
 """


### PR DESCRIPTION
Fix #140. Just keep track of visited structures since some (Paths) need special handling.