### PR TITLE
Sort holes in interiorcuts

### DIFF
--- a/src/polygons.jl
+++ b/src/polygons.jl
@@ -411,11 +411,12 @@ Return the array of `Point` objects that make up the contour of the `PolyNode`
 points(x::Clipper.PolyNode) = x.contour
 
 # Estimate keyhole polygon point count for an outer contour PolyNode.
-# Each immediate hole child adds its contour points plus 2 bridge vertices.
+# Each immediate hole child adds its contour points, duplicates an inner contour point,
+# and a duplicated new point where the cut intersects the outer contour.
 function total_points(node::Clipper.PolyNode)
     n = length(contour(node))
     for child in children(node)
-        n += length(contour(child)) + 2
+        n += length(contour(child)) + 3
     end
     return n
 end
@@ -1974,7 +1975,7 @@ function interiorcuts(nodeortree::Clipper.PolyNode, outpolys::Vector{Polygon{T}}
         loop_node.prev = last(nodes)
         last(nodes).next = loop_node
 
-        for hole in children(enclosing)
+        for hole in sort(children(enclosing), by=h -> uniqueray(contour(h))[1].p0.y)
             # process all the holes.
             interiorcuts(hole, outpolys)
 
@@ -2013,6 +2014,12 @@ function interiorcuts(nodeortree::Clipper.PolyNode, outpolys::Vector{Polygon{T}}
                     round(getx(best_intersection_point)),
                     round(gety(best_intersection_point))
                 )
+                if w == Point(3950000000000, 0)
+                    @show w
+                    @show ray.p0
+                    @show length(enclosing_contour)
+                    @show length.(contour.(children(enclosing)))
+                end
 
                 # We are going to replace `best_node`
                 # need to do all of the following...

--- a/src/polygons.jl
+++ b/src/polygons.jl
@@ -410,18 +410,7 @@ Return the array of `Point` objects that make up the contour of the `PolyNode`
 """
 points(x::Clipper.PolyNode) = x.contour
 
-# Estimate keyhole polygon point count for an outer contour PolyNode.
-# Each immediate hole child adds its contour points, duplicates an inner contour point,
-# and a duplicated new point where the cut intersects the outer contour.
-function total_points(node::Clipper.PolyNode)
-    n = length(contour(node))
-    for child in children(node)
-        n += length(contour(child)) + 3
-    end
-    return n
-end
-
-# Collect all contour point arrays from a PolyNode tree (no keyhole conversion).
+# Collect all contour point arrays from a PolyNode tree (no keyhole conversion)
 function _all_contours(node::Clipper.PolyNode{S}) where {S}
     contours = Vector{S}[]
     _collect_contours!(contours, node)
@@ -2014,12 +2003,6 @@ function interiorcuts(nodeortree::Clipper.PolyNode, outpolys::Vector{Polygon{T}}
                     round(getx(best_intersection_point)),
                     round(gety(best_intersection_point))
                 )
-                if w == Point(3950000000000, 0)
-                    @show w
-                    @show ray.p0
-                    @show length(enclosing_contour)
-                    @show length.(contour.(children(enclosing)))
-                end
 
                 # We are going to replace `best_node`
                 # need to do all of the following...

--- a/src/polygons.jl
+++ b/src/polygons.jl
@@ -410,6 +410,31 @@ Return the array of `Point` objects that make up the contour of the `PolyNode`
 """
 points(x::Clipper.PolyNode) = x.contour
 
+# Estimate keyhole polygon point count for an outer contour PolyNode.
+# Each immediate hole child adds its contour points plus 2 bridge vertices.
+function total_points(node::Clipper.PolyNode)
+    n = length(contour(node))
+    for child in children(node)
+        n += length(contour(child)) + 2
+    end
+    return n
+end
+
+# Collect all contour point arrays from a PolyNode tree (no keyhole conversion).
+function _all_contours(node::Clipper.PolyNode{S}) where {S}
+    contours = Vector{S}[]
+    _collect_contours!(contours, node)
+    return contours
+end
+
+function _collect_contours!(contours, node::Clipper.PolyNode)
+    c = contour(node)
+    !isempty(c) && push!(contours, c)
+    for child in children(node)
+        _collect_contours!(contours, child)
+    end
+end
+
 function DeviceLayout.transform(r::Rectangle, f::Transformation)
     preserves_angles(f) && return transform(r, ScaledIsometry(f))
     return f(convert(Polygon, r))
@@ -976,9 +1001,11 @@ end
 # Clipping requires an AbstractVector{Polygon{T}}
 _normalize_clip_arg(p::Polygon) = [p]
 _normalize_clip_arg(p::GeometryEntity) = _normalize_clip_arg(to_polygons(p))
+_normalize_clip_arg(p::ClippedPolygon{T}) where {T} =
+    Polygon{T}[Polygon(c) for c in _all_contours(p.tree)]
 _normalize_clip_arg(p::AbstractArray{Polygon{T}}) where {T} = p
 _normalize_clip_arg(p::AbstractArray{<:GeometryEntity{T}}) where {T} =
-    reduce(vcat, to_polygons.(p); init=Polygon{T}[])
+    reduce(vcat, _normalize_clip_arg.(p); init=Polygon{T}[])
 _normalize_clip_arg(p::Union{GeometryStructure, GeometryReference}) =
     _normalize_clip_arg(flat_elements(p))
 _normalize_clip_arg(p::Pair{<:Union{GeometryStructure, GeometryReference}}) =

--- a/src/render/polygons.jl
+++ b/src/render/polygons.jl
@@ -80,14 +80,8 @@ function render!(c::Cell{S}, p::Polygon, meta::GDSMeta=GDSMeta(); kwargs...) whe
         push!(c.element_metadata, meta)
         return c
     end
-
-    bestclip = _best_guillotine_cut((points(p),))
-    for q in [
-        clip(Clipper.ClipTypeIntersection, p, bestclip)
-        clip(Clipper.ClipTypeDifference, p, bestclip)
-    ]
-        render!(c, q, meta)
-    end
+    # Reconstruct ClippedPolygon with topology info to make safe guillotine cuts
+    render!(c, union2d(p), meta)
     return c
 end
 

--- a/src/render/polygons.jl
+++ b/src/render/polygons.jl
@@ -84,6 +84,98 @@ function render!(c::Cell{S}, p::Polygon, meta::GDSMeta=GDSMeta(); kwargs...) whe
 end
 
 """
+    render!(c::Cell, cp::ClippedPolygon, meta::GDSMeta=GDSMeta())
+
+Render a `ClippedPolygon`, applying guillotine cutting at the PolyNode level
+to preserve hole topology. Only converts to keyhole polygons (via `interiorcuts`)
+when sub-polygons are small enough to fit within `GDS_POLYGON_MAX`.
+"""
+function render!(
+    c::Cell{S},
+    cp::ClippedPolygon{T},
+    meta::GDSMeta=GDSMeta();
+    kwargs...
+) where {S, T}
+    gds_max =
+        haskey(ENV, "GDS_POLYGON_MAX") ? parse(Int, ENV["GDS_POLYGON_MAX"]) :
+        GDS_POLYGON_MAX
+
+    # Check if any outer contour (with its holes) would produce a keyhole polygon
+    # exceeding the point limit
+    if all(Polygons.total_points(child) <= gds_max for child in Clipper.children(cp.tree))
+        for poly in to_polygons(cp)
+            render!(c, poly, meta; kwargs...)
+        end
+        return c
+    end
+
+    # At least one outer contour is too large — guillotine cut preserving hole topology
+    rng = MersenneTwister(1234)
+
+    contours = Polygons._all_contours(cp.tree)
+    allpoints = reduce(vcat, contours)
+
+    # Build interval trees over edges from each contour
+    xtree = IntervalTree{T, IntervalValue{T, Int}}()
+    ytree = IntervalTree{T, IntervalValue{T, Int}}()
+    seg_idx = 0
+    for pts in contours
+        lsview = Polygons.LineSegmentView(pts)
+        for i in eachindex(lsview)
+            seg_idx += 1
+            push!(xtree, IntervalValue(Polygons.xinterval(lsview[i])..., seg_idx))
+            push!(ytree, IntervalValue(Polygons.yinterval(lsview[i])..., seg_idx))
+        end
+    end
+
+    b = Rectangle(lowerleft(allpoints), upperright(allpoints))
+    bestclip = b
+    bestscore = typemax(Int)
+    for _ = 1:200
+        x1 = getx(allpoints[rand(rng, 1:length(allpoints))])
+        clipPoly = Rectangle(lowerleft(b), Point(x1, upperright(b).y))
+        left, right = Interval(b.ll.x, x1), Interval(x1, b.ur.x)
+        nleft = nright = 0
+        for _ in intersect(xtree, left)
+            nleft += 1
+        end
+        for _ in intersect(xtree, right)
+            nright += 1
+        end
+        score = abs(nleft - nright)
+        if bestscore > score
+            bestscore = score
+            bestclip = clipPoly
+        end
+    end
+    for _ = 1:200
+        y1 = gety(allpoints[rand(rng, 1:length(allpoints))])
+        clipPoly = Rectangle(lowerleft(b), Point(upperright(b).x, y1))
+        left, right = Interval(b.ll.y, y1), Interval(y1, b.ur.y)
+        nleft = nright = 0
+        for _ in intersect(ytree, left)
+            nleft += 1
+        end
+        for _ in intersect(ytree, right)
+            nright += 1
+        end
+        score = abs(nleft - nright)
+        if bestscore > score
+            bestscore = score
+            bestclip = clipPoly
+        end
+    end
+
+    for q in [ # Clip cp without converting to polygons (bypass interiorcuts)
+        clip(Clipper.ClipTypeIntersection, cp, bestclip)
+        clip(Clipper.ClipTypeDifference, cp, bestclip)
+    ]
+        render!(c, q, meta; kwargs...)
+    end
+    return c
+end
+
+"""
     render!(c::CoordinateSystem, ent, meta)
 
 Synonym for [`place!`](@ref).

--- a/src/render/polygons.jl
+++ b/src/render/polygons.jl
@@ -1,65 +1,5 @@
 using IntervalTrees
 
-# Find a balanced guillotine cut rectangle from polygon contours.
-# Samples random vertex-aligned cuts and scores by edge-count balance.
-function _best_guillotine_cut(contours)
-    rng = MersenneTwister(1234)
-    allpoints = reduce(vcat, contours)
-    T = eltype(eltype(allpoints))
-
-    xtree = IntervalTree{T, IntervalValue{T, Int}}()
-    ytree = IntervalTree{T, IntervalValue{T, Int}}()
-    seg_idx = 0
-    for pts in contours
-        lsview = Polygons.LineSegmentView(pts)
-        for i in eachindex(lsview)
-            seg_idx += 1
-            push!(xtree, IntervalValue(Polygons.xinterval(lsview[i])..., seg_idx))
-            push!(ytree, IntervalValue(Polygons.yinterval(lsview[i])..., seg_idx))
-        end
-    end
-
-    b = Rectangle(lowerleft(allpoints), upperright(allpoints))
-    bestclip = b
-    bestscore = typemax(Int)
-    for _ = 1:200
-        x1 = getx(allpoints[rand(rng, 1:length(allpoints))])
-        clipPoly = Rectangle(lowerleft(b), Point(x1, upperright(b).y))
-        left, right = Interval(b.ll.x, x1), Interval(x1, b.ur.x)
-        nleft = nright = 0
-        for _ in intersect(xtree, left)
-            nleft += 1
-        end
-        for _ in intersect(xtree, right)
-            nright += 1
-        end
-        score = abs(nleft - nright)
-        if bestscore > score
-            bestscore = score
-            bestclip = clipPoly
-        end
-    end
-    for _ = 1:200
-        y1 = gety(allpoints[rand(rng, 1:length(allpoints))])
-        clipPoly = Rectangle(lowerleft(b), Point(upperright(b).x, y1))
-        left, right = Interval(b.ll.y, y1), Interval(y1, b.ur.y)
-        nleft = nright = 0
-        for _ in intersect(ytree, left)
-            nleft += 1
-        end
-        for _ in intersect(ytree, right)
-            nright += 1
-        end
-        score = abs(nleft - nright)
-        if bestscore > score
-            bestscore = score
-            bestclip = clipPoly
-        end
-    end
-
-    return bestclip
-end
-
 """
     render!(c::Cell, p::Polygon, meta::GDSMeta=GDSMeta())
 
@@ -80,41 +20,63 @@ function render!(c::Cell{S}, p::Polygon, meta::GDSMeta=GDSMeta(); kwargs...) whe
         push!(c.element_metadata, meta)
         return c
     end
-    # Reconstruct ClippedPolygon with topology info to make safe guillotine cuts
-    render!(c, union2d(p), meta)
-    return c
-end
 
-"""
-    render!(c::Cell, cp::ClippedPolygon, meta::GDSMeta=GDSMeta())
+    # for determinism
+    rng = MersenneTwister(1234)
 
-Render a `ClippedPolygon`, applying guillotine cutting at the PolyNode level
-to preserve hole topology. Only converts to keyhole polygons (via `interiorcuts`)
-when sub-polygons are small enough to fit within `GDS_POLYGON_MAX`.
-"""
-function render!(
-    c::Cell{S},
-    cp::ClippedPolygon{T},
-    meta::GDSMeta=GDSMeta();
-    kwargs...
-) where {S, T}
-    gds_max =
-        haskey(ENV, "GDS_POLYGON_MAX") ? parse(Int, ENV["GDS_POLYGON_MAX"]) :
-        GDS_POLYGON_MAX
+    # idea will be to make a cut that balances the number of line segments
+    # on one side of the cut or the other. should be cheaper than clipping.
 
-    # Check if any outer contour (with its holes) would produce a keyhole polygon
-    # exceeding the point limit
-    if all(Polygons.total_points(child) <= gds_max for child in Clipper.children(cp.tree))
-        for poly in to_polygons(cp)
-            render!(c, poly, meta; kwargs...)
-        end
-        return c
+    T = eltype(eltype(points(p)))
+    xtree = IntervalTree{T, IntervalValue{T, Int}}()
+    ytree = IntervalTree{T, IntervalValue{T, Int}}()
+    lsview = Polygons.LineSegmentView(points(p))
+    for i in eachindex(lsview)
+        push!(xtree, IntervalValue(Polygons.xinterval(lsview[i])..., i))
+        push!(ytree, IntervalValue(Polygons.yinterval(lsview[i])..., i))
     end
 
-    bestclip = _best_guillotine_cut(Polygons._all_contours(cp.tree))
+    b = bounds(p)
+    bestclip = b
+    bestscore = typemax(Int)
+    for _ = 1:200
+        x1 = getx(points(p)[rand(rng, 1:end)])
+        clipPoly = Rectangle(lowerleft(b), Point(x1, upperright(b).y))
+        left, right = Interval(b.ll.x, x1), Interval(x1, b.ur.x)
+        nleft = nright = 0
+        for i in intersect(xtree, left)
+            nleft += 1
+        end
+        for _ in intersect(xtree, right)
+            nright += 1
+        end
+        score = abs(nleft - nright)
+        if bestscore > score
+            bestscore = score
+            bestclip = clipPoly
+        end
+    end
+    for _ = 1:200
+        y1 = gety(points(p)[rand(rng, 1:end)])
+        clipPoly = Rectangle(lowerleft(b), Point(upperright(b).x, y1))
+        left, right = Interval(b.ll.y, y1), Interval(y1, b.ur.y)
+        nleft = nright = 0
+        for i in intersect(ytree, left)
+            nleft += 1
+        end
+        for _ in intersect(ytree, right)
+            nright += 1
+        end
+        score = abs(nleft - nright)
+        if bestscore > score
+            bestscore = score
+            bestclip = clipPoly
+        end
+    end
+
     for q in [
-        clip(Clipper.ClipTypeIntersection, cp, bestclip)
-        clip(Clipper.ClipTypeDifference, cp, bestclip)
+        clip(Clipper.ClipTypeIntersection, p, bestclip)
+        clip(Clipper.ClipTypeDifference, p, bestclip)
     ]
         render!(c, q, meta; kwargs...)
     end

--- a/src/render/polygons.jl
+++ b/src/render/polygons.jl
@@ -1,121 +1,12 @@
 using IntervalTrees
 
-"""
-    render!(c::Cell, p::Polygon, meta::GDSMeta=GDSMeta())
-
-Render a polygon `p` to cell `c`, defaulting to plain styling.
-If `p` has more than 8190 (set by DeviceLayout's `GDS_POLYGON_MAX` constant),
-then it is partitioned into smaller polygons which are then rendered.
-Environment variable `ENV["GDS_POLYGON_MAX"]` will override this constant.
-The partitioning algorithm implements guillotine cutting, that goes through
-at least one existing vertex and in manhattan directions.
-Cuts are selected by ad hoc optimization for "nice" partitions.
-"""
-function render!(c::Cell{S}, p::Polygon, meta::GDSMeta=GDSMeta(); kwargs...) where {S}
-    if length(points(p)) <= (
-        haskey(ENV, "GDS_POLYGON_MAX") ? parse(Int, ENV["GDS_POLYGON_MAX"]) :
-        GDS_POLYGON_MAX
-    )
-        push!(c.elements, p)
-        push!(c.element_metadata, meta)
-        return c
-    end
-
-    # for determinism
+# Find a balanced guillotine cut rectangle from polygon contours.
+# Samples random vertex-aligned cuts and scores by edge-count balance.
+function _best_guillotine_cut(contours)
     rng = MersenneTwister(1234)
-
-    # idea will be to make a cut that balances the number of line segments
-    # on one side of the cut or the other. should be cheaper than clipping.
-
-    T = eltype(eltype(points(p)))
-    xtree = IntervalTree{T, IntervalValue{T, Int}}()
-    ytree = IntervalTree{T, IntervalValue{T, Int}}()
-    lsview = Polygons.LineSegmentView(points(p))
-    for i in eachindex(lsview)
-        push!(xtree, IntervalValue(Polygons.xinterval(lsview[i])..., i))
-        push!(ytree, IntervalValue(Polygons.yinterval(lsview[i])..., i))
-    end
-
-    b = bounds(p)
-    bestclip = b
-    bestscore = typemax(Int)
-    for _ = 1:200
-        x1 = getx(points(p)[rand(rng, 1:end)])
-        clipPoly = Rectangle(lowerleft(b), Point(x1, upperright(b).y))
-        left, right = Interval(b.ll.x, x1), Interval(x1, b.ur.x)
-        nleft = nright = 0
-        for i in intersect(xtree, left)
-            nleft += 1
-        end
-        for _ in intersect(xtree, right)
-            nright += 1
-        end
-        score = abs(nleft - nright)
-        if bestscore > score
-            bestscore = score
-            bestclip = clipPoly
-        end
-    end
-    for _ = 1:200
-        y1 = gety(points(p)[rand(rng, 1:end)])
-        clipPoly = Rectangle(lowerleft(b), Point(upperright(b).x, y1))
-        left, right = Interval(b.ll.y, y1), Interval(y1, b.ur.y)
-        nleft = nright = 0
-        for i in intersect(ytree, left)
-            nleft += 1
-        end
-        for _ in intersect(ytree, right)
-            nright += 1
-        end
-        score = abs(nleft - nright)
-        if bestscore > score
-            bestscore = score
-            bestclip = clipPoly
-        end
-    end
-
-    for q in [
-        clip(Clipper.ClipTypeIntersection, p, bestclip)
-        clip(Clipper.ClipTypeDifference, p, bestclip)
-    ]
-        render!(c, q, meta)
-    end
-    return c
-end
-
-"""
-    render!(c::Cell, cp::ClippedPolygon, meta::GDSMeta=GDSMeta())
-
-Render a `ClippedPolygon`, applying guillotine cutting at the PolyNode level
-to preserve hole topology. Only converts to keyhole polygons (via `interiorcuts`)
-when sub-polygons are small enough to fit within `GDS_POLYGON_MAX`.
-"""
-function render!(
-    c::Cell{S},
-    cp::ClippedPolygon{T},
-    meta::GDSMeta=GDSMeta();
-    kwargs...
-) where {S, T}
-    gds_max =
-        haskey(ENV, "GDS_POLYGON_MAX") ? parse(Int, ENV["GDS_POLYGON_MAX"]) :
-        GDS_POLYGON_MAX
-
-    # Check if any outer contour (with its holes) would produce a keyhole polygon
-    # exceeding the point limit
-    if all(Polygons.total_points(child) <= gds_max for child in Clipper.children(cp.tree))
-        for poly in to_polygons(cp)
-            render!(c, poly, meta; kwargs...)
-        end
-        return c
-    end
-
-    # At least one outer contour is too large — guillotine cut preserving hole topology
-    rng = MersenneTwister(1234)
-
-    contours = Polygons._all_contours(cp.tree)
     allpoints = reduce(vcat, contours)
+    T = eltype(eltype(allpoints))
 
-    # Build interval trees over edges from each contour
     xtree = IntervalTree{T, IntervalValue{T, Int}}()
     ytree = IntervalTree{T, IntervalValue{T, Int}}()
     seg_idx = 0
@@ -166,7 +57,68 @@ function render!(
         end
     end
 
-    for q in [ # Clip cp without converting to polygons (bypass interiorcuts)
+    return bestclip
+end
+
+"""
+    render!(c::Cell, p::Polygon, meta::GDSMeta=GDSMeta())
+
+Render a polygon `p` to cell `c`, defaulting to plain styling.
+If `p` has more than 8190 (set by DeviceLayout's `GDS_POLYGON_MAX` constant),
+then it is partitioned into smaller polygons which are then rendered.
+Environment variable `ENV["GDS_POLYGON_MAX"]` will override this constant.
+The partitioning algorithm implements guillotine cutting, that goes through
+at least one existing vertex and in manhattan directions.
+Cuts are selected by ad hoc optimization for "nice" partitions.
+"""
+function render!(c::Cell{S}, p::Polygon, meta::GDSMeta=GDSMeta(); kwargs...) where {S}
+    if length(points(p)) <= (
+        haskey(ENV, "GDS_POLYGON_MAX") ? parse(Int, ENV["GDS_POLYGON_MAX"]) :
+        GDS_POLYGON_MAX
+    )
+        push!(c.elements, p)
+        push!(c.element_metadata, meta)
+        return c
+    end
+
+    bestclip = _best_guillotine_cut((points(p),))
+    for q in [
+        clip(Clipper.ClipTypeIntersection, p, bestclip)
+        clip(Clipper.ClipTypeDifference, p, bestclip)
+    ]
+        render!(c, q, meta)
+    end
+    return c
+end
+
+"""
+    render!(c::Cell, cp::ClippedPolygon, meta::GDSMeta=GDSMeta())
+
+Render a `ClippedPolygon`, applying guillotine cutting at the PolyNode level
+to preserve hole topology. Only converts to keyhole polygons (via `interiorcuts`)
+when sub-polygons are small enough to fit within `GDS_POLYGON_MAX`.
+"""
+function render!(
+    c::Cell{S},
+    cp::ClippedPolygon{T},
+    meta::GDSMeta=GDSMeta();
+    kwargs...
+) where {S, T}
+    gds_max =
+        haskey(ENV, "GDS_POLYGON_MAX") ? parse(Int, ENV["GDS_POLYGON_MAX"]) :
+        GDS_POLYGON_MAX
+
+    # Check if any outer contour (with its holes) would produce a keyhole polygon
+    # exceeding the point limit
+    if all(Polygons.total_points(child) <= gds_max for child in Clipper.children(cp.tree))
+        for poly in to_polygons(cp)
+            render!(c, poly, meta; kwargs...)
+        end
+        return c
+    end
+
+    bestclip = _best_guillotine_cut(Polygons._all_contours(cp.tree))
+    for q in [
         clip(Clipper.ClipTypeIntersection, cp, bestclip)
         clip(Clipper.ClipTypeDifference, cp, bestclip)
     ]

--- a/test/test_clipping.jl
+++ b/test/test_clipping.jl
@@ -920,3 +920,58 @@ end
     # Ensure the curve_start_idx are sorted absolutely
     @test issorted(abs.(rcp.curve_start_idx))
 end
+
+@testitem "Issue #175: Guillotine cutting with holes" setup = [CommonTestSetup] begin
+    import DeviceLayout: GDS_POLYGON_MAX
+
+    # Shoelace formula for signed polygon area
+    area(p) =
+        sum(
+            (gety.(p.p) + gety.(circshift(p.p, -1))) .*
+            (getx.(p.p) - getx.(circshift(p.p, -1)))
+        ) / 2
+
+    @testset "MRE: 3-circle difference" begin
+        # MRE from issue #175: two small circles subtracted from a large one,
+        # producing a ~15,004 vertex keyhole polygon that triggers the guillotine.
+        c1 = circle_polygon(0.5mm, 2π / 5000) - Point(0mm, 1mm)
+        c2 = c1 + Point(0mm, 2mm)
+        c3 = circle_polygon(3mm, 2π / 5000)
+        cp = difference2d(c3, [c1, c2])
+
+        c = Cell("test175_mre", mm)
+        render!(c, cp, GDSMeta())
+
+        # no regression: 
+        @test all(length(points(el)) <= GDS_POLYGON_MAX for el in c.elements)
+        original_area = abs(area(c3)) - abs(area(c1)) - abs(area(c2))
+        rendered_area = sum(abs(area(el)) for el in c.elements)
+        @test rendered_area ≈ original_area
+        # Without fix, positive offset will add too much area because it expands the bad cut
+        off = to_polygons(union2d(offset(elements(c), 0.1mm)))
+        @test area(only(off)) ≈ pi * (3.1mm)^2 - 2 * pi * (0.4mm)^2 rtol = 1e-4
+    end
+
+    @testset "Nested holes" begin
+        # As with MRE but one hole has holes
+        c1 = circle_polygon(0.5mm, 2π / 5000) - Point(0mm, 1mm)
+        c2 = c1 + Point(0mm, 2mm)
+        c3 = circle_polygon(3mm, 2π / 5000)
+        c4 = circle_polygon(0.25mm, 2π / 100) - Point(0mm, 1mm)
+        cp = difference2d(c3, [difference2d(c1, c4), c2])
+
+        c = Cell("test175_mre", mm)
+        render!(c, cp, GDSMeta())
+
+        # no regression: 
+        @test all(length(points(el)) <= GDS_POLYGON_MAX for el in c.elements)
+        original_area = abs(area(c3)) - abs(area(c1)) - abs(area(c2)) + abs(area(c4))
+        rendered_area = sum(abs(area(el)) for el in c.elements)
+        @test rendered_area ≈ original_area
+        # Check offset area as test for bad cuts
+        off = to_polygons(union2d(offset(elements(c), 0.1mm)))
+        @test length(off) == 2
+        @test area(off[1]) ≈ pi * (0.35mm)^2 rtol = 1e-2
+        @test area(off[2]) ≈ pi * (3.1mm)^2 - 2 * pi * (0.4mm)^2 rtol = 1e-4
+    end
+end

--- a/test/test_clipping.jl
+++ b/test/test_clipping.jl
@@ -921,9 +921,8 @@ end
     @test issorted(abs.(rcp.curve_start_idx))
 end
 
-@testitem "Issue #175: Guillotine cutting with holes" setup = [CommonTestSetup] begin
-    import DeviceLayout: GDS_POLYGON_MAX
-
+@testitem "Hole sorting" setup = [CommonTestSetup] begin
+    # Issue #175
     # Shoelace formula for signed polygon area
     area(p) =
         sum(
@@ -931,47 +930,43 @@ end
             (getx.(p.p) - getx.(circshift(p.p, -1)))
         ) / 2
 
-    @testset "MRE: 3-circle difference" begin
-        # MRE from issue #175: two small circles subtracted from a large one,
-        # producing a ~15,004 vertex keyhole polygon that triggers the guillotine.
-        c1 = circle_polygon(0.5mm, 2π / 5000) - Point(0mm, 1mm)
-        c2 = c1 + Point(0mm, 2mm)
-        c3 = circle_polygon(3mm, 2π / 5000)
+    @testset "Hole sorting" begin
+        c1 = rotate(centered(Rectangle(0.5mm, 0.5mm)), 45°) - Point(0mm, 0.5mm)
+        c2 = c1 + Point(0mm, 1mm)
+        c3 = convert(Polygon, centered(Rectangle(3mm, 3mm)))
         cp = difference2d(c3, [c1, c2])
 
         c = Cell("test175_mre", mm)
         render!(c, cp, GDSMeta())
-
-        # no regression: 
-        @test all(length(points(el)) <= GDS_POLYGON_MAX for el in c.elements)
+        # No regression
         original_area = abs(area(c3)) - abs(area(c1)) - abs(area(c2))
         rendered_area = sum(abs(area(el)) for el in c.elements)
         @test rendered_area ≈ original_area
         # Without fix, positive offset will add too much area because it expands the bad cut
-        off = to_polygons(union2d(offset(elements(c), 0.1mm)))
-        @test area(only(off)) ≈ pi * (3.1mm)^2 - 2 * pi * (0.4mm)^2 rtol = 1e-4
+        off = to_polygons(union2d(offset(elements(c), 0.05mm)))
+        @test area(only(off)) ≈ (3.1mm)^2 - 2 * (0.4mm)^2
     end
 
     @testset "Nested holes" begin
         # As with MRE but one hole has holes
-        c1 = circle_polygon(0.5mm, 2π / 5000) - Point(0mm, 1mm)
-        c2 = c1 + Point(0mm, 2mm)
-        c3 = circle_polygon(3mm, 2π / 5000)
-        c4 = circle_polygon(0.25mm, 2π / 100) - Point(0mm, 1mm)
+        c1 = rotate(centered(Rectangle(0.5mm, 0.5mm)), 45°) - Point(0mm, 0.5mm)
+        c2 = c1 + Point(0mm, 1mm)
+        c3 = convert(Polygon, centered(Rectangle(3mm, 3mm)))
+        c4 = rotate(centered(Rectangle(0.25mm, 0.25mm)), 45°) - Point(0mm, 0.5mm)
+        cp = difference2d(c3, [c1, c2])
         cp = difference2d(c3, [difference2d(c1, c4), c2])
 
         c = Cell("test175_mre", mm)
         render!(c, cp, GDSMeta())
 
         # no regression: 
-        @test all(length(points(el)) <= GDS_POLYGON_MAX for el in c.elements)
         original_area = abs(area(c3)) - abs(area(c1)) - abs(area(c2)) + abs(area(c4))
         rendered_area = sum(abs(area(el)) for el in c.elements)
         @test rendered_area ≈ original_area
         # Check offset area as test for bad cuts
-        off = to_polygons(union2d(offset(elements(c), 0.1mm)))
+        off = to_polygons(union2d(offset(elements(c), 0.05mm)))
         @test length(off) == 2
-        @test area(off[1]) ≈ pi * (0.35mm)^2 rtol = 1e-2
-        @test area(off[2]) ≈ pi * (3.1mm)^2 - 2 * pi * (0.4mm)^2 rtol = 1e-4
+        @test area(off[1]) ≈ (0.35mm)^2
+        @test area(off[2]) ≈ (3.1mm)^2 - 2 * (0.4mm)^2
     end
 end


### PR DESCRIPTION
Fixes #175.

Right now `_normalize_clip_arg` turns ClippedPolygons into polygons via `interiorcuts`, but we can just extract the oriented contours directly. This then lets us do the guillotine cut for ClippedPolygons with more points than `GDS_POLYGON_MAX` without an intermediate `interiorcuts`, which fixes the mentioned issue. [Edit: it doesn't, see comments further down on how we actually fix the issue.]

In a follow-up, we can probably do the same for offsets of ClippedPolygons, which should address the issue where shrinking a polygon with an interior cut pulls it open. [This is still probably a good idea.]