### PR TITLE
Add more control over GDSII spec warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format of this changelog is based on
   - Changed default CPW mesh size to use `2 * min(trace, gap)` (higher element quality when trace and gap are very different)
   - Changed default global mesh grading from `0.9` to `0.75` (more robust meshing for complex geometries, relatively small cost)
   - Fixed `SolidModel` rendering issue where some exterior boundaries might not be tagged
-  - Changed threshold for GDSII layer/datatype number spec warning to 32767; added keyword options and `GDSWriterOptions` to configure this
+  - Changed threshold for GDSII layer/datatype number spec warning to 32767; added `GDSWriterOptions` to configure this
 
 ## 1.8.0 (2026-01-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format of this changelog is based on
   - Changed default CPW mesh size to use `2 * min(trace, gap)` (higher element quality when trace and gap are very different)
   - Changed default global mesh grading from `0.9` to `0.75` (more robust meshing for complex geometries, relatively small cost)
   - Fixed `SolidModel` rendering issue where some exterior boundaries might not be tagged
-  - Changed threshold for GDSII layer/datatype number spec warning to 65535; added keyword options and `GDSWriterOptions` to configure this
+  - Changed threshold for GDSII layer/datatype number spec warning to 32767; added keyword options and `GDSWriterOptions` to configure this
 
 ## 1.8.0 (2026-01-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format of this changelog is based on
   - Changed default CPW mesh size to use `2 * min(trace, gap)` (higher element quality when trace and gap are very different)
   - Changed default global mesh grading from `0.9` to `0.75` (more robust meshing for complex geometries, relatively small cost)
   - Fixed `SolidModel` rendering issue where some exterior boundaries might not be tagged
+  - Changed threshold for GDSII layer/datatype number spec warning to 65535; added keyword options and `GDSWriterOptions` to configure this
 
 ## 1.8.0 (2026-01-05)
 

--- a/docs/src/fileio.md
+++ b/docs/src/fileio.md
@@ -14,6 +14,7 @@ systems. In the future it may be useful to implement machine-specific pattern fo
 force fracturing or dosing in an explicit manner.
 
 ```@docs
+    DeviceLayout.GDSWriterOptions
     DeviceLayout.save
 ```
 

--- a/src/DeviceLayout.jl
+++ b/src/DeviceLayout.jl
@@ -583,6 +583,9 @@ import .Autofill: autofill!, make_halo
 export Autofill, autofill!, make_halo
 
 include("backends/gds.jl")
+import .GDS: GDSWriterOptions
+export GDSWriterOptions
+
 include("backends/graphics.jl")
 include("backends/dxf.jl")
 

--- a/src/backends/gds.jl
+++ b/src/backends/gds.jl
@@ -18,6 +18,7 @@ import FileIO: File, @format_str, stream, magic, skipmagic
 
 export GDS64
 export gdsbegin, gdsend, gdswrite
+export GDSWriterOptions
 
 const GDSVERSION   = UInt16(600)
 const HEADER       = 0x0002
@@ -60,6 +61,41 @@ const PROPVALUE    = 0x2C06
 const BOX          = 0x2D00
 const BOXTYPE      = 0x2E02
 const PLEX         = 0x2F03
