### PR TITLE
Add method to find connected components of SolidModels entities

### DIFF
--- a/docs/src/reference/api.md
+++ b/docs/src/reference/api.md
@@ -292,6 +292,7 @@ See [Shapes](./shapes.md).
 
 ```@docs
     SolidModels.box_selection
+    SolidModels.connected_components
     SolidModels.difference_geom!
     SolidModels.extrude_z!
     SolidModels.fragment_geom!

--- a/src/solidmodels/postrender.jl
+++ b/src/solidmodels/postrender.jl
@@ -1008,6 +1008,95 @@ function remove_group!(group::PhysicalGroup; recursive=true, remove_entities=tru
 end
 
 """
+    connected_components(dim::Int, tags::Vector{Int32})
+    connected_components(sm::SolidModel, group::Union{String, Symbol}, dim=2)
+    connected_components(sm::SolidModel, groups, dim=2)
+
+Find connected components among SolidModel entities at dimension `dim` with the given `tags` or physical group names.
+
+Two entities are connected if they share any boundary entity (dimension `dim - 1`).
+Uses union-find with path compression on the adjacency graph from `gmsh.model.getAdjacencies`.
+
+Returns a `Vector{Vector{Tuple{Int32, Int32}}}` where each inner vector contains the entity dimtags
+of one connected component.
+
+# Algorithm
+
+ 1. Query downward adjacencies (boundary entities) for each tag via getAdjacencies
+ 2. Build a mapping from boundary tags to parent entity indices
+ 3. Use union-find to merge entities sharing boundaries
+ 4. Collect and return connected component groups
+
+# Notes
+
+  - Requires Gmsh model to be synchronized before calling
+  - Works for any dimension ≥ 1 (uses dim - 1 boundary adjacencies)
+  - For dim=3 (volumes): shares boundary surfaces (dim=2)
+  - For dim=2 (surfaces): shares boundary curves (dim=1)
+  - O(N) where N = number of entities + number of boundary connections
+"""
+function connected_components(sm::SolidModel, groups, dim=2)
+    tags = reduce(vcat, [entitytags(sm[name, dim]) for name in groups], init=Int32[])
+    return connected_components(dim, tags)
+end
+connected_components(sm::SolidModel, group::Union{String, Symbol}, dim=2) =
+    connected_components(dim, entitytags(sm[group, dim]))
+
+function connected_components(dim::Int, tags::Vector{Int32})
+    n = length(tags)
+    isempty(tags) && return Vector{Int32}[]
+    n == 1 && return [tags]
+
+    # Build adjacency: map boundary entities to parent entity indices
+    boundary_to_parents = Dict{Int32, Vector{Int}}()
+    for (i, tag) in enumerate(tags)
+        _, downward = gmsh.model.getAdjacencies(dim, tag)
+        for btag in downward
+            if haskey(boundary_to_parents, btag)
+                push!(boundary_to_parents[btag], i)
+            else
+                boundary_to_parents[btag] = [i]
+            end
+        end
+    end
+
+    # Union-Find with path compression
+    parent = collect(1:n)
+    function find(x)
+        while parent[x] != x
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        end
+        return x
+    end
+    function unite(a, b)
+        ra = find(a)
+        rb = find(b)
+        return ra != rb && (parent[ra] = rb)
+    end
+
+    # Merge entities that share boundary elements
+    for (_, parents) in boundary_to_parents
+        for j = 2:length(parents)
+            unite(parents[1], parents[j])
+        end
+    end
+
+    # Collect components
+    components = Dict{Int, Vector{Tuple{Int32, Int32}}}()
+    for (i, tag) in enumerate(tags)
+        root = find(i)
+        if haskey(components, root)
+            push!(components[root], (dim, tag))
+        else
+            components[root] = [(dim, tag)]
+        end
+    end
+
+    return collect(values(components))
+end
+
+"""
     check_overlap(sm::SolidModel)
 
 Check for overlap/intersections between SolidModel groups of the same dimension.

--- a/src/solidmodels/postrender.jl
+++ b/src/solidmodels/postrender.jl
@@ -1033,19 +1033,19 @@ of one connected component.
   - Works for any dimension ≥ 1 (uses dim - 1 boundary adjacencies)
   - For dim=3 (volumes): shares boundary surfaces (dim=2)
   - For dim=2 (surfaces): shares boundary curves (dim=1)
-  - O(N) where N = number of entities + number of boundary connections
 """
 function connected_components(sm::SolidModel, groups, dim=2)
     tags = reduce(vcat, [entitytags(sm[name, dim]) for name in groups], init=Int32[])
+    unique!(tags)
     return connected_components(dim, tags)
 end
 connected_components(sm::SolidModel, group::Union{String, Symbol}, dim=2) =
     connected_components(dim, entitytags(sm[group, dim]))
 
-function connected_components(dim::Int, tags::Vector{Int32})
+function connected_components(dim::Integer, tags::Vector{Int32})
     n = length(tags)
-    isempty(tags) && return Vector{Int32}[]
-    n == 1 && return [tags]
+    isempty(tags) && return Vector{Tuple{Int32, Int32}}[]
+    n == 1 && return [(Int32(dim), only(tags))]
 
     # Build adjacency: map boundary entities to parent entity indices
     boundary_to_parents = Dict{Int32, Vector{Int}}()

--- a/test/test_connected_components.jl
+++ b/test/test_connected_components.jl
@@ -129,7 +129,6 @@
         # If you skip the connecting rectangle you get 3 groups
         disconnected = unique(vcat(dtmap[1], dtmap[3], dtmap[4], dtmap[5]))
         result2 = connected_components(2, last.(disconnected))
-        @show result2
         @test length(result2) == 3
         sizes = sort([length(c) for c in result2])
         @test sizes == [1, 1, 2]

--- a/test/test_connected_components.jl
+++ b/test/test_connected_components.jl
@@ -1,0 +1,130 @@
+@testitem "Connected components" setup = [CommonTestSetup] begin
+    import DeviceLayout.SolidModels
+    import DeviceLayout.SolidModels: connected_components
+
+    gmsh = SolidModels.gmsh
+
+    # Helper: initialize a fresh Gmsh model for each testset
+    function fresh_model(name="test")
+        sm = SolidModel(name; overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
+        return sm
+    end
+
+    @testset "empty input" begin
+        fresh_model("empty")
+        result = connected_components(3, Int32[])
+        @test result == Vector{Int32}[]
+    end
+
+    @testset "single entity" begin
+        fresh_model("single")
+        gmsh.model.occ.addBox(0, 0, 0, 1, 1, 1)
+        gmsh.model.occ.synchronize()
+        tags = Int32[1]
+        result = connected_components(3, tags)
+        @test length(result) == 1
+        @test result[1] == Int32[1]
+    end
+
+    @testset "two disconnected volumes" begin
+        fresh_model("disconnected")
+        gmsh.model.occ.addBox(0, 0, 0, 1, 1, 1)     # tag 1
+        gmsh.model.occ.addBox(10, 10, 10, 1, 1, 1)   # tag 2, far apart
+        gmsh.model.occ.synchronize()
+        vols = [dt[2] for dt in gmsh.model.getEntities(3)]
+        result = connected_components(3, vols)
+        @test length(result) == 2
+        # Each component should have exactly one volume
+        sizes = sort([length(c) for c in result])
+        @test sizes == [1, 1]
+    end
+
+    @testset "shared-boundary volumes via fragment" begin
+        fresh_model("shared")
+        # Two overlapping boxes — fragment will create shared boundary surfaces
+        gmsh.model.occ.addBox(0, 0, 0, 2, 1, 1)
+        gmsh.model.occ.addBox(1, 0, 0, 2, 1, 1)
+        gmsh.model.occ.fragment([(3, 1)], [(3, 2)])
+        gmsh.model.occ.synchronize()
+        vols = [dt[2] for dt in gmsh.model.getEntities(3)]
+        @test length(vols) == 3  # fragment produces 3 volumes
+        result = connected_components(3, vols)
+        # All volumes share boundaries, so should be one connected component
+        @test length(result) == 1
+        @test sort(last.(result[1])) == sort(vols)
+    end
+
+    @testset "chain connectivity A-B-C" begin
+        fresh_model("chain")
+        # Three boxes in a chain: A overlaps B, B overlaps C, but A does not overlap C
+        gmsh.model.occ.addBox(0, 0, 0, 2, 1, 1)    # A
+        gmsh.model.occ.addBox(1, 0, 0, 3, 1, 1)    # B overlaps A
+        gmsh.model.occ.addBox(3, 0, 0, 2, 1, 1)    # C overlaps B but not A
+        # Fragment all three to create shared boundaries
+        gmsh.model.occ.fragment([(3, 1), (3, 2), (3, 3)], [])
+        gmsh.model.occ.synchronize()
+        vols = [dt[2] for dt in gmsh.model.getEntities(3)]
+        @test length(vols) == 5  # fragment produces multiple volumes
+        result = connected_components(3, vols)
+        # All volumes are transitively connected: A-B-C chain
+        @test length(result) == 1
+        @test sort(last.(result[1])) == sort(vols)
+    end
+
+    @testset "mixed: one connected group and one isolated" begin
+        fresh_model("mixed")
+        # Two overlapping boxes (will be connected after fragment)
+        gmsh.model.occ.addBox(0, 0, 0, 2, 1, 1)
+        gmsh.model.occ.addBox(1, 0, 0, 2, 1, 1)
+        # One isolated box far away
+        gmsh.model.occ.addBox(100, 100, 100, 1, 1, 1)
+        # Fragment the overlapping pair (include isolated box too)
+        gmsh.model.occ.fragment([(3, 1), (3, 2), (3, 3)], [])
+        gmsh.model.occ.synchronize()
+        vols = [dt[2] for dt in gmsh.model.getEntities(3)]
+        result = connected_components(3, vols)
+        # Should have exactly 2 components: the connected pair and the isolated box
+        @test length(result) == 2
+        sizes = sort([length(c) for c in result])
+        @test sizes[1] == 1  # isolated box
+        @test sizes[2] == 3  # connected volumes from the overlap
+    end
+
+    @testset "2D surface connectivity" begin
+        fresh_model("surfaces")
+        # Two overlapping rectangles in 2D (surfaces)
+        gmsh.model.occ.addRectangle(0, 0, 0, 2, 1)
+        gmsh.model.occ.addRectangle(1, 0, 0, 2, 1)
+        # One isolated rectangle
+        gmsh.model.occ.addRectangle(100, 100, 0, 1, 1)
+        gmsh.model.occ.fragment([(2, 1), (2, 2), (2, 3)], [])
+        gmsh.model.occ.synchronize()
+        surfs = [dt[2] for dt in gmsh.model.getEntities(2)]
+        result = connected_components(2, surfs)
+        # Should have 2 components: the connected pair and the isolated rectangle
+        @test length(result) == 2
+        sizes = sort([length(c) for c in result])
+        @test sizes[1] == 1  # isolated rectangle
+        @test sizes[2] == 3  # connected surfaces from the overlap
+
+        fresh_model("surfaces2")
+        # Three chained adjacent rectangles
+        gmsh.model.occ.addRectangle(10, 10, 0, 1, 1)
+        gmsh.model.occ.addRectangle(11, 10, 0, 1, 1)
+        gmsh.model.occ.addRectangle(12, 10, 0, 1, 1)
+        # Two nested rectangles
+        gmsh.model.occ.addRectangle(50, 50, 0, 4, 4)
+        gmsh.model.occ.addRectangle(51, 51, 0, 1, 1)
+        gmsh.model.occ.synchronize()
+        gmsh.model.occ.fragment(gmsh.model.getEntities(2), [])
+        gmsh.model.occ.synchronize()
+        surfs = [dt[2] for dt in gmsh.model.getEntities(2)]
+        result = connected_components(2, surfs)
+        # Should have 2 components
+        @test length(result) == 2
+        sizes = sort([length(c) for c in result])
+        @test sizes[1] == 2
+        @test sizes[2] == 3
+    end
+end

--- a/test/test_connected_components.jl
+++ b/test/test_connected_components.jl
@@ -14,7 +14,7 @@
     @testset "empty input" begin
         fresh_model("empty")
         result = connected_components(3, Int32[])
-        @test result == Vector{Int32}[]
+        @test result == Vector{Tuple{Int32, Int32}}[]
     end
 
     @testset "single entity" begin
@@ -24,7 +24,7 @@
         tags = Int32[1]
         result = connected_components(3, tags)
         @test length(result) == 1
-        @test result[1] == Int32[1]
+        @test result[1] == (Int32(3), Int32(1))
     end
 
     @testset "two disconnected volumes" begin
@@ -117,7 +117,7 @@
         gmsh.model.occ.addRectangle(50, 50, 0, 4, 4)
         gmsh.model.occ.addRectangle(51, 51, 0, 1, 1)
         gmsh.model.occ.synchronize()
-        gmsh.model.occ.fragment(gmsh.model.getEntities(2), [])
+        dt, dtmap = gmsh.model.occ.fragment(gmsh.model.getEntities(2), [])
         gmsh.model.occ.synchronize()
         surfs = [dt[2] for dt in gmsh.model.getEntities(2)]
         result = connected_components(2, surfs)
@@ -126,5 +126,12 @@
         sizes = sort([length(c) for c in result])
         @test sizes[1] == 2
         @test sizes[2] == 3
+        # If you skip the connecting rectangle you get 3 groups
+        disconnected = unique(vcat(dtmap[1], dtmap[3], dtmap[4], dtmap[5]))
+        result2 = connected_components(2, last.(disconnected))
+        @show result2
+        @test length(result2) == 3
+        sizes = sort([length(c) for c in result2])
+        @test sizes == [1, 1, 2]
     end
 end

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -81,4 +81,14 @@ end
     )
     @test length(metal_conn_comps) == 3  # Ground, island, transmission line
     @test length(active_conn_comps) == 1 # Ports and lumped elements connect metal components
+    # Assign to new groups
+    metal_comp_tags = []
+    for i in eachindex(metal_conn_comps)
+        sm["metal_island_$i"] = metal_conn_comps[i]
+        push!(metal_comp_tags, SolidModels.entitytags(sm["metal_island_$i", 2]))
+    end
+    sort!(metal_comp_tags, by=length)
+    @test length(metal_comp_tags[1]) == 1 # Transmission line
+    @test length(metal_comp_tags[2]) == 2 # Transmon island + junction top lead
+    @test length(metal_comp_tags[3]) == 4 # Ground plane + bottom lead + TL ends
 end

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -74,4 +74,11 @@ end
     @test length(SolidModels.dimtags(sm["port_1", 2])) == 1
     @test length(SolidModels.dimtags(sm["port_2", 2])) == 1
     @test length(SolidModels.dimtags(sm["lumped_element", 2])) == 1
+    metal_conn_comps = SolidModels.connected_components(sm, "metal")
+    active_conn_comps = SolidModels.connected_components(
+        sm,
+        ["metal", "lumped_element", "port_1", "port_2"]
+    )
+    @test length(metal_conn_comps) == 3  # Ground, island, transmission line
+    @test length(active_conn_comps) == 1 # Ports and lumped elements connect metal components
 end


### PR DESCRIPTION
Close #151 under the assumption that connected subgroups only need to be identified, not used in further postrender operations. Implements `SolidModel.connected_components` which takes physical group names or entity tags and a dimension and outputs a vector of the connected components in those groups or tags.

To create physical groups, you would run something like this after rendering:

```julia
metal_islands = SolidModels.connected_components(sm, "metal")
for i in eachindex(metal_islands)
    sm["metal_island_$i"] = metal_islands[i]
end
```