### PR TITLE
Add auto_union and skip_unused_layers options to SolidModel rendering

### DIFF
--- a/src/solidmodels/postrender.jl
+++ b/src/solidmodels/postrender.jl
@@ -307,6 +307,8 @@ function union_geom!(
         if length(dt) <= 1
             length(dt) == 1 &&
                 @info "union_geom!(sm, $object, $d): ($object, $d) is a single entity, skipping union"
+            length(dt) == 0 &&
+                @info "union_geom!(sm, $object, $d): ($object, $d) is empty, skipping union"
             return dt
         end
     end

--- a/src/solidmodels/postrender.jl
+++ b/src/solidmodels/postrender.jl
@@ -304,8 +304,9 @@ function union_geom!(
         @error "union_geom!(sm, $object, $d): ($object, $d) is not a physical group."
     else
         dt = dimtags(sm[object, d])
-        if length(dt) == 1
-            @info "union_geom!(sm, $object, $d): ($object, $d) is a single entity, skipping union"
+        if length(dt) <= 1
+            length(dt) == 1 &&
+                @info "union_geom!(sm, $object, $d): ($object, $d) is a single entity, skipping union"
             return dt
         end
     end

--- a/src/solidmodels/render.jl
+++ b/src/solidmodels/render.jl
@@ -1144,10 +1144,10 @@ Render `cs` to `sm`.
   - `skip_postrender`: Whether or not to return early without performing any postrendering
     operations. This can be particularly helpful during debugging, as all two dimensional
     entities will be placed appropriately but will not have been combined.
-  - `auto_union`: If `true`, union each physical group in dimensions 2 and 3
+  - `auto_union`: If `true`, union each 2D physical group
     as the first postrender step, before extrusions and user-defined `postrender_ops`. This
     consolidates overlapping entities within each group, reducing the cost of subsequent
-    pairwise fragmentation.
+    pairwise fragmentation. Default is `false`.
   - `skip_unused_layers`: If `true`, skip rendering layers whose names are not referenced by
     `postrender_ops` or `retained_physical_groups`. A layer is considered referenced if either
     its mapped name or its base layer name (from `layer(meta)`) appears in the referenced set.
@@ -1316,10 +1316,8 @@ function render!(
     # Doing this before extrusions/booleans reduces the cost of pairwise fragmentation.
     if auto_union
         auto_union_ops = Tuple[]
-        for dim in (2, 3)
-            for groupname in collect(keys(dimgroupdict(sm, dim)))
-                push!(auto_union_ops, (groupname, union_geom!, (groupname, dim)))
-            end
+        for groupname in collect(keys(dimgroupdict(sm, 2))) # Only dim 2 will be present
+            push!(auto_union_ops, (groupname, union_geom!, (groupname, 2)))
         end
         _postrender!(sm, auto_union_ops)
         _synchronize!(sm)
@@ -1786,7 +1784,7 @@ function _used_group_names(postrender_ops, retained_physical_groups)
         # op = (destination, func, args, kwargs...)
         push!(names, string(op[1]))  # destination name
         if length(op) >= 3
-            _extract_op_names!(names, op[3])  # args tuple
+            _extract_op_names!(names, op[3])  # args tuple (kwargs are never layer names)
         end
     end
     return names

--- a/src/solidmodels/render.jl
+++ b/src/solidmodels/render.jl
@@ -1113,7 +1113,8 @@ end
 
 """
     render!(sm::SolidModel, cs::AbstractCoordinateSystem{T}; map_meta=layer,
-    postrender_ops=[], zmap=(_) -> zero(T), gmsh_options = Dict(), skip_postrender = false, kwargs...) where {T}
+    postrender_ops=[], zmap=(_) -> zero(T), gmsh_options = Dict(), skip_postrender = false,
+    auto_union=false, skip_unused_layers=false, kwargs...) where {T}
 
 Render `cs` to `sm`.
 
@@ -1143,6 +1144,15 @@ Render `cs` to `sm`.
   - `skip_postrender`: Whether or not to return early without performing any postrendering
     operations. This can be particularly helpful during debugging, as all two dimensional
     entities will be placed appropriately but will not have been combined.
+  - `auto_union`: If `true`, union each physical group in dimensions 2 and 3
+    as the first postrender step, before extrusions and user-defined `postrender_ops`. This
+    consolidates overlapping entities within each group, reducing the cost of subsequent
+    pairwise fragmentation.
+  - `skip_unused_layers`: If `true`, skip rendering layers whose names are not referenced by
+    `postrender_ops` or `retained_physical_groups`. A layer is considered referenced if either
+    its mapped name or its base layer name (from `layer(meta)`) appears in the referenced set.
+    This keeps indexed and levelwise variants (e.g. `"port_1"`) when the base layer (`"port"`)
+    is referenced. Default is `false`.
 
 Available postrendering operations include [`translate!`](@ref), [`extrude_z!`](@ref), [`revolve!`](@ref),
 [`union_geom!`](@ref), [`intersect_geom!`](@ref), [`difference_geom!`](@ref), [`fragment_geom!`](@ref), and [`box_selection`](@ref).
@@ -1162,6 +1172,8 @@ function render!(
     gmsh_options=Dict{String, Union{String, Int, Float64}}(),
     meshing_parameters::Union{Nothing, MeshingParameters}=nothing,
     skip_postrender=false,
+    auto_union=false,
+    skip_unused_layers=false,
     kwargs...
 ) where {T}
     gmsh.model.set_current(name(sm))
@@ -1188,9 +1200,22 @@ function render!(
     # Create RTree for avoiding duplicating points
     points_tree = RTree{Float64, 3}(Int32)
 
+    # Build set of used layer names for skip_unused_layers optimization
+    used_names = if skip_unused_layers
+        _used_group_names(postrender_ops, retained_physical_groups)
+    else
+        nothing
+    end
+
     # Create physical groups
     for meta in unique(element_metadata(flat)) # For each unique (layer, level, index) triple
-        isnothing(map_meta(meta)) && continue
+        mapped_name = map_meta(meta)
+        isnothing(mapped_name) && continue
+        if !isnothing(used_names) &&
+           string(mapped_name) ∉ used_names &&
+           string(layer(meta)) ∉ used_names
+            continue
+        end
         idx = (element_metadata(flat) .== meta) # Get the corresponding elements
         els = to_primitives.(sm, elements(flat)[idx]; kwargs...)
         meshsizes = sizeandgrading.(elements(flat)[idx]; kwargs...)
@@ -1208,13 +1233,13 @@ function render!(
         group_dimtags = reduce(vcat, group_dimtags_unflattened, init=Tuple{Int32, Int32}[])
         # If group already exists, add to it
         for dim in unique(first.(group_dimtags))
-            if hasgroup(sm, map_meta(meta), dim)
-                append!(group_dimtags, dimtags(sm[map_meta(meta), dim]))
+            if hasgroup(sm, mapped_name, dim)
+                append!(group_dimtags, dimtags(sm[mapped_name, dim]))
             end
         end
 
         # Make physical group for each dimension
-        sm[map_meta(meta)] = group_dimtags
+        sm[mapped_name] = group_dimtags
 
         # Collect dimtags for each sizeandgrading
         for (s, dts) ∈ zip(meshsizes, group_dimtags_unflattened)
@@ -1287,6 +1312,18 @@ function render!(
     # Extrusions, Booleans, etc
     _synchronize!(sm)
     skip_postrender && return nothing
+    # Union each physical group to consolidate overlapping entities before postrender.
+    # Doing this before extrusions/booleans reduces the cost of pairwise fragmentation.
+    if auto_union
+        auto_union_ops = Tuple[]
+        for dim in (2, 3)
+            for groupname in collect(keys(dimgroupdict(sm, dim)))
+                push!(auto_union_ops, (groupname, union_geom!, (groupname, dim)))
+            end
+        end
+        _postrender!(sm, auto_union_ops)
+        _synchronize!(sm)
+    end
     _postrender!(sm, postrender_ops)
     _synchronize!(sm)
     # Get rid of redundant entities and update groups accordingly.
@@ -1732,3 +1769,32 @@ function _add_offset_curve!(
     endp_pairs = [[start, stop] for (start, stop) in zip(starts, stops)]
     return _add_curve!.(endp_pairs, bspline_approx.segments, k, z)
 end
+
+"""
+    _used_group_names(postrender_ops, retained_physical_groups)
+
+Build a `Set{String}` of physical group names referenced by `postrender_ops` or
+`retained_physical_groups`. Used by `skip_unused_layers` to avoid rendering
+entities for unreferenced layers.
+"""
+function _used_group_names(postrender_ops, retained_physical_groups)
+    names = Set{String}()
+    for (name, _) in retained_physical_groups
+        push!(names, string(name))
+    end
+    for op in postrender_ops
+        # op = (destination, func, args, kwargs...)
+        push!(names, string(op[1]))  # destination name
+        if length(op) >= 3
+            _extract_op_names!(names, op[3])  # args tuple
+        end
+    end
+    return names
+end
+
+# Recursively extract String and Symbol values from nested args structures.
+# Numeric parameters (dimensions, thicknesses) are Int or length-unit types, never strings.
+_extract_op_names!(names::Set{String}, x::Union{String, Symbol}) = push!(names, string(x))
+_extract_op_names!(names::Set{String}, x::Union{Tuple, AbstractVector}) =
+    foreach(a -> _extract_op_names!(names, a), x)
+_extract_op_names!(names::Set{String}, ::Any) = nothing

--- a/test/test_solidmodel.jl
+++ b/test/test_solidmodel.jl
@@ -1452,4 +1452,156 @@
         SolidModels.set_gmsh_option("Mesh.ElementOrder", dict)
         @test SolidModels.get_gmsh_number("Mesh.ElementOrder") == 1
     end
+
+    @testset "auto_union" begin
+        # Two overlapping rectangles on the same layer should be unioned into one entity
+        cs = CoordinateSystem("test_auto_union", nm)
+        r1 = Rectangle(Point(0μm, 0μm), Point(2μm, 1μm))
+        r2 = Rectangle(Point(1μm, 0μm), Point(3μm, 1μm))
+        place!(cs, r1, SemanticMeta(:overlap))
+        place!(cs, r2, SemanticMeta(:overlap))
+
+        # With auto_union=true (default), overlapping entities are consolidated
+        sm = SolidModel("test_auto_union", overwrite=true)
+        render!(sm, cs; auto_union=true)
+        # After auto-union + fragment, the "overlap" group should have a single surface
+        @test SolidModels.hasgroup(sm, "overlap", 2)
+        @test length(SolidModels.dimtags(sm["overlap", 2])) == 1
+
+        # With auto_union=false, overlapping entities are NOT consolidated before postrender.
+        # After fragmentation, the overlap region is split into separate fragments.
+        sm2 = SolidModel("test_auto_union_off", overwrite=true)
+        render!(sm2, cs; auto_union=false)
+        @test SolidModels.hasgroup(sm2, "overlap", 2)
+        @test length(SolidModels.dimtags(sm2["overlap", 2])) > 1
+
+        # auto_union composes with postrender_ops: union happens first, then ops run
+        cs2 = CoordinateSystem("test_auto_union_compose", nm)
+        r3 = Rectangle(Point(0μm, 0μm), Point(2μm, 1μm))
+        r4 = Rectangle(Point(1μm, 0μm), Point(3μm, 1μm))
+        r5 = Rectangle(Point(5μm, 5μm), Point(7μm, 7μm))
+        place!(cs2, r3, SemanticMeta(:a))
+        place!(cs2, r4, SemanticMeta(:a))
+        place!(cs2, r5, SemanticMeta(:b))
+        sm3 = SolidModel("test_auto_union_compose", overwrite=true)
+        render!(
+            sm3,
+            cs2;
+            auto_union=true,
+            postrender_ops=[("combined", SolidModels.union_geom!, ("a", "b", 2, 2))]
+        )
+        @test SolidModels.hasgroup(sm3, "combined", 2)
+        @test length(SolidModels.dimtags(sm3["combined", 2])) == 2
+    end
+
+    @testset "skip_unused_layers" begin
+        # Create a cs with three layers: "used", "intermediate", and "unused"
+        cs = CoordinateSystem("test_skip_unused", nm)
+        place!(cs, Rectangle(Point(0μm, 0μm), Point(1μm, 1μm)), SemanticMeta(:used))
+        place!(cs, Rectangle(Point(2μm, 0μm), Point(3μm, 1μm)), SemanticMeta(:intermediate))
+        place!(cs, Rectangle(Point(4μm, 0μm), Point(5μm, 1μm)), SemanticMeta(:unused))
+
+        # Without skip_unused_layers, all three layers are rendered
+        sm = SolidModel("test_skip_unused_off", overwrite=true)
+        render!(
+            sm,
+            cs;
+            skip_unused_layers=false,
+            postrender_ops=[(
+                "result",
+                SolidModels.union_geom!,
+                ("used", "intermediate", 2, 2),
+                :remove_object => true,
+                :remove_tool => true
+            )]
+        )
+        # "unused" was rendered
+        @test SolidModels.hasgroup(sm, "unused", 2)
+
+        # With skip_unused_layers=true, "unused" is never rendered
+        sm2 = SolidModel("test_skip_unused_on", overwrite=true)
+        render!(
+            sm2,
+            cs;
+            skip_unused_layers=true,
+            postrender_ops=[(
+                "result",
+                SolidModels.union_geom!,
+                ("used", "intermediate", 2, 2),
+                :remove_object => true,
+                :remove_tool => true
+            )]
+        )
+        @test !SolidModels.hasgroup(sm2, "unused", 2)
+
+        # Indexed layers: "port_1" kept when base layer "port" is referenced
+        cs3 = CoordinateSystem("test_skip_indexed", nm)
+        place!(cs3, Rectangle(Point(0μm, 0μm), Point(1μm, 1μm)), SemanticMeta(:metal))
+        place!(
+            cs3,
+            Rectangle(Point(2μm, 0μm), Point(3μm, 1μm)),
+            SemanticMeta(:port, index=0)
+        )
+        place!(
+            cs3,
+            Rectangle(Point(4μm, 0μm), Point(5μm, 1μm)),
+            SemanticMeta(:port, index=1)
+        )
+        place!(
+            cs3,
+            Rectangle(Point(6μm, 0μm), Point(7μm, 1μm)),
+            SemanticMeta(:port, index=2)
+        )
+        place!(cs3, Rectangle(Point(8μm, 0μm), Point(9μm, 1μm)), SemanticMeta(:unused))
+        # map_meta that appends _$(index) for non-zero port indices (like _map_meta_fn)
+        indexed_map = m -> begin
+            name = string(layer(m))
+            if layer(m) == :port
+                idx = DeviceLayout.layerindex(m)
+                idx != 0 && (name = name * "_$(idx)")
+            end
+            return name
+        end
+        sm4 = SolidModel("test_skip_indexed", overwrite=true)
+        render!(
+            sm4,
+            cs3;
+            skip_unused_layers=true,
+            map_meta=indexed_map,
+            postrender_ops=[(
+                "result",
+                SolidModels.difference_geom!,
+                ("metal", "port", 2, 2)
+            )]
+        )
+        # "port" referenced by postrender_ops → indexed variants kept via base name
+        @test SolidModels.hasgroup(sm4, "port_1", 2)
+        @test SolidModels.hasgroup(sm4, "port_2", 2)
+        # "unused" not referenced and has no referenced base layer
+        @test !SolidModels.hasgroup(sm4, "unused", 2)
+
+        # Verify the _used_group_names helper extracts names correctly
+        ops = [
+            ("metal", SolidModels.union_geom!, ("metal_negative", "metal_negative", 2, 2)),
+            ("base", SolidModels.difference_geom!, ("writeable_area", "base_negative"))
+        ]
+        retained = [("vacuum", 3), ("substrate", 3)]
+        names = DeviceLayout.SolidModels._used_group_names(ops, retained)
+        @test "metal" ∈ names
+        @test "metal_negative" ∈ names
+        @test "base" ∈ names
+        @test "writeable_area" ∈ names
+        @test "base_negative" ∈ names
+        @test "vacuum" ∈ names
+        @test "substrate" ∈ names
+
+        # Verify transitive deps: intermediate names referenced by ops are included
+        ops2 =
+            [("final", SolidModels.difference_geom!, ("big", ["small1", "small2"], 2, 2))]
+        names2 = DeviceLayout.SolidModels._used_group_names(ops2, [])
+        @test "final" ∈ names2
+        @test "big" ∈ names2
+        @test "small1" ∈ names2
+        @test "small2" ∈ names2
+    end
 end


### PR DESCRIPTION
Adds two rendering options:

  - `auto_union`: If `true`, union each physical group in dimensions 2 and 3
    as the first postrender step, before extrusions and user-defined `postrender_ops`. This
    consolidates overlapping entities within each group, reducing the cost of subsequent
    pairwise fragmentation.
  - `skip_unused_layers`: If `true`, skip rendering layers whose names are not referenced by
    `postrender_ops` or `retained_physical_groups`. A layer is considered referenced if either
    its mapped name or its base layer name (from `layer(meta)`) appears in the referenced set.
    This keeps indexed and levelwise variants (e.g. `"port_1"`) when the base layer (`"port"`)
    is referenced. Default is `false`.

These can be provided as keyword options to `render!` or to a SolidModelTarget used in `render!`.