### PR TITLE
Minor functional and doc fixes

### DIFF
--- a/src/cells.jl
+++ b/src/cells.jl
@@ -52,7 +52,7 @@ const CellArray = ArrayReference{S, T} where {S, T <: AbstractCell}
 cell(r::CellRef) = r.structure
 
 """
-    mutable struct Cell{S<:Coordinate}
+    mutable struct Cell{S<:Coordinate} <: AbstractCell{S}
 
 A cell has a name and contains polygons and references to `CellArray` or
 `CellReference` objects. It also records the time of its own creation. As

--- a/src/paths/contstyles/strands.jl
+++ b/src/paths/contstyles/strands.jl
@@ -61,7 +61,7 @@ struct SimpleStrands{T <: Coordinate} <: Strands{false}
     num::Int
 end
 copy(x::SimpleStrands) = SimpleStrands(x.offset, x.width, x.spacing, x.num)
-extent(s::SimpleStrands, t...) = s.offset + (s.num) * (s.width + (s.num - 1) * (s.spacing))
+extent(s::SimpleStrands, t...) = s.offset + (s.num) * (s.width) + (s.num - 1) * (s.spacing)
 offset(s::SimpleStrands, t...) = s.offset
 width(s::SimpleStrands, t...) = s.width
 spacing(s::SimpleStrands, t...) = s.spacing
@@ -112,7 +112,7 @@ Strands(offset, width, spacing, num::Int) = GeneralStrands(offset, width, spacin
 
 summary(::GeneralStrands) = "Strands with variable center offset, width, and spacing"
 summary(s::SimpleStrands) = string(
-    num,
+    s.num,
     " strands with center offset ",
     s.offset,
     ", width ",

--- a/src/paths/paths.jl
+++ b/src/paths/paths.jl
@@ -357,7 +357,7 @@ function pathlength_nearest(seg::Paths.Segment{T}, pt::Point) where {T}
 end
 
 """
-    mutable struct Path{T<:Coordinate} <: GeometryStructure{T}
+    mutable struct Path{T<:Coordinate} <: AbstractComponent{T}
 
 Type for abstracting an arbitrary styled path in the plane. Iterating returns
 [`Paths.Node`](@ref) objects.
