### PR TITLE
Add preextrusion_ops and cavity etch regression test

### DIFF
--- a/src/schematics/solidmodels.jl
+++ b/src/schematics/solidmodels.jl
@@ -59,6 +59,7 @@ struct SolidModelTarget <: Target
     ignored_layers::Vector{Symbol}
     retained_physical_groups::Vector{Tuple{String, Int}}
     rendering_options
+    preextrusion_ops
     postrenderer
 end
 
@@ -70,6 +71,7 @@ SolidModelTarget(
     substrate_layers=[],
     wave_port_layers=[],
     ignored_layers=[],
+    preextrusion_ops=[],
     postrender_ops=[],
     retained_physical_groups=[],
     kwargs...
@@ -83,6 +85,7 @@ SolidModelTarget(
     ignored_layers,
     retained_physical_groups,
     (; solidmodel=true, retained_physical_groups=retained_physical_groups, kwargs...),
+    preextrusion_ops,
     postrender_ops
 )
 
@@ -246,8 +249,12 @@ function render!(sm::SolidModel, sch::Schematic, target::Target; strict=:error, 
     # Extrusions
     # Target specific actions
     # Intersections with rendered volume
-    postrender_ops =
-        vcat(extrusion_ops(target, sch), target.postrenderer, intersection_ops(target, sch))
+    postrender_ops = vcat(
+        target.preextrusion_ops,
+        extrusion_ops(target, sch),
+        target.postrenderer,
+        intersection_ops(target, sch)
+    )
     reopen_logfile(sch, :render_solidmodel)
     with_logger(sch.logger) do
         return render!(

--- a/test/test_schematic_solidmodel.jl
+++ b/test/test_schematic_solidmodel.jl
@@ -1189,3 +1189,84 @@ end
         )
     end
 end
+
+@testitem "Schematic + SolidModel + Cavity Etch" setup = [CommonTestSetup] begin
+    using .SchematicDrivenLayout
+
+    # Reproducer for Gmsh booleanOperator preserve-numbering bugs:
+    # Mixed-dimension BooleanFragments with overlapping 2D surfaces extruded
+    # into volumes at different heights, followed by boolean domain decomposition.
+    # Tests that physical groups survive correctly through the pipeline and that
+    # 3D meshing produces a valid mesh.
+    cavity_depth = 20μm
+
+    cs = CoordinateSystem("test")
+    place!(cs, MeshSized(148 * cavity_depth)(centered(Rectangle(1mm, 1mm))), :cavity)
+    place!(cs, centered(Rectangle(2mm, 2mm)), :metal_negative)
+    place!(cs, centered(Rectangle(3mm, 3mm)), :chip_area)
+    place!(cs, centered(Rectangle(3mm, 3mm)), :simulated_area)
+    place!(cs, centered(Rectangle(3mm, 3mm)), :writeable_area)
+
+    tech = ProcessTechnology(
+        (;),
+        (;
+            height=(; simulated_area=-1mm),
+            thickness=(; simulated_area=2mm, chip_area=525μm, cavity=cavity_depth)
+        )
+    )
+
+    g = SchematicGraph("test")
+    add_node!(g, BasicComponent(cs))
+    sch = plan(g)
+    check!(sch)
+
+    target = SolidModelTarget(
+        tech;
+        simulation=true,
+        bounding_layers=[],
+        substrate_layers=[:chip_area, :cavity],
+        indexed_layers=[],
+        wave_port_layers=[],
+        ignored_layers=[],
+        postrender_ops=[
+            (
+                "substrate",
+                SolidModels.difference_geom!,
+                ("chip_area_extrusion", "cavity_extrusion", 3, 3),
+                :remove_object => true,
+                :remove_tool => true
+            ),
+            (
+                "vacuum",
+                SolidModels.difference_geom!,
+                ("simulated_area_extrusion", "substrate", 3, 3)
+            )
+        ],
+        retained_physical_groups=[
+            ("vacuum", 3),
+            ("substrate", 3),
+            ("cavity", 3),
+            ("metal", 2)
+        ]
+    )
+
+    sm = SolidModel("test"; overwrite=true)
+    @testset "Cavity etch render" begin
+        @test_nowarn render!(sm, sch, target)
+    end
+
+    @testset "Physical groups" begin
+        @test SolidModels.hasgroup(sm, "vacuum", 3)
+        @test SolidModels.hasgroup(sm, "substrate", 3)
+        @test length(SolidModels.entitytags(sm["vacuum", 3])) >= 1
+        @test length(SolidModels.entitytags(sm["substrate", 3])) >= 1
+    end
+
+    @testset "3D meshing" begin
+        @test_nowarn SolidModels.gmsh.model.mesh.generate(3)
+        ntets = SolidModels.gmsh.option.get_number("Mesh.NbTetrahedra")
+        @test ntets > 0
+    end
+
+    SolidModels.gmsh.finalize()
+end


### PR DESCRIPTION
## Summary

- Adds `preextrusion_ops` keyword to `SolidModelTarget` for operations that must
  run before layer extrusions (e.g., 2D metal patterning that would otherwise be
  destroyed by OCC's recursive deletion when 3D extrusions are consumed by boolean ops)
- Adds a cavity etch solidmodel test exercising substrate/cavity/vacuum domain
  decomposition with overlapping 2D surfaces extruded to different depths

The postrender pipeline order is now:
`preextrusion_ops → extrusion_ops → postrender_ops → intersection_ops`

## Cavity etch test

The new test creates a geometry with three concentric rectangles (cavity, metal_negative,
chip_area/simulated_area), extrudes them into volumes at different heights, performs boolean
domain decomposition (substrate = chip - cavity, vacuum = sim - substrate), then verifies
physical groups exist and 3D meshing succeeds.

This test currently requires a patched Gmsh 4.15.0 to pass. Stock 4.15.0 produces
PLC mesh errors due to two bugs in `booleanOperator`'s preserve-numbering path:

1. Ascending-dim unbind order leaves stale face bindings when parent volumes block `_unbind`
2. Entity map uses stale integer tags instead of shape identity for unmodified entities

A patch for `GModelIO_OCC.cpp` has been prepared against Gmsh master and will be submitted
upstream. Once a patched `gmsh_jll` is available (via Yggdrasil), this test will pass in CI.

## Test plan

- [x] Full test suite passes with patched Gmsh 4.15.0 (5425 pass, 1 Aqua stale deps)
- [x] Full test suite passes with patched Gmsh 5.0.0 master
- [x] Cavity etch test fails on stock Gmsh 4.15.0 (PLC Error crash) — confirms the test catches the bug
- [x] `preextrusion_ops=[]` default is backward-compatible — no existing behavior changes