### PR TITLE
Fix nested rounding+style to polygons

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ DeviceLayout.jl is a [Julia](http://julialang.org) package for computer-aided de
 
 ## Why DeviceLayout.jl?
 
-We develop DeviceLayout.jl to accelerate design cycles as we scale to larger quantum processors and larger teams. Key features include:
+We develop DeviceLayout.jl to accelerate design cycles as projects scale to larger quantum processors and larger teams. Key features include:
 
 - **Rich geometry types** with first-class support for paths
 - **Schematic-driven layout**: Manage complexity by separating component geometry and device connectivity

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,7 +15,7 @@ DeviceLayout.jl is a [Julia](http://julialang.org) package for computer-aided de
 
 ## Why DeviceLayout.jl?
 
-We develop DeviceLayout.jl to accelerate design cycles as we scale to larger quantum processors and larger teams. Key features include:
+We develop DeviceLayout.jl to accelerate design cycles as projects scale to larger quantum processors and larger teams. Key features include:
 
 - **Rich geometry types** with first-class support for paths
 - **Schematic-driven layout**: Manage complexity by separating component geometry and device connectivity

--- a/src/curvilinear.jl
+++ b/src/curvilinear.jl
@@ -182,10 +182,12 @@ CurvilinearRegion(points::Vector{Point{T}}, curves, curve_start_idx) where {T} =
     CurvilinearRegion(CurvilinearPolygon(points, curves, curve_start_idx))
 
 to_polygons(e::CurvilinearRegion{T}; kwargs...) where {T} =
-    difference2d(to_polygons(e.exterior), to_polygons.(e.holes))
-to_polygons(e::CurvilinearRegion, sty::Polygons.Rounded; kwargs...) = difference2d(
-    to_polygons(e.exterior, sty; kwargs...),
-    [to_polygons(h, sty; kwargs...) for h in e.holes]
+    to_polygons(difference2d(to_polygons(e.exterior), to_polygons.(e.holes)))
+to_polygons(e::CurvilinearRegion, sty::Polygons.Rounded; kwargs...) = to_polygons(
+    difference2d(
+        to_polygons(e.exterior, sty; kwargs...),
+        [to_polygons(h, sty; kwargs...) for h in e.holes]
+    )
 )
 
 function transform(e::CurvilinearRegion{T}, f::Transformation) where {T}

--- a/src/solidmodels/render.jl
+++ b/src/solidmodels/render.jl
@@ -74,25 +74,25 @@ function to_primitives(
     ent::StyledEntity{T, ClippedPolygon{T}, <:StyleDict};
     kwargs...
 ) where {T}
+    return to_curvilinear_regions(ent.ent, ent.sty; kwargs...)
+end
+
+function to_curvilinear_regions(ent::ClippedPolygon{T}, sty::StyleDict; kwargs...) where {T}
     # Flatten the tree into a collection of CurvilinearRegion with style applied to subpolygons.
     flat = CurvilinearRegion{T}[]
     function add_region(node)
         push!(
             flat,
             CurvilinearRegion{T}(
-                styled_loop(node, ent.sty[node]; kwargs...),
-                styled_loop.(
-                    node.children,
-                    getindex.(Ref(ent.sty), node.children);
-                    kwargs...
-                )
+                styled_loop(node, sty[node]; kwargs...),
+                styled_loop.(node.children, getindex.(Ref(sty), node.children); kwargs...)
             )
         )
         for n ∈ node.children
             add_region.(n.children) # Add all grand children -- positives
         end
     end
-    add_region.(ent.ent.tree.children)
+    add_region.(ent.tree.children)
     return flat
 end
 
@@ -600,10 +600,37 @@ styled_loop(::CurvilinearPolygon{T}, ::NoRender; kwargs...) where {T} =
 function to_polygons(
     ent::StyledEntity{T, U, V},
     sty::Rounded{S};
-    atol=DeviceLayout.Polygons._round_atol(S, T),
     kwargs...
-) where {S, T, U, V <: Rounded}
-    return to_polygons(styled_loop(ent.ent, ent.sty), sty; atol, kwargs...)
+) where {S, T, U, V}
+    inner_roundable = to_roundable(ent.ent, ent.sty; kwargs...)
+    if inner_roundable isa Vector
+        return vcat(to_polygons.(inner_roundable, Ref(sty); kwargs...)...)
+    end
+    return to_polygons(sty(inner_roundable); kwargs...)
+end
+
+# To AbstractPolygon, CurvilinearPolygon, CurvilinearRegion, or vector of those
+to_roundable(ent::GeometryEntity, sty; kwargs...) = to_polygons(ent, sty; kwargs...)
+function to_roundable(ent::StyledEntity, sty; kwargs...)
+    return to_roundable(to_roundable(ent.ent, ent.sty), sty; kwargs...)
+end
+to_roundable(ents::AbstractVector, sty; kwargs...) =
+    vcat(to_roundable.(ents, Ref(sty); kwargs...)...)
+to_roundable(ent::AbstractPolygon, sty; kwargs...) =
+    styled_loop(convert(Polygon, ent), sty; kwargs...)
+to_roundable(ent::CurvilinearPolygon, sty; kwargs...) = styled_loop(ent, sty; kwargs...)
+to_roundable(ent::ClippedPolygon, sty; kwargs...) =
+    to_roundable(ent, StyleDict(sty); kwargs...)
+to_roundable(ent::CurvilinearRegion, sty; kwargs...) =
+    to_roundable(ent, StyleDict(sty); kwargs...)
+function to_roundable(ent::ClippedPolygon, sty::StyleDict; kwargs...)
+    return to_curvilinear_regions(ent, sty; kwargs...)
+end
+function to_roundable(ent::CurvilinearRegion{T}, sty::StyleDict; kwargs...) where {T}
+    return CurvilinearRegion{T}(
+        styled_loop(ent.exterior, sty[1]; kwargs...),
+        styled_loop.(ent.holes, getindex.(sty, 1, 1:length(ent.holes)); kwargs...)
+    )
 end
 
 ######## Ellipse

--- a/test/test_line_arc_rounding.jl
+++ b/test/test_line_arc_rounding.jl
@@ -259,20 +259,9 @@
     @test_nowarn place!(cs_region, region, GDSMeta())
     @test_nowarn render!(Cell("region_no_round", nm), cs_region)
 
-    # Apply rounding to region (returns a ClippedPolygon)
-    rounded_region = to_polygons(region, Rounded(fillet_r))
-    region_polys = to_polygons(rounded_region)
+    # Apply rounding to region
+    region_polys = to_polygons(region, Rounded(fillet_r))
     @test length(region_polys) > 0
-
-    # Renders after rounding
-    @test_nowarn render!(
-        Cell("region_rounded", nm),
-        let
-            cs = CoordinateSystem("rr", nm)
-            place!(cs, rounded_region, GDSMeta())
-            cs
-        end
-    )
 
     # SolidModel segment version: rounded_corner_segment_line_arc
     # Verify that the Turn-returning variant produces tangent points and

--- a/test/test_render.jl
+++ b/test/test_render.jl
@@ -1072,3 +1072,19 @@ end
         @test all(m -> m == GDSMeta(7, 1), c.element_metadata)
     end
 end
+
+@testitem "Rounding on StyledEntity" setup = [CommonTestSetup] begin
+    # Line-arc rounding should still happen
+    rnd1 = Rounded(1mm, p0=[Point(0, 0)mm, Point(5, 0)mm], selection_tolerance=1nm)
+    rnd2 = Rounded(0.1mm)
+    rect = Rectangle(1.0mm, 1.0mm)
+    poly = to_polygons(rect) + Point(5mm, 0mm)
+    clipped_poly = union2d(rect, poly) # multiple disjoint shapes
+    res_rect = to_polygons(rnd2(rnd1(DeviceLayout.Plain(rect))))
+    res_poly = to_polygons(rnd2(rnd1(DeviceLayout.Plain(poly))))
+    res_clipped_poly = to_polygons(rnd2(rnd1(DeviceLayout.Plain(clipped_poly))))
+    @test minimum(getx.(points(res_rect))) > 0mm # Bottom line-arc corner was rounded
+    @test minimum(getx.(points(res_poly))) > 0mm # Bottom line-arc corner was rounded
+    @test res_poly ≈ res_rect + Point(5mm, 0mm)
+    @test isempty(to_polygons(xor2d(res_clipped_poly, [res_rect, res_poly])))
+end


### PR DESCRIPTION
#166 introduced an error when turning a rounded StyledEntity to polygons (`no method matching points(::DeviceLayout.StyledEntity{Unitful.Quantity{…}...`). This adds the necessary methods for dispatch to work correctly with styled entities.

It also fixes a bug where `to_polygons(::CurvilinearRegion)` returned a `ClippedPolygon` instead of `Polygon`s.