### PR TITLE
Experimental graphical text rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format of this changelog is based on
   - Added component style guide to docs
   - Fixed bug where `map_metadata!` would map multiply-referenced structures multiple times
   - Fixed bug where `@composite_variant` would not forward `map_hooks` to base variant when defined with component instance rather than type
+  - Added experimental Text entity support to graphics backend
 
 ## 1.9.0 (2026-02-09)
 

--- a/src/backends/graphics.jl
+++ b/src/backends/graphics.jl
@@ -144,6 +144,16 @@ function Base.show(
         Cairo.restore(ctx)
     end
 
+    if c0 isa Cell
+        Cairo.save(ctx)
+        for (t, meta) in zip(c0.texts, c0.text_metadata)
+            Cairo.set_source_rgba(ctx, fillcolor(options, gdslayer(meta))...)
+            render_text!(ctx, trans(t), sf)
+        end
+        Cairo.fill(ctx)
+        Cairo.restore(ctx)
+    end
+
     if bboxes
         for ref in c0.refs
             Cairo.save(ctx)
@@ -193,7 +203,7 @@ alignstr(::YCenter) = "center"
 alignstr(::BottomEdge) = "bottom"
 
 function render_text!(ctx, t::Text, sf)
-    fontsize = Int(round(iszero(t.width) ? 12 : (ustrip(t.width) * sf * t.mag)))
+    fontsize = Int(round(iszero(t.width) ? 12 * t.mag : (ustrip(t.width) * sf * t.mag)))
     pos = ustrip(t.origin)
     Cairo.set_font_face(ctx, "Serif $fontsize")
     return Cairo.text(

--- a/src/render/render.jl
+++ b/src/render/render.jl
@@ -57,7 +57,7 @@ function render!(
 end
 
 function render!(c::Cell{S}, text::Texts.Text, meta::GDSMeta=GDSMeta(); kwargs...) where {S}
-    return text!(c, text, meta; kwargs...)
+    return text!(c, text, meta)
 end
 
 function render!(c::Cell{S}, text::Vector{Texts.Text{S}}, meta::Vector{GDSMeta}) where {S}

--- a/src/texts.jl
+++ b/src/texts.jl
@@ -25,11 +25,14 @@ import DeviceLayout: to_polygons, transform, transformation, Transformation
 
 Text element in a layout. Distinct from rendering text as polygons (`PolyText`).
 
+Text rendering may be viewer or system dependent. Use `PolyText` for text with
+well-defined geometry.
+
 Arguments:
 
   - `text`: the text string.
   - `origin`: location of the text in parent coordinate system.
-  - `width`: character width
+  - `width`: character size
   - `can_scale`: defaults to `false`, set to `true` if the text size should not be affected
     by scaling of parent coordinate system.
   - `xalign`: horizontal alignment of text with respect to `origin`. Can be any instance of
@@ -51,6 +54,23 @@ struct Text{S} <: GeometryEntity{S}
     mag::Float64
     rot::Float64
 end
+Base.convert(::Type{GeometryEntity{T}}, t::Text) where {T} = convert(Text{T}, t)
+function Base.convert(::Type{Text{T}}, t::Text) where {T}
+    origin = convert(Point{T}, t.origin)
+    width = convert(T, t.width)
+    return Text(;
+        t.text,
+        origin,
+        width,
+        t.can_scale,
+        t.xalign,
+        t.yalign,
+        t.xrefl,
+        t.mag,
+        t.rot
+    )
+end
+Base.convert(::Type{Text{T}}, t::Text{T}) where {T} = t
 
 transformation(t::Text) = ScaledIsometry(t.origin, t.rot, t.xrefl, t.mag)
 
@@ -103,21 +123,5 @@ function Text(;
     return Text{S}(text, origin, width, can_scale, xalign, yalign, xrefl, mag, rot)
 end
 Text(text, origin; kwargs...) = Text(; text, origin, kwargs...)
-
-function Base.convert(::Type{Text{S}}, t::Text) where {S}
-    origin = convert(Point{S}, t.origin)
-    width = convert(S, t.width)
-    return Text(;
-        t.text,
-        origin,
-        width,
-        t.can_scale,
-        t.xalign,
-        t.yalign,
-        t.xrefl,
-        t.mag,
-        t.rot
-    )
-end
 
 end

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -977,7 +977,13 @@ end
         cs2 = CoordinateSystem("test")
         r1 = Rectangle(10mm, 10mm)
         t1 = Texts.Text("test1", Point(1, 1)mm, rot=10°, xalign=Align.XCenter())
-        t2 = Texts.Text("test2", Point(1, 1)mm, rot=pi / 2, yalign=Align.YCenter())
+        t2 = Texts.Text(
+            "test2",
+            Point(1, 1)mm,
+            rot=pi / 2,
+            yalign=Align.YCenter(),
+            width=2mm
+        )
         t3 = Texts.Text(
             "test3",
             Point(1, 1)mm,
@@ -990,6 +996,10 @@ end
         place!(cs2, t2, :text)
         place!(cs2, t3, :text)
         save(path, cs2)
+        rm(path, force=true)
+        # With intermediate cell
+        c = Cell(cs2)
+        save(path, c)
         rm(path, force=true)
     end
 end

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -972,5 +972,24 @@ end
         path = joinpath(tdir, "test_cs.png")
         save(path, cs1)
         rm(path, force=true)
+
+        # Text in graphics
+        cs2 = CoordinateSystem("test")
+        r1 = Rectangle(10mm, 10mm)
+        t1 = Texts.Text("test1", Point(1, 1)mm, rot=10°, xalign=Align.XCenter())
+        t2 = Texts.Text("test2", Point(1, 1)mm, rot=pi / 2, yalign=Align.YCenter())
+        t3 = Texts.Text(
+            "test3",
+            Point(1, 1)mm,
+            xalign=Align.RightEdge(),
+            yalign=Align.BottomEdge(),
+            mag=2
+        )
+        place!(cs2, r1, :nontext)
+        place!(cs2, t1, :text)
+        place!(cs2, t2, :text)
+        place!(cs2, t3, :text)
+        save(path, cs2)
+        rm(path, force=true)
     end
 end


### PR DESCRIPTION
Use Cairo to draw text entities for graphical output. The interface is not very good and gives poor control over text size (uses font size) and alignment (doesn't use actual bounding box of text but something mysterious) and has no x reflection, but Text does not have a well-defined graphical representation in the first place (GDS viewers may ignore text size entirely) -- that's what PolyText is for. Added a warning to the docstring.

(I believe even CairoMakie doesn't use this API, they do something lower level with glyphs directly.)