### PR TITLE
Fix uniquename on route created via matching hooks

### DIFF
--- a/src/schematics/routes.jl
+++ b/src/schematics/routes.jl
@@ -101,7 +101,7 @@ function route!(
     node2::ComponentNode,
     sty,
     meta;
-    name="r_$(component(node1).name)_$(component(node2).name)",
+    name=uniquename("r_$(component(node1).name)_$(component(node2).name)"),
     kwargs...
 )
     h1, h2 = matching_hooks(component(node1), component(node2))
@@ -115,7 +115,7 @@ route!(
     node2::ComponentNode,
     sty,
     meta;
-    name="r_$(component(nodehook1.first).name)_$(component(node2).name)",
+    name=uniquename("r_$(component(nodehook1.first).name)_$(component(node2).name)"),
     kwargs...
 ) = route!(
     g,
@@ -136,7 +136,7 @@ route!(
     nodehook2::Pair{ComponentNode, Symbol},
     sty,
     meta;
-    name="r_$(component(node1).name)_$(component(nodehook2.first).name)",
+    name=uniquename("r_$(component(node1).name)_$(component(nodehook2.first).name)"),
     kwargs...
 ) = route!(
     g,


### PR DESCRIPTION
The main method uses `uniquename` as documented, but these were overlooked.

A separate question is why the non-unique component name is used rather than the already-unique node id. Would it be a breaking change to correct that? Are changes to auto-generated names breaking in general? Not urgent to answer those questions, and this PR is a bug fix in any case.