@@ -1511,7 +1511,7 @@ function halo(sty::Union{TaperTrace, TaperCPW}, outer_delta, inner_delta=nothing
     end
     return _withlength!(
         Paths.TaperCPW(
-            2 * (extent(sty, zero(delta)) + inner_delta),
+            2 * (extent(sty, zero(outer_delta)) + inner_delta),
             outer_delta - inner_delta,
             2 * (extent(sty, sty.length) + inner_delta),
             outer_delta - inner_delta

--- a/src/paths/routes.jl
+++ b/src/paths/routes.jl
@@ -112,16 +112,17 @@ end
 
 """
     CompoundRouteRule <: RouteRule
-    CompoundRouteRule(rules::Vector{RouteRule}, leg_length::Vector{Int}=ones(length(rules)))
+    CompoundRouteRule(rules::Vector{RouteRule}, leg_lengths::Vector{Int}=ones(Int, length(rules)))
 
 Specifies a sequence of rules for routing from one point to another, where `rules[i]` is used
-to route through the next `leg_length[i]` waypoints and/or endpoint.
+to route through the next `leg_lengths[i]` waypoints and/or endpoint.
 """
 struct CompoundRouteRule <: RouteRule
     rules::Vector{RouteRule}
     leg_lengths::Vector{Int}
 end
-CompoundRouteRule(rules::Vector{RouteRule}) = CompoundRouteRule(rules, ones(length(rules)))
+CompoundRouteRule(rules::Vector{RouteRule}) =
+    CompoundRouteRule(rules, ones(Int, length(rules)))
 
 """
     struct Route{T<:RouteRule, S<:Coordinate}
@@ -384,10 +385,9 @@ function reconcile!(
             isapprox_angle(nextdir_target, startdir - 90°)
         )
             # Check if double turn is possible
-            abs(perp) < rule.min_bend_radius ||
-                abs(par) < rule.min_bend_radius &&
-                    @error "Next point can't be reached with a pair of 45° turns" _group =
-                        :route
+            (abs(perp) < rule.min_bend_radius || abs(par) < rule.min_bend_radius) &&
+                @error "Next point can't be reached with a pair of 45° turns" _group =
+                    :route
             bend_r =
                 max(rule.min_bend_radius, min(abs(perp), abs(par), rule.max_bend_radius))
 
@@ -513,7 +513,7 @@ function route!(
     p1::Point,
     α1,
     crr::CompoundRouteRule,
-    sty=fill(Paths.nextstyle(path), length(rules));
+    sty=fill(Paths.nextstyle(path), length(crr.rules));
     waypoints=Point{S}[],
     waydirs=Vector{typeof(1.0°)}(undef, length(waypoints))
 ) where {S}

--- a/src/paths/segments/turn.jl
+++ b/src/paths/segments/turn.jl
@@ -150,4 +150,4 @@ function _split(seg::Turn{T}, x) where {T}
     return s1, s2
 end
 
-direction(s::Turn, t) = s.α0 + s.α * (t / pathlength(s))
+direction(s::Turn, t) = iszero(s.α) ? s.α0 : s.α0 + s.α * (t / pathlength(s))

--- a/src/schematics/routes.jl
+++ b/src/schematics/routes.jl
@@ -8,12 +8,13 @@ Route(rule, hook0::PointHook, hook1::PointHook; kwargs...) =
     Route(rule, hook0.p, hook1.p, out_direction(hook0), hook1.in_direction; kwargs...)
 
 """
-    struct RouteComponent{T} <: AbstractComponent{T}
+    mutable struct RouteComponent{T} <: AbstractComponent{T}
         name::String
         r::Paths.Route{T}
         global_waypoints::Bool
-        sty::Paths.Style
+        sty::Vector{Paths.Style}
         meta::Meta
+        _path::Path{T}
 
 Wraps a `Route` in a `Component` type for use with schematics.
 

--- a/src/schematics/schematics.jl
+++ b/src/schematics/schematics.jl
@@ -326,7 +326,7 @@ function fuse!(
 end
 
 """
-    add_graph!(g0::SchematicGraph, g1::SchematicGraph; id_prefix=name(g1))
+    add_graph!(g0::SchematicGraph, g1::SchematicGraph; id_prefix=name(g1) * ".", kwargs...)
 
 Add the graph `g1` to `g0`, creating new nodes by prefixing IDs with `id_prefix`.
 
@@ -870,10 +870,8 @@ schematic's origin is the keyword argument `schematic_origin_globalcoords` in
 function position_dependent_replace!(
     sch::Schematic{S},
     node_index::Int,
-    replacement::Function,
-    args...;
-    schematic_origin_globalcoords=zero(Point{S}),
-    kwargs...
+    replacement::Function;
+    schematic_origin_globalcoords=zero(Point{S})
 ) where {S}
     node = nodes(sch.graph)[node_index]
     orig = origin(sch, node)
@@ -908,8 +906,8 @@ function position_dependent_replace!(
 end
 
 """
-    plan(g::SchematicGraph, hooks_fn=hooks; strict=:error, log_dir="build", log_level=Logging.Info)
-    plan(g::SchematicGraph, t::Target; strict=:error, log_dir="build", log_level=Logging.Info)
+    plan(g::SchematicGraph, hooks_fn=hooks; strict=:error, log_dir="build", log_level=Logging.Info, id_prefix="")
+    plan(g::SchematicGraph, t::Target; strict=:error, log_dir="build", log_level=Logging.Info, id_prefix="")
 
 Constructs a `Schematic` floorplan from `g` without rendering Components.
 

--- a/src/schematics/solidmodels.jl
+++ b/src/schematics/solidmodels.jl
@@ -5,8 +5,10 @@
         levelwise_layers::Vector{Symbol}
         indexed_layers::Vector{Symbol}
         substrate_layers::Vector{Symbol}
+        wave_port_layers::Vector{Symbol}
         ignored_layers::Vector{Symbol}
-        rendering_options::NamedTuple
+        retained_physical_groups::Vector{Tuple{String, Int}}
+        rendering_options
         postrenderer
     end
 

--- a/test/test_entity.jl
+++ b/test/test_entity.jl
@@ -145,5 +145,11 @@
         @test bounds(cs_halo2) ≈ Rectangle(Point(80μm, 80μm), Point(120μm, 920μm))
         @test bounds(cs_halo3) ≈ Rectangle(Point(80μm, 80μm), Point(120μm, 920μm))
         @test bounds(cs_halo4) ≈ Rectangle(Point(75μm, 85μm), Point(125μm, 915μm))
+
+        # TaperTrace halo
+        pth = Path()
+        straight!(pth, 10μm, Paths.TaperTrace(10μm, 20μm))
+        @test halo(pth[1].sty, 20μm, 10μm) ==
+              Paths.TaperCPW{typeof(1.0μm)}(30μm, 10μm, 40μm, 10μm, 10μm)
     end
 end

--- a/test/test_render.jl
+++ b/test/test_render.jl
@@ -498,6 +498,9 @@ end
             pts = (elements(c)[i]).p
             @test pts[1].y < pts[end].y
         end
+        # verify extent
+        @test height(bounds(c)) ≈ 2 * Paths.extent(pa[1].sty)
+        @test contains(summary(pa[1].sty), "2 strands")
     end
 
     @testset "Turn, Strands" begin

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -640,6 +640,11 @@ end
         @test hash(pa[3].seg) == hash(turn_um)
         @test pa[1].seg != Paths.Straight(10.0)
         @test hash(pa[1].seg) != hash(Paths.Straight(10.0))
+
+        # Zero-length turn
+        pa = Path(α0=90°)
+        turn!(pa, 0°, 10μm, Paths.Trace(10μm))
+        @test Paths.direction(pa[1].seg, 0μm) == 90°
     end
 
     @testset "> Path transformations" begin


### PR DESCRIPTION
- `extent(s::SimpleStrands, t...)` is now correct for more than 1 strand
- `summary(::SimpleStrands)` now runs without error
- Halo of taper with inner delta now runs without error
- Fix to 45 degree routing double turn check
- Fix CompoundRouteRule default argument