### PR TITLE
Fix preserved -> retained physical groups in SolidModelTarget

### DIFF
--- a/src/schematics/ExamplePDK/ExamplePDK.jl
+++ b/src/schematics/ExamplePDK/ExamplePDK.jl
@@ -246,7 +246,7 @@ function singlechip_solidmodel_target(boundary_groups...)
         )
     )
     retained_physical_groups = [(x, 2) for x ∈ boundary_groups]
-    append!(target.rendering_options.retained_physical_groups, retained_physical_groups)
+    append!(target.retained_physical_groups, retained_physical_groups)
     return target
 end
 singlechip_solidmodel_target(boundary_groups::Vector) =
@@ -367,7 +367,7 @@ groups to be retained specified by boundary_groups
 function flipchip_solidmodel_target(boundary_groups...)
     target = deepcopy(FLIPCHIP_SOLIDMODEL_TARGET)
     retained_physical_groups = [(x, 2) for x ∈ boundary_groups]
-    append!(target.rendering_options.retained_physical_groups, retained_physical_groups)
+    append!(target.retained_physical_groups, retained_physical_groups)
     return target
 end
 flipchip_solidmodel_target(boundary_groups::Vector) =

--- a/src/schematics/solidmodels.jl
+++ b/src/schematics/solidmodels.jl
@@ -42,6 +42,7 @@ The `rendering_options` include any keyword arguments to be passed down to the l
     `technology` into the substrate, rather than away from it.
   - `wave_port_layers`: A list of layer `Symbol`s for layers that are 1D line segments extruded to define wave port boundary conditions.
   - `ignored_layers`: A list of layer `Symbol`s for layers that should be ignored during rendering (mapped to `nothing`). This provides an alternative to using `NORENDER_META` for layers that should be conditionally ignored in solid model rendering but may be needed for other rendering targets.
+  - `retained_physical_groups`: Vector of `(name, dimension)` tuples specifying which physical groups to keep after rendering. All other groups are removed.
 
 The `postrenderer` is a list of geometry kernel commands that create new named groups of
 entities from other groups, for example by geometric Boolean operations like intersection.
@@ -56,7 +57,7 @@ struct SolidModelTarget <: Target
     substrate_layers::Vector{Symbol}
     wave_port_layers::Vector{Symbol}
     ignored_layers::Vector{Symbol}
-    preserved_groups::Vector{Tuple{String, Int}}
+    retained_physical_groups::Vector{Tuple{String, Int}}
     rendering_options
     postrenderer
 end
@@ -70,7 +71,7 @@ SolidModelTarget(
     wave_port_layers=[],
     ignored_layers=[],
     postrender_ops=[],
-    preserved_groups=[],
+    retained_physical_groups=[],
     kwargs...
 ) = SolidModelTarget(
     tech,
@@ -80,8 +81,8 @@ SolidModelTarget(
     substrate_layers,
     wave_port_layers,
     ignored_layers,
-    preserved_groups,
-    (; solidmodel=true, kwargs...),
+    retained_physical_groups,
+    (; solidmodel=true, retained_physical_groups=retained_physical_groups, kwargs...),
     postrender_ops
 )
 
@@ -255,6 +256,7 @@ function render!(sm::SolidModel, sch::Schematic, target::Target; strict=:error, 
             zmap=Base.Fix1(layer_z, target),
             postrender_ops=postrender_ops,
             map_meta=_map_meta_fn(target),
+            retained_physical_groups=target.retained_physical_groups,
             kwargs...,
             target.rendering_options...
         )

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -1,6 +1,16 @@
 @testitem "ExamplePDK" setup = [CommonTestSetup] begin
     include("../examples/DemoQPU17/DemoQPU17.jl")
     @time "Total" schematic, artwork = DemoQPU17.qpu17_demo(dir=tdir)
+
+    # Check target constructor
+    fc_target = SchematicDrivenLayout.ExamplePDK.flipchip_solidmodel_target([
+        "port_1",
+        "port_2",
+        "lumped_element"
+    ])
+    @show SchematicDrivenLayout.ExamplePDK.FLIPCHIP_SOLIDMODEL_TARGET.rendering_options
+    @test ("port_1", 2) in fc_target.retained_physical_groups
+    @test ("port_2", 2) in fc_target.rendering_options.retained_physical_groups # Backwards compatibility
 end
 
 @testitem "Single Transmon" setup = [CommonTestSetup] begin
@@ -49,11 +59,11 @@ end
     render!(
         sm,
         floorplan,
-        SchematicDrivenLayout.ExamplePDK.ExamplePDK.singlechip_solidmodel_target(
+        SchematicDrivenLayout.ExamplePDK.singlechip_solidmodel_target([
             "port_1",
             "port_2",
             "lumped_element"
-        );
+        ]);
         strict=:no
     )
     # Ensure fragment and map found all the exterior boundaries: 3*4 sides of chip and vacuum boxes + top + bottom = 14


### PR DESCRIPTION
`preserved_groups` should have been `retained_physical_groups` in SolidModelTarget. Updated and added to the docstring. `retained_physical_groups` also goes in the rendering options now in case anyone was accessing it that way.