### PR TITLE
Fix kwarg forwarding in Rounded transformation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ coverage/
 *.xao
 *.msh2
 CLAUDE*
+test/build/

--- a/src/coordsys_interface.jl
+++ b/src/coordsys_interface.jl
@@ -157,7 +157,7 @@ function order!(a::AbstractArray)
 end
 
 """
-    flatten!(c::AbstractCoordinateSystem, depth::Integer=-1, metadata_filter=nothing, max_copy=Inf)
+    flatten!(c::AbstractCoordinateSystem; depth::Integer=-1, metadata_filter=nothing, max_copy=Inf)
 
 Recursively flatten references and arrays up to a hierarchical `depth`, adding their elements to `c` with appropriate transformations.
 
@@ -180,7 +180,7 @@ function flatten!(
 end
 
 """
-    flatten(c::GeometryStructure; depth::Integer=-1, name=uniquename("flatten_"*name(c)))
+    flatten(c::GeometryStructure; depth::Integer=-1, name=uniquename("flatten_"*name(c)), metadata_filter=nothing, max_copy=Inf)
 
 Return a new coordinate system with name `name` with recursively flattened references and arrays up to a hierarchical `depth`.
 

--- a/src/curvilinear.jl
+++ b/src/curvilinear.jl
@@ -140,7 +140,8 @@ function transform(e::CurvilinearPolygon, f::Transformation)
         f.(xrefl(f) ? reverse(e.p) : e.p),
         isempty(e.curves) ? deepcopy(e.curves) :
         transform.(xrefl(f) ? reverse(e.curves) : e.curves, Ref(f)),
-        xrefl(f) ? reverse(csi_rev.(e.curve_start_idx, length(e.p))) : copy(e.curve_start_idx)
+        xrefl(f) ? reverse(csi_rev.(e.curve_start_idx, length(e.p))) :
+        copy(e.curve_start_idx)
     )
 end
 

--- a/src/curvilinear.jl
+++ b/src/curvilinear.jl
@@ -152,7 +152,7 @@ convert(::Type{CurvilinearPolygon{T}}, e::CurvilinearPolygon{T}) where {T} = e
 function convert(::Type{CurvilinearPolygon{T}}, e::CurvilinearPolygon{S}) where {T, S}
     return CurvilinearPolygon{T}(
         convert(Vector{Point{T}}, e.p),
-        [convert(Paths.Segment{T}, c) for c in e.curves],
+        convert(Vector{Paths.Segment{T}}, e.curves),
         copy(e.curve_start_idx)
     )
 end

--- a/src/curvilinear.jl
+++ b/src/curvilinear.jl
@@ -140,18 +140,19 @@ function transform(e::CurvilinearPolygon, f::Transformation)
         f.(xrefl(f) ? reverse(e.p) : e.p),
         isempty(e.curves) ? deepcopy(e.curves) :
         transform.(xrefl(f) ? reverse(e.curves) : e.curves, Ref(f)),
-        xrefl(f) ? reverse(csi_rev.(e.curve_start_idx, length(e.p))) : e.curve_start_idx
+        xrefl(f) ? reverse(csi_rev.(e.curve_start_idx, length(e.p))) : copy(e.curve_start_idx)
     )
 end
 
 convert(::Type{GeometryEntity{T}}, e::CurvilinearPolygon) where {T} =
     convert(CurvilinearPolygon{T}, e)
 convert(::Type{GeometryEntity{T}}, e::CurvilinearPolygon{T}) where {T} = e
+convert(::Type{CurvilinearPolygon{T}}, e::CurvilinearPolygon{T}) where {T} = e
 function convert(::Type{CurvilinearPolygon{T}}, e::CurvilinearPolygon{S}) where {T, S}
     return CurvilinearPolygon{T}(
         convert(Vector{Point{T}}, e.p),
-        e.curves,
-        e.curve_start_idx
+        [convert(Paths.Segment{T}, c) for c in e.curves],
+        copy(e.curve_start_idx)
     )
 end
 
@@ -210,6 +211,7 @@ end
 convert(::Type{GeometryEntity{T}}, e::CurvilinearRegion) where {T} =
     convert(CurvilinearRegion{T}, e)
 convert(::Type{GeometryEntity{T}}, e::CurvilinearRegion{T}) where {T} = e
+convert(::Type{CurvilinearRegion{T}}, e::CurvilinearRegion{T}) where {T} = e
 function convert(::Type{CurvilinearRegion{T}}, e::CurvilinearRegion{S}) where {T, S}
     return CurvilinearRegion{T}(
         convert(CurvilinearPolygon{T}, e.exterior),

--- a/src/polygons.jl
+++ b/src/polygons.jl
@@ -524,11 +524,11 @@ end
 """
     perimeter(poly::ClippedPolygon)
 
-The (Euclidean) perimeter of the outermost contour of a `ClippedPolygon`
+The (Euclidean) perimeter of the outermost contours of a `ClippedPolygon`.
 """
 function perimeter(p::ClippedPolygon{T}) where {T}
     isempty(p.tree.children) && return zero(T)
-    return sum(norm.(points(p[1]) .- circshift(points(p[1]), -1)))
+    return sum([sum(norm.(points(c) .- circshift(points(c), -1))) for c in p.tree.children])
 end
 
 """

--- a/src/polygons.jl
+++ b/src/polygons.jl
@@ -378,6 +378,7 @@ function to_polygons(p::ClippedPolygon{Int})
     return interiorcuts(p.tree, Polygon{Int}[])
 end
 function to_polygons(p::ClippedPolygon{T}; kwargs...) where {T}
+    isempty(p.tree.children) && return Polygon{T}[]
     pc = clipperize(p)
     S = typeof(pc).parameters[1]
     pci = recast(Clipper.PolyNode{Point{Int64}}, pc.tree)
@@ -525,7 +526,8 @@ end
 
 The (Euclidean) perimeter of the outermost contour of a `ClippedPolygon`
 """
-function perimeter(p::ClippedPolygon)
+function perimeter(p::ClippedPolygon{T}) where {T}
+    isempty(p.tree.children) && return zero(T)
     return sum(norm.(points(p[1]) .- circshift(points(p[1]), -1)))
 end
 
@@ -681,7 +683,8 @@ function transform(sty::Rounded{T}, f::Transformation) where {T}
         min_side_len=mag(f) * sty.min_side_len,
         min_angle=sty.min_angle,
         p0=f.(sty.p0),
-        inverse_selection=sty.inverse_selection
+        inverse_selection=sty.inverse_selection,
+        selection_tolerance=mag(f) * sty.selection_tolerance
     )
 end
 
