### PR TITLE
backend/gds: Normalize angles upon export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format of this changelog is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+  - Normalize rotation angles to [0, 360) when writing GDS files
+
 ## 1.12.0 (2026-04-13)
 
   - Added `auto_union` SolidModel rendering option; if `true`, self-unions every 2D group before any other postrendering (default `false`)
@@ -95,7 +99,7 @@ The documentation has also been reorganized and improved:
   - Deprecated `SolidModels.MeshingParameters` in favour of new `mesh_scale`, `mesh_order`,
     `mesh_grading_default` accessed from `SolidModels`. Removed `apply_size_to_surfaces`.
   - Improvements to `SolidModels.render!` to improve stability and performance.
-    
+
       + Changed `SolidModels.restrict_to_volume!` to perform a check if the simulation domain
         already bounds all two and three dimensional objects, if so skips operation.
       + Changed `SolidModels.render!` to incorporate a two stage `_fragment_and_map!` operation,
@@ -112,7 +116,7 @@ The documentation has also been reorganized and improved:
   - Added `xor2d` for polygon XOR
 
   - Improved support for wave port boundaries in a `SolidModel`
-    
+
       + `SolidModelTargets` now take `wave_port_layers`, a list of layer symbols used to define wave port boundary conditions
       + Added support for `LineSegment` in SolidModel
       + Added `add_wave_ports!` to automatically place wave port boundaries where specified paths/routes intersect the simulation area
@@ -129,7 +133,7 @@ For developers, the test suite now uses the TestItem framework, and new benchmar
 ## 1.6.0 (2025-10-16)
 
   - Improved metadata handling for `LayoutTarget` and `SolidModelTarget`
-    
+
       + SolidModelTargets will now ignore `NORENDER_META` (the `:norender` layer)
       + SolidModelTargets now take `ignored_layers`, a list of layer symbols which are not rendered
       + LayoutTargets now allow overriding the mapping of `GDSMeta` by setting `target.map_meta_dict[my_gdsmeta] = my_override`, allowing changes to different `GDSMeta` or `nothing` rather than always mapping a `GDSMeta` to itself
@@ -147,7 +151,7 @@ For developers, the test suite now uses the TestItem framework, and new benchmar
 ## 1.5.0 (2025-10-10)
 
   - Added `auto_speed`, `endpoints_curvature`, and `auto_curvature` keyword options to `bspline!` and `BSplineRouting`
-    
+
       + `auto_speed` sets the speed at endpoints to avoid sharp bends (minimizing the integrated square of the curvature derivative with respect to arclength)
       + `endpoints_curvature` sets boundary conditions on the curvature (by inserting extra waypoints)
       + `auto_curvature` B-spline sets curvature at endpoints to match previous segment (or to zero if there is no previous segment)

--- a/src/backends/gds.jl
+++ b/src/backends/gds.jl
@@ -533,6 +533,8 @@ end
 
 Writes bytes to the IO stream (if needed) to encode x-reflection, magnification,
 and rotation settings of a reference or array. Returns the number of bytes written.
+
+Rotation angles are normalized to [0, 360) via `mod` before writing.
 """
 function strans(io::IO, ref)
     bits = 0x0000
@@ -547,7 +549,10 @@ function strans(io::IO, ref)
     bytes = 0
     (ref.xrefl || ref.mag != 1.0 || ref.rot != 0.0) && (bytes += gdswrite(io, STRANS, bits))
     ref.mag != 1.0 && (bytes += gdswrite(io, MAG, ref.mag))
-    ref.rot != 0.0 && (bytes += gdswrite(io, ANGLE, ustrip(ref.rot |> °)))
+    if ref.rot != 0.0
+        angle_deg = mod(ustrip(ref.rot |> °), 360)
+        bytes += gdswrite(io, ANGLE, angle_deg)
+    end
     return bytes
 end
 

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -1042,6 +1042,18 @@ end
             rm(path, force=true)
         end
 
+        # Round-trip test: out-of-range rotation is normalized to [0, 360)
+        let c = Cell("main", nm), c2 = Cell("sub", nm)
+            render!(c2, Rectangle(1μm, 1μm), GDSMeta(0))
+            c2ref = CellReference(c2, rot=540°)
+            push!(c.refs, c2ref)
+            path = joinpath(tdir, "test_normalize.gds")
+            save(path, c)
+            gds = load(path)
+            @test gds["main"].refs[1].rot == 180°
+            rm(path, force=true)
+        end
+
         # test we can recognize PROPATTR and PROPVALUE tags (though ignored)
         @test_logs (:info, r"PROPATTR: 0") match_mode = :any load(
             joinpath(@__DIR__, "propattr.gds");


### PR DESCRIPTION
During routing, angles can accumulate, resulting in values which are outside the GDS spec of [-360, 360]. This results in warnings from tools like Klayout.

This PR adds an option to warn about invalid angles during export (on by default) and to normalize the angles (off by default).