+
+"""
+    @kwdef struct GDSWriterOptions
+
+Options controlling warnings and validation during GDS file writing.
+
+# Fields
+
+  - `max_layer::Int = 65535`: Maximum allowed layer number. Modern tools support 0-65535.
+  - `max_datatype::Int = 65535`: Maximum allowed datatype number. Modern tools support 0-65535.
+  - `warn_invalid_names::Bool = true`: Whether to warn about cell/text names that violate
+    the GDSII spec (must be ≤32 chars, only A-Z, a-z, 0-9, '_', '?', '\$').
+
+# Examples
+
+```julia
+# Default: modern limits, name warnings enabled
+opts = GDSWriterOptions()
+
+# Strict GDSII spec compliance
+opts = GDSWriterOptions(max_layer=63, max_datatype=63)
+
+# No warnings at all
+opts = GDSWriterOptions(
+    max_layer=typemax(Int),
+    max_datatype=typemax(Int),
+    warn_invalid_names=false
+)
+```
+"""
+@kwdef struct GDSWriterOptions
+    max_layer::Int = 65535
+    max_datatype::Int = 65535
+    warn_invalid_names::Bool = true
+end
 
 const GDSTokens = Dict{UInt16, String}(
     0x0258 => "GDSVERSION",
@@ -292,16 +328,20 @@ function gdsbegin(
 end
 
 """
-    gdswrite(io::IO, cell::Cell, dbs::Length, spec_warnings::Bool=true)
+    gdswrite(io::IO, cell::Cell, dbs::Length, options::GDSWriterOptions=GDSWriterOptions())
 
 Write a `Cell` to an IO buffer. The creation and modification date of the cell
 are written first, followed by the cell name, the polygons in the cell,
-and finally any references or arrays. If `spec_warnings`,
-warnings will be emitted on GDSII format violations.
+and finally any references or arrays. Warnings are controlled by `options`.
 """
-function gdswrite(io::IO, cell::Cell, dbs::Length, spec_warnings::Bool=true)
+function gdswrite(
+    io::IO,
+    cell::Cell,
+    dbs::Length,
+    options::GDSWriterOptions=GDSWriterOptions()
+)
     name = even(cell.name)
-    spec_warnings && namecheck(name)
+    options.warn_invalid_names && namecheck(name)
 
     y   = UInt16(Dates.value(Dates.Year(cell.create)))
     mo  = UInt16(Dates.value(Dates.Month(cell.create)))
@@ -321,13 +361,13 @@ function gdswrite(io::IO, cell::Cell, dbs::Length, spec_warnings::Bool=true)
     bytes = gdswrite(io, BGNSTR, y, mo, d, h, min, s, y1, mo1, d1, h1, min1, s1)
     bytes += gdswrite(io, STRNAME, name)
     for (x, m) in zip(cell.elements, cell.element_metadata)
-        bytes += gdswrite(io, x, m, dbs, spec_warnings)
+        bytes += gdswrite(io, x, m, dbs, options)
     end
     for x in cell.refs
         bytes += gdswrite(io, x, dbs)
     end
     for (x, m) in zip(cell.texts, cell.text_metadata)
-        bytes += gdswrite(io, x, m, dbs, spec_warnings)
+        bytes += gdswrite(io, x, m, dbs, options)
     end
     return bytes += gdswrite(io, ENDSTR)
 end
@@ -336,20 +376,26 @@ p2p(x::Length, dbs) = convert(Int, round(convert(Float64, x / dbs)))
 p2p(x::Real, dbs) = p2p(x * 1μm, dbs)
 
 """
-    gdswrite(io::IO, poly::Polygon{T}, meta, dbs, spec_warnings::Bool=true) where {T}
+    gdswrite(io::IO, poly::Polygon{T}, meta, dbs, options::GDSWriterOptions=GDSWriterOptions()) where {T}
 
 Write a polygon to an IO buffer. The layer and datatype are written first,
 then the boundary of the polygon is written in a 32-bit integer format with
 specified database scale.
 
-Note that polygons without units are presumed to be in microns. If `spec_warnings`,
-warnings will be emitted on GDSII format violations.
+Note that polygons without units are presumed to be in microns. Warnings are
+controlled by `options`.
 """
-function gdswrite(io::IO, poly::Polygon{T}, meta, dbs, spec_warnings::Bool=true) where {T}
+function gdswrite(
+    io::IO,
+    poly::Polygon{T},
+    meta,
+    dbs,
+    options::GDSWriterOptions=GDSWriterOptions()
+) where {T}
     bytes = gdswrite(io, BOUNDARY)
     lyr = gdslayer(meta)
-    spec_warnings && layercheck(lyr)
     dt = datatype(meta)
+    layerdatatypecheck(lyr, dt, options)
     bytes += gdswrite(io, LAYER, lyr)
     bytes += gdswrite(io, DATATYPE, dt)
 
@@ -363,16 +409,22 @@ function gdswrite(io::IO, poly::Polygon{T}, meta, dbs, spec_warnings::Bool=true)
 end
 
 """
-    gdswrite(io::IO, t::Texts.Text, dbs, spec_warnings::Bool=true)
+    gdswrite(io::IO, t::Texts.Text, meta, dbs, options::GDSWriterOptions=GDSWriterOptions())
 
-Write text to an IO buffer. Width without units presumed to be in microns. If `spec_warnings`,
-warnings will be emitted on GDSII format violations.
+Write text to an IO buffer. Width without units presumed to be in microns. Warnings are
+controlled by `options`.
 """
-function gdswrite(io::IO, t::Texts.Text, meta, dbs, spec_warnings::Bool=true)
+function gdswrite(
+    io::IO,
+    t::Texts.Text,
+    meta,
+    dbs,
+    options::GDSWriterOptions=GDSWriterOptions()
+)
     bytes = gdswrite(io, TEXT)
     lyr = gdslayer(meta)
-    spec_warnings && layercheck(lyr)
     dt = datatype(meta)
+    layerdatatypecheck(lyr, dt, options)
     bytes += gdswrite(io, LAYER, lyr)
     bytes += gdswrite(io, TEXTTYPE, dt)
 
@@ -391,7 +443,7 @@ function gdswrite(io::IO, t::Texts.Text, meta, dbs, spec_warnings::Bool=true)
     bytes += gdswrite(io, XY, x, y)
 
     str = even(t.text)
-    spec_warnings && namecheck(str)
+    options.warn_invalid_names && namecheck(str)
     bytes += gdswrite(io, STRING, str)
 
     return bytes += gdswrite(io, ENDEL)
@@ -496,14 +548,36 @@ function namecheck(a::String)
     )
 end
 
-function layercheck(layer)
-    return (0 <= layer <= 63) || @warn(
-        string(
-            "CellPolygon layer ",
-            layer,
-            ": The GDSII spec only permits layers from 0 to 63."
+"""
+    layerdatatypecheck(layer, datatype, options::GDSWriterOptions)
+
+Check layer and datatype against configured limits. Warns if either exceeds the
+maximum values specified in `options`.
+"""
+function layerdatatypecheck(layer, datatype, options::GDSWriterOptions)
+    if !(0 <= layer <= options.max_layer)
+        @warn(
+            string(
+                "Layer ",
+                layer,
+                " exceeds configured maximum (",
+                options.max_layer,
+                ")."
+            )
         )
-    )
+    end
+    if !(0 <= datatype <= options.max_datatype)
+        @warn(
+            string(
+                "Datatype ",
+                datatype,
+                " exceeds configured maximum (",
+                options.max_datatype,
+                ")."
+            )
+        )
+    end
+    return nothing
 end
 
 gdsend(io::IO) = gdswrite(io, ENDLIB)
@@ -512,7 +586,8 @@ gdsend(io::IO) = gdswrite(io, ENDLIB)
     save(::Union{AbstractString,IO}, cell0::Cell{T}, cell::Cell...)
     save(f::File{format"GDS"}, cell0::Cell, cell::Cell...;
         name="GDSIILIB", userunit=1μm, modify=now(), acc=now(),
-        spec_warnings=true, verbose=false)
+        options=GDSWriterOptions(), spec_warnings=nothing, verbose=false,
+        max_layer=nothing, max_datatype=nothing, warn_invalid_names=nothing)
 
 This bottom method is implicitly called when you use the convenient syntax of
 the top method: `save("/path/to/my.gds", cells_i_want_to_save...)`
@@ -525,7 +600,11 @@ Keyword arguments include:
     with inferior unit support.
   - `modify`: date of last modification.
   - `acc`: date of last accession. It would be unusual to have this differ from `now()`.
-  - `spec_warnings`: whether to emit warnings due to GDSII format violations (default: `true`)
+  - `options`: a [`GDSWriterOptions`](@ref) controlling validation and warnings.
+  - `max_layer`: if specified, overrides `options.max_layer`
+  - `max_datatype`: if specified, overrides `options.max_datatype`
+  - `warn_invalid_names`: if specified, overrides `options.warn_invalid_names`
+  - `spec_warnings`: if `false`, disables warnings for max layer/datatype and invalid names
   - `verbose`: monitor the output of [`traverse!`](@ref) and [`order!`](@ref) to see if
     something funny is happening while saving.
 """
@@ -537,9 +616,22 @@ function save(
     userunit=1μm,
     modify=now(),
     acc=now(),
-    spec_warnings=true,
+    options::GDSWriterOptions=GDSWriterOptions(),
+    max_layer=nothing,
+    max_datatype=nothing,
+    warn_invalid_names=nothing,
+    spec_warnings::Bool=true,
     verbose=false
 )
+    if !spec_warnings
+        options = GDSWriterOptions(typemax(Int), typemax(Int), false)
+    else
+        options = GDSWriterOptions(
+            isnothing(max_layer) ? options.max_layer : max_layer,
+            isnothing(max_datatype) ? options.max_datatype : max_datatype,
+            isnothing(warn_invalid_names) ? options.warn_invalid_names : warn_invalid_names
+        )
+    end
     dbs = dbscale(cell0, cell...)
     pad = mod(length(name), 2) == 1 ? "\0" : ""
     open(f, "w") do s
@@ -576,7 +668,7 @@ function save(
                 )
             end
             names[c.name] = c
-            bytes += gdswrite(io, c, dbs, spec_warnings)
+            bytes += gdswrite(io, c, dbs, options)
         end
         return bytes += gdsend(io)
     end


### PR DESCRIPTION
Set the threshold for layer/datatype number warnings to 32767, consistent with the 2-byte signed integer specified as the data type in the spec, rather than 63 as specified as the strict limit in the spec. Also update LAYER/DATATYPE record read/write to use unsigned integers, allowing numbers 0 to 65535, consistent with a common extension of the GDSII format. (This is consistent with our use of technical limits due to GDSII record sizes rather than the original spec, like 8191 as the maximum number of points in a polygon rather than the original spec's 200 -- c.f. https://harrydole.com/wp/2017/09/18/gds/.) 

Also make this configurable by keyword argument or `GDSWriterOptions` passed to `save`, along with `warn_invalid_names`, all of which are still overridden by `spec_warnings=false`. (Note that increasing it beyond 65535 is useless because you will get an error from trying to write it as a UInt16.)

There are other warnings or functionality we could add as configurable options. For example, some readers may limit the number of unique layers or datatypes (https://www.artwork.com/gdsii/qis/faq/qis_limits.htm). Max number of points in a polygon could also be configurable, although we enforce that limit on rendering to a Cell rather than on saving. However, any of that should be done in a separate PR.