@@ -1377,6 +1380,7 @@ declipperize(p, ::Type{T}) where {T <: Union{Int64, Unitful.Quantity{Int64}}} =
 
 # Prepare a ClippedPolygon for use with Clipper.
 function clipperize(p::ClippedPolygon)
+    isempty(p.tree.children) && return p
     R = typeof(clipperize(p.tree.children[1].contour[1]))
     t = deepcopy(p.tree)
     function prescale(p::Clipper.PolyNode)

--- a/src/schematics/ExamplePDK/components/Transmons/Transmons.jl
+++ b/src/schematics/ExamplePDK/components/Transmons/Transmons.jl
@@ -206,7 +206,7 @@ Transmon component with a rectangular island acting as a shunt capacitor across 
 
 # Parameters
 
-  - `name = "island"`: Name of component
+  - `name = "tr"`: Name of component
   - `jj_template = ExampleSimpleJunction()`: Template to generate JJ or SQUID,
     where `name` and `h_ground_island` will be overridden
   - `cap_width = 24μm`: The width of the rectangular island

--- a/src/schematics/ExamplePDK/utils.jl
+++ b/src/schematics/ExamplePDK/utils.jl
@@ -78,7 +78,7 @@ function bridge_geometry(style::Paths.SimpleCPW)
 end
 
 """
-    add_bridges!(schematic, bridge=FEEDLINE_BRIDGE; spacing=200μm, margin=50μm)
+    add_bridges!(schematic, bridge=FEEDLINE_BRIDGE; spacing=500μm, margin=50μm)
 
 Example utility for adding bridges. Not optimized for microwave properties.
 

--- a/test/test_bspline.jl
+++ b/test/test_bspline.jl
@@ -353,7 +353,7 @@ end
 
     ### Unbounded optimization (issue #135)
     pa = Path(Point(-5.8, 3.9)mm, α0=-90°)
-    @test_warn "increasing speed without bound" bspline!(
+    @test_logs (:warn, r"increasing speed without bound") bspline!(
         pa,
         [Point(-0.55, 1.8)mm],
         180°,

--- a/test/test_clipping.jl
+++ b/test/test_clipping.jl
@@ -524,6 +524,14 @@
         @test union2d(p1, cs => :test) == union2d([p1, p2])
         @test union2d(p1, [cs => :test]) == union2d([p1, p2])
     end
+
+    @testset "Polygon methods" begin
+        r1 = Rectangle(1, 1)
+        empty_poly = difference2d(r1, r1)
+        @test iszero(perimeter(empty_poly))
+        multi_poly = union2d(r1, r1 + Point(3, 0))
+        @test perimeter(multi_poly) == 8
+    end
 end
 
 @testitem "Polygon offsetting" setup = [CommonTestSetup] begin

--- a/test/test_pathstyles.jl
+++ b/test/test_pathstyles.jl
@@ -181,7 +181,7 @@ end
     pa = Path()
     straight!(pa, 10μm, Paths.Trace(1μm))
     straight!(pa, 10μm, Paths.Trace(27μm))
-    @test_warn "taper length" Paths.round_trace_transitions!(pa; radius=10μm)
+    @test_logs (:warn, r"taper length") Paths.round_trace_transitions!(pa; radius=10μm)
 
     # Rounding of TaperTrace
     pa = Path()

--- a/test/test_render.jl
+++ b/test/test_render.jl
@@ -53,7 +53,7 @@ end
         simplify!(pa)
         attach!(pa, cref, range(0μm, stop=pathlength(pa), length=3))
         render!(c, pa)
-        @test_warn "Ignoring attachments" render!.(c, pa, GDSMeta())
+        @test_logs (:warn, r"Ignoring attachments") render!.(c, pa, GDSMeta())
         @test transformation(pa["sub", 2]) ≈ transformation(refs(pa)[2])
 
         @test isempty(c.elements)
@@ -131,7 +131,7 @@ end
         attach!(ro, c2ref, pathlength(ro))
         render!(c, ro)
         @test transformation(ro, c2ref) == ScaledIsometry(p1(ro), α1(ro))
-        @test_warn "Ignoring attachments" render!.(c, ro)
+        @test_logs (:warn, r"Ignoring attachments") render!.(c, ro)
         # === End Issue 13 ===
 
         # === Issue 51 ===


### PR DESCRIPTION
`selection_tolerance` wasn't being forwarded -- the `transform` construction site was missed when that feature was added. Also fix some docstrings, missing identity conversions, and empty ClippedPolygon handling.