### PR TITLE
Allow dependent compdef defaults

### DIFF
--- a/docs/src/concepts/components.md
+++ b/docs/src/concepts/components.md
@@ -51,7 +51,9 @@ There are a few details worth pointing out above:
 - We defined `SchematicDrivenLayout._geometry!` rather than just `_geometry!`, and likewise for `hooks`. In Julia, when we extend an existing function with a new method for our custom type, we need to specify the module it comes from. If we just define `function _geometry!(...)`, then DeviceLayout won't know to call that method internally. Making this mistake will result in an empty geometry and no hooks, since SchematicDrivenLayout will fall back on generic implementations of those methods.
 - `hooks` returns a `NamedTuple` with a single element using a leading semicolon. If we wrote `(p0 = PointHook(...))`, then this would be interepreted as a variable assignment. Our [style guide](./styleguide.md) recommends defining literal `NamedTuple`s with a leading semicolon.
 
-`@compdef` creates the keyword constructor with defaults, like [`Base.@kwdef`](https://docs.julialang.org/en/v1/base/base/#Base.@kwdef) does, as well as a `default_parameters` method. It also creates a private field for geometry, which is computed the first time `geometry` is called and stored thereafter. Parameter defaults should not depend on the values of other parameters. Validation or reconciling of parameters should be done in an inner constructor. At least one
+`@compdef` creates the keyword constructor with defaults, like [`Base.@kwdef`](https://docs.julialang.org/en/v1/base/base/#Base.@kwdef) does, as well as a `default_parameters` method. It also creates a private field for geometry, which is computed the first time `geometry` is called and stored thereafter. Parameter defaults may reference earlier parameters with defaults (evaluated in
+declaration order). Use this only for simple derived defaults that may be overridden.
+To enforce invariants, use an inner constructor. At least one
 inner constructor should accept arguments in the
 same form as the default inner constructor (i.e. one positional argument per field) in
 order to function correctly with the keyword outer constructor. 

--- a/src/schematics/components/compdef.jl
+++ b/src/schematics/components/compdef.jl
@@ -76,11 +76,7 @@ macro compdef(expr)
                     esc(:(SchematicDrivenLayout.default_parameters)),
                     :(::Type{$(esc(T))})
                 ),
-                Expr(
-                    :block,
-                    __source__,
-                    _defaults_let_expr(public_defaults)
-                )
+                Expr(:block, __source__, _defaults_let_expr(public_defaults))
             )
         elseif Base.Meta.isexpr(T, :curly)
             # if T == S{A<:AA,B<:BB}, define one method
@@ -96,11 +92,7 @@ macro compdef(expr)
             kwdefs = def2
 
             # Define default_parameters method to return NamedTuple of keywords with defaults
