### PR TITLE
Add hash and == for Straight and Turn

### DIFF
--- a/src/paths/segments/bspline.jl
+++ b/src/paths/segments/bspline.jl
@@ -101,27 +101,29 @@ function Base.:(==)(b1::BSpline, b2::BSpline)
            b1.r == b2.r &&
            b1.p0 == b2.p0 &&
            b1.p1 == b2.p1 &&
-           b1.α0 == b2.α0 &&
-           b1.α1 == b2.α1
+           b1.α0 % 360° == b2.α0 % 360° &&
+           b1.α1 % 360° == b2.α1 % 360°
 end
 
 function Base.hash(b::BSpline, h::UInt)
+    um = unit(DeviceLayout.onemicron(b.p0.x))
     h = hash(BSpline, h)
-    h = hash(b.p, h)
-    h = hash(b.t0, h)
-    h = hash(b.t1, h)
+    h = hash(1um, h) # Unitful and unitless turns are not equal
+    h = hash(ustrip(um, b.p), h)
+    h = hash(ustrip(um, b.t0), h) # Workaround Unitful.jl issue #379
+    h = hash(ustrip(um, b.t1), h) # Same segment hash for different units
     # h = hash(b.r, h) # Hashes for AbstractInterpolation are different even when b1.r == b2.r
     # But b.r follows from everything else, including scaling which is captured in p0, p1
     # ... as long as _update_interpolation! has been called
     # So we hash the parts of r that can vary
     h = hash(b.r.ranges, h)
     h = hash(b.r.itp.it, h)
-    h = hash(b.r.itp.coefs, h)
+    h = hash(ustrip(um, b.r.itp.coefs), h)
     h = hash(b.r.itp.parentaxes, h)
-    h = hash(b.p0, h)
-    h = hash(b.p1, h)
-    h = hash(b.α0, h)
-    return hash(b.α1, h)
+    h = hash(ustrip(um, b.p0), h)
+    h = hash(ustrip(um, b.p1), h)
+    h = hash(b.α0 % 360°, h)
+    return hash(b.α1 % 360°, h)
 end
 
 """

--- a/src/paths/segments/straight.jl
+++ b/src/paths/segments/straight.jl
@@ -22,8 +22,21 @@ Straight(l::T, p0::Point{T}, α0::Real) where {T} = Straight{T}(l, p0, α0)
 convert(::Type{Straight{T}}, x::Straight) where {T} =
     Straight{T}(convert(T, x.l), convert(Point{T}, x.p0), x.α0)
 convert(::Type{Segment{T}}, x::Straight) where {T} = convert(Straight{T}, x)
-
 copy(s::Straight{T}) where {T} = Straight{T}(s.l, s.p0, s.α0)
+
+function Base.:(==)(a::Straight, b::Straight)
+    return a.l == b.l && a.p0 == b.p0 && (a.α0 % 360° == b.α0 % 360°)
+end
+
+function Base.hash(a::Straight, h::UInt)
+    um = unit(DeviceLayout.onemicron(a.l))
+    h = hash(Straight, h)
+    h = hash(1um, h) # Unitful and unitless segments are not equal
+    h = hash(ustrip(um, a.l), h)  # Workaround Unitful.jl issue #379
+    h = hash(ustrip(um, a.p0), h) # Same segment hash for different units
+    return hash(a.α0 % 360°, h)
+end
+
 pathlength(s::Straight) = s.l
 p0(s::Straight) = s.p0
 α0(s::Straight) = s.α0

--- a/src/paths/segments/turn.jl
+++ b/src/paths/segments/turn.jl
@@ -32,6 +32,20 @@ convert(::Type{Turn{T}}, x::Turn) where {T} =
 convert(::Type{Segment{T}}, x::Turn) where {T} = convert(Turn{T}, x)
 copy(s::Turn{T}) where {T} = Turn{T}(s.α, s.r, s.p0, s.α0)
 
+function Base.:(==)(a::Turn, b::Turn)
+    return a.α == b.α && a.r == b.r && a.p0 == b.p0 && (a.α0 % 360° == b.α0 % 360°)
+end
+
+function Base.hash(a::Turn, h::UInt)
+    um = unit(DeviceLayout.onemicron(a.r))
+    h = hash(Turn, h)
+    h = hash(1um, h) # Unitful and unitless segments are not equal
+    h = hash(a.α, h)
+    h = hash(ustrip(um, a.r), h)  # Workaround Unitful.jl issue #379
+    h = hash(ustrip(um, a.p0), h) # Same segment hash for different units
+    return hash(a.α0 % 360°, h)
+end
+
 pathlength(s::Turn{T}) where {T} = convert(T, abs(s.r * s.α))
 p0(s::Turn) = s.p0
 α0(s::Turn) = s.α0

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -621,6 +621,25 @@ end
         turn!(pa, "lrrl", 25μm, Paths.Trace(10μm))
         @test Paths.p1(pa) == Point(100μm, 0μm)
         @test Paths.α1(pa) == 0
+
+        # Straight/Turn == and hash
+        pa = Path()
+        straight!(pa, 10μm, Paths.Trace(10μm))
+        straight!(pa, 10μm)
+        turn!(pa, 90°, 10μm)
+        turn!(pa, 90°, 10μm)
+        @test pa[1].seg != pa[2].seg
+        @test hash(pa[1].seg) != hash(pa[2].seg)
+        @test pa[3].seg != pa[4].seg
+        @test hash(pa[3].seg) != hash(pa[4].seg)
+        straight_um = convert(Paths.Straight{typeof(1.0μm)}, pa[1].seg)
+        turn_um = convert(Paths.Turn{typeof(1.0μm)}, pa[3].seg)
+        @test pa[1].seg == straight_um
+        @test hash(pa[1].seg) == hash(straight_um)
+        @test pa[3].seg == turn_um
+        @test hash(pa[3].seg) == hash(turn_um)
+        @test pa[1].seg != Paths.Straight(10.0)
+        @test hash(pa[1].seg) != hash(Paths.Straight(10.0))
     end
 
     @testset "> Path transformations" begin


### PR DESCRIPTION
Also fixes BSpline hash and == so that segments with different units give the same hash despite https://github.com/JuliaPhysics/Unitful.jl/issues/379. Unitful and unitless segments are never equal and never have the same hash. Angles are considered mod 360 degrees.

The remaining segment types should also implement these methods.