### PR TITLE
Add reverse methods for offset segments

### DIFF
--- a/src/paths/channels.jl
+++ b/src/paths/channels.jl
@@ -129,6 +129,16 @@ reverse(s::GeneralCPW, l) = GeneralCPW(t -> trace(s, l - t), t -> gap(s, l - t))
 # For compound segments, reverse the individual sections and reverse their order
 # Keep the same tag so if a compound segment/style pair matched before they will still match
 reverse(s::CompoundSegment) = CompoundSegment(reverse(reverse.(s.segments)), s.tag)
+# Offset segments: reverse the underlying segment and negate the offset.
+# Reversal flips tangent direction → flips normal → offset sign must flip.
+# (Same reason change_handedness! negates offset in offset.jl.)
+function reverse(s::ConstantOffset{T, S}) where {T, S}
+    return ConstantOffset{T, S}(reverse(s.seg), -s.offset)
+end
+function reverse(s::GeneralOffset{T, S}) where {T, S}
+    l = pathlength(s.seg)
+    return GeneralOffset{T, S}(reverse(s.seg), t -> -s.offset(l - t))
+end
 function reverse(s::CompoundStyle{T}, l) where {T}
     lengths = diff(s.grid)
     return CompoundStyle{T}(

--- a/test/test_channels.jl
+++ b/test/test_channels.jl
@@ -219,6 +219,56 @@
     @test p1(resolved.segments[1]) == Point(2, 4)
     @test p1(resolved.segments[2]) == Point(3, 9)
 
+    ## reverse(::OffsetSegment) tests
+    @testset "reverse ConstantOffset" begin
+        seg = Paths.Straight(10.0μm)
+        offset_seg = Paths.offset(seg, 2.0μm)
+        rev = reverse(offset_seg)
+        # Type preserved
+        @test typeof(rev) === typeof(offset_seg)
+        # Pathlength preserved
+        @test pathlength(rev) ≈ pathlength(offset_seg)
+        # Offset negated
+        @test Paths.getoffset(rev) ≈ -2.0μm
+        # Endpoints swapped: p0 of reversed ≈ p1 of original
+        @test p0(rev) ≈ p1(offset_seg) atol = 0.01nm
+        @test p1(rev) ≈ p0(offset_seg) atol = 0.01nm
+        # Round-trip: reverse(reverse(seg)) ≈ original
+        roundtrip = reverse(rev)
+        @test p0(roundtrip) ≈ p0(offset_seg) atol = 0.01nm
+        @test p1(roundtrip) ≈ p1(offset_seg) atol = 0.01nm
+        @test Paths.getoffset(roundtrip) ≈ 2.0μm
+    end
+
+    @testset "reverse ConstantOffset Turn" begin
+        seg = Paths.Turn(90°, 50.0μm)
+        offset_seg = Paths.offset(seg, 5.0μm)
+        rev = reverse(offset_seg)
+        @test typeof(rev) === typeof(offset_seg)
+        @test pathlength(rev) ≈ pathlength(offset_seg)
+        @test Paths.getoffset(rev) ≈ -5.0μm
+        @test p0(rev) ≈ p1(offset_seg) atol = 0.01nm
+        @test p1(rev) ≈ p0(offset_seg) atol = 0.01nm
+    end
+
+    @testset "reverse GeneralOffset" begin
+        seg = Paths.Turn(90°, 50.0μm)
+        l = pathlength(seg)
+        offset_fn = t -> t / 10  # linear offset: 0 at start, 1μm at end
+        offset_seg = Paths.offset(seg, offset_fn)
+        rev = reverse(offset_seg)
+        # Type preserved
+        @test typeof(rev) === typeof(offset_seg)
+        # Pathlength preserved
+        @test pathlength(rev) ≈ pathlength(offset_seg)
+        # Offset function is remapped: at t=0 of reversed, should get negated original end value
+        @test Paths.getoffset(rev, 0.0μm) ≈ -Paths.getoffset(offset_seg, l) atol = 0.001nm
+        @test Paths.getoffset(rev, l) ≈ -Paths.getoffset(offset_seg, 0.0μm) atol = 0.001nm
+        # Endpoints swapped
+        @test p0(rev) ≈ p1(offset_seg) atol = 0.1nm
+        @test p1(rev) ≈ p0(offset_seg) atol = 0.1nm
+    end
+
     ## Schematic-level routing
     test_schematic_single_channel()
 end

--- a/test/test_channels.jl
+++ b/test/test_channels.jl
@@ -227,6 +227,7 @@
         # Type preserved
         @test typeof(rev) === typeof(offset_seg)
         # Pathlength preserved
+        @test Paths.arclength(rev) ≈ Paths.arclength(offset_seg)
         @test pathlength(rev) ≈ pathlength(offset_seg)
         # Offset negated
         @test Paths.getoffset(rev) ≈ -2.0μm
@@ -245,10 +246,23 @@
         offset_seg = Paths.offset(seg, 5.0μm)
         rev = reverse(offset_seg)
         @test typeof(rev) === typeof(offset_seg)
-        @test pathlength(rev) ≈ pathlength(offset_seg)
+        @test Paths.arclength(rev) ≈ Paths.arclength(offset_seg)
+        @test pathlength(rev) == pathlength(offset_seg)
         @test Paths.getoffset(rev) ≈ -5.0μm
         @test p0(rev) ≈ p1(offset_seg) atol = 0.01nm
         @test p1(rev) ≈ p0(offset_seg) atol = 0.01nm
+    end
+
+    @testset "reverse ConstantOffset BSpline" begin
+        pa = Path(0.0μm, 0.0μm)
+        bspline!(pa, [Point(0.5, 0.5)mm, Point(1.0mm, 0.0mm)], -90°, Paths.Trace(0.1mm))
+        seg = pa[1].seg
+        offset_seg = Paths.offset(seg, 300.0μm)
+        rev = reverse(offset_seg)
+        @test Paths.arclength(rev) ≈ Paths.arclength(offset_seg)
+        @test Paths.pathlength(rev) ≈ Paths.pathlength(offset_seg)
+        @test p0(rev) ≈ p1(offset_seg) atol = 0.1nm
+        @test p1(rev) ≈ p0(offset_seg) atol = 0.1nm
     end
 
     @testset "reverse GeneralOffset" begin
@@ -260,7 +274,8 @@
         # Type preserved
         @test typeof(rev) === typeof(offset_seg)
         # Pathlength preserved
-        @test pathlength(rev) ≈ pathlength(offset_seg)
+        @test Paths.arclength(rev) ≈ Paths.arclength(offset_seg)
+        @test pathlength(rev) == pathlength(offset_seg)
         # Offset function is remapped: at t=0 of reversed, should get negated original end value
         @test Paths.getoffset(rev, 0.0μm) ≈ -Paths.getoffset(offset_seg, l) atol = 0.001nm
         @test Paths.getoffset(rev, l) ≈ -Paths.getoffset(offset_seg, 0.0μm) atol = 0.001nm


### PR DESCRIPTION
This is a prerequisite to normalizing CurvilinearPolygons in their inner constructor to only use forward-parameterized curves (no more negative `curve_start_idx` and associated pitfalls), since offset curves are used in the SolidModel rendering pathway for `Path.Node` with both forward and reverse parameterizations.

These were the only continuous segments still missing a `reverse` method.