-            defbody = Expr(
-                :block,
-                __source__,
-                _defaults_let_expr(public_defaults)
-            )
+            defbody = Expr(:block, __source__, _defaults_let_expr(public_defaults))
             defsig = :(
                 $(esc(:SchematicDrivenLayout)).default_parameters(
                     ::Type{$(esc(SQ))}

--- a/src/schematics/components/compdef.jl
+++ b/src/schematics/components/compdef.jl
@@ -79,7 +79,7 @@ macro compdef(expr)
                 Expr(
                     :block,
                     __source__,
-                    :((; $(filter(arg -> Base.Meta.isexpr(arg, :kw), public_defaults)...)))
+                    _defaults_let_expr(public_defaults)
                 )
             )
         elseif Base.Meta.isexpr(T, :curly)
@@ -99,7 +99,7 @@ macro compdef(expr)
             defbody = Expr(
                 :block,
                 __source__,
-                :((; $(filter(arg -> Base.Meta.isexpr(arg, :kw), public_defaults)...)))
+                _defaults_let_expr(public_defaults)
             )
             defsig = :(
                 $(esc(:SchematicDrivenLayout)).default_parameters(
@@ -118,6 +118,37 @@ macro compdef(expr)
         $kwdefs
         $defaults
     end
+end
+
+"""
+    _defaults_let_expr(public_defaults)
+
+Build a `let` expression that evaluates default values left-to-right, so that later
+defaults can reference earlier parameter names, then returns a NamedTuple.
+
+Input: the `public_defaults` array from `params_args`, containing a mix of bare symbols
+(required params, no default) and `Expr(:kw, var, defexpr)`.
+
+Only `:kw` entries (those with defaults) are included in the result. The `defexpr` values
+are already `esc`'d (from `_kwdef!`), so `let`-bound names are also `esc`'d to ensure
+references like `a` inside `esc(:(2*a))` resolve to the `let`-bound `a`.
+"""
+function _defaults_let_expr(public_defaults)
+    kw_args = filter(arg -> Base.Meta.isexpr(arg, :kw), public_defaults)
+    isempty(kw_args) && return :((;))
+
+    vars = [arg.args[1] for arg in kw_args]          # plain symbols, e.g. [:name, :a, :b]
+    defexprs = [arg.args[2] for arg in kw_args]       # already esc'd expressions
+
+    # Build:  let name = "foo", a = 10, b = 2*a
+    #             (; name, a, b)
+    #         end
+    # The esc() on variable names places them in the caller's module scope, matching
+    # the esc'd references within defexprs.
+    let_bindings = [Expr(:(=), esc(v), d) for (v, d) in zip(vars, defexprs)]
+    nt_expr = Expr(:tuple, Expr(:parameters, esc.(vars)...))
+
+    return Expr(:let, Expr(:block, let_bindings...), nt_expr)
 end
 
 # @kwdef helper function

--- a/src/schematics/components/compdef.jl
+++ b/src/schematics/components/compdef.jl
@@ -13,6 +13,10 @@ This generates a `default_parameters` method for the defined type, which returns
 default parameters as a `NamedTuple`. If any parameters are required (have no default),
 they do not appear in `default_parameters`.
 
+Parameter defaults may reference earlier parameters with defaults (evaluated in
+declaration order). Use this only for simple derived defaults that may be overridden.
+To enforce invariants, use an inner constructor.
+
 The new type will also have a `_geometry` field for caching geometry, or `_graph`,
 `_schematic`, and `_hooks` fields for composite components. If there is no `name`
 field, one will automatically be created with a default name of the type name

--- a/test/test_schematicdriven.jl
+++ b/test/test_schematicdriven.jl
@@ -1195,4 +1195,35 @@
             )
         )
     end
+
+    @testset "Issue #20: dependent @compdef defaults" begin
+        # Non-parametric path: defaults that reference earlier parameters
+        @compdef struct DepDefaultsComp <: Component
+            a::Int = 10
+            b::Int = 2 * a
+            c::Int = a + b
+        end
+
+        # default_parameters should evaluate without error and propagate values
+        dp = default_parameters(DepDefaultsComp)
+        @test dp.a == 10
+        @test dp.b == 20       # 2 * 10
+        @test dp.c == 30       # 10 + 20
+
+        # Constructor should still work (it always did via kwarg scoping)
+        comp = DepDefaultsComp()
+        @test comp.a == 10
+        @test comp.b == 20
+        @test comp.c == 30
+
+        # Parametric path: defaults that reference earlier parameters
+        @compdef struct DepDefaultsParam{T} <: AbstractComponent{T}
+            x::Int = 3
+            y::Int = x^2
+        end
+
+        dp2 = default_parameters(DepDefaultsParam{typeof(1.0nm)})
+        @test dp2.x == 3
+        @test dp2.y == 9       # 3^2
+    end
 end

--- a/test/test_schematicdriven.jl
+++ b/test/test_schematicdriven.jl
@@ -1196,7 +1196,8 @@
         )
     end
 
-    @testset "Issue #20: dependent @compdef defaults" begin
+    @testset "Dependent @compdef defaults" begin
+        # Issue #20
         # Non-parametric path: defaults that reference earlier parameters
         @compdef struct DepDefaultsComp <: Component
             a::Int = 10


### PR DESCRIPTION
Close #20. The main question for me is whether we actually want to allow this, if we should explicitly forbid it, if we should advise against it in the style guide, or not take a stance. Note that the existing behavior is problematic because the constructor still works, but `default_parameters` will error, so this fix is necessary even if we want to discourage it.

Inclined to allow, but add

> Parameter defaults may reference earlier parameters (evaluated by declaration order). Use this for simple derived values (e.g., `gap = trace_width / 2`). For complex
   derived quantities, prefer inner constructors — they are more explicit about evaluation order and visible to code review.

to the style guide and/or docstring.