### PR TITLE
Fix composite variant map_hooks forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format of this changelog is based on
   - Added `SchematicDrivenLayout.filter_parameters` for sharing parameters between composite components and subcomponents
   - Added component style guide to docs
   - Fixed bug where `map_metadata!` would map multiply-referenced structures multiple times
+  - Fixed bug where `@composite_variant` would not forward `map_hooks` to base variant when defined with component instance rather than type
 
 ## 1.9.0 (2026-02-09)
 

--- a/src/schematics/components/composite_components.jl
+++ b/src/schematics/components/composite_components.jl
@@ -174,18 +174,19 @@ function hooks(cc::T) where {T <: AbstractCompositeComponent}
         !isempty(cc._hooks) && return (; pairs(cc._hooks)...)
     end
     floorplan = schematic(cc)
-    hooknames = [keys(hooks(floorplan, node)) for node in nodes(graph(cc))]
-    cc_names = [
-        compose_hookname(cc, i, hookname) for (i, hnames) in enumerate(hooknames) for
-        hookname in hnames
+    hooknames_cc_hooks_pairs = [pairs(hooks(floorplan, node)) for node in nodes(graph(cc))]
+    cc_hook_pairs = [
+        compose_hookname(cc, i, hookname) => h for
+        (i, hpairs) in enumerate(hooknames_cc_hooks_pairs) for (hookname, h) in hpairs
     ]
-    cc_hooks = [values(hooks(floorplan, node)) for node in nodes(graph(cc))]
     if hasfield(T, :_hooks)
-        for (name, hook) in zip(cc_names, Iterators.flatten(cc_hooks))
+        for (name, hook) in cc_hook_pairs
             cc._hooks[name] = hook
         end
     end
-    return NamedTuple{(cc_names...,)}(Iterators.flatten(cc_hooks))
+    cc_names = first.(cc_hook_pairs)
+    cc_hooks = last.(cc_hook_pairs)
+    return NamedTuple{(cc_names...,)}(cc_hooks)
 end
 
 """

--- a/src/schematics/components/variants.jl
+++ b/src/schematics/components/variants.jl
@@ -118,6 +118,7 @@ function composite_variant_expr(
         SchematicDrivenLayout.base_variant(::$esctype) = $T
         # Hook map is the same
         SchematicDrivenLayout.map_hooks(::$esctype) = map_hooks($T)
+        SchematicDrivenLayout.map_hooks(comp::$escname) = map_hooks(base_variant(comp))
         # Subcomponents are the same
         SchematicDrivenLayout._build_subcomponents(comp::$escname) =
             _build_subcomponents(base_variant(comp))

--- a/test/test_schematicdriven.jl
+++ b/test/test_schematicdriven.jl
@@ -760,12 +760,16 @@
         )
             return add_node!(g, subcomps.bqbq)
         end
+        function SchematicDrivenLayout.map_hooks(comp::TestWrapper) # Define based on instance
+            return Dict((1 => :xy1) => :xy1)
+        end
         c = TestWrapper(jj_width=200nm)
         @test component(graph(c)[1]).jj_width == 200nm
         @test component(graph(component(graph(c)[1]))[1]).jj_width == 200nm
 
         @composite_variant TestWrapperVariant TestWrapper new_defaults = (; jj_width=200nm)
         @test component(graph(TestWrapperVariant())[1]).jj_width == 200nm
+        @test hooks(TestWrapperVariant()).xy1.p == hooks(c).xy1.p # Uses base variant map_hooks
 
         ### No reordering of nodes or changing root of rendering tree
         g = SchematicGraph("spacers")


### PR DESCRIPTION
Forward `map_hooks(::MyCompositeVariant)` to base variant of composite component rather than just `map_hooks(::Type{MyCompositeVariant})`. Also fix a rare bug where `map_hooks` could iterate over subcomponent keys and values in different orders. Closes #139.