### PR TITLE
Repo maintenance, DOI and CITATION.cff

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union

--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: '1.10'
       - uses: julia-actions/cache@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: '1.10'
       - uses: julia-actions/cache@v3
@@ -59,7 +59,7 @@ jobs:
       - run: |
           pip install -r requirements.txt
           export PYTHON=$(which python3)
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}

--- a/.github/workflows/CompatHelper.yaml
+++ b/.github/workflows/CompatHelper.yaml
@@ -15,7 +15,7 @@ jobs:
         run: which julia
         continue-on-error: true
       - name: Install Julia, but only if it is not already available in the PATH
-        uses: julia-actions/setup-julia@v2
+        uses: julia-actions/setup-julia@v3
         with:
           version: '1'
           arch: ${{ runner.arch }}

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
     steps:
     - uses: actions/checkout@v6
-    - uses: julia-actions/setup-julia@v2
+    - uses: julia-actions/setup-julia@v3
       with:
         version: '1.10'
     - uses: julia-actions/cache@v3

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,35 @@
+abstract: <p>A Julia package for computer-aided design of quantum integrated circuits</p>
+authors:
+- affiliation: Amazon Center for Quantum Computing
+  family-names: Peairs
+  given-names: Gregory
+  orcid: 0000-0001-9958-9975
+- affiliation: Amazon Center for Quantum Computing
+  family-names: Carson
+  given-names: Hugh
+  orcid: 0000-0003-1221-4850
+- affiliation: Amazon Center for Quantum Computing
+  family-names: Arrangoiz-Arriola
+  given-names: Patricio
+- affiliation: Amazon Center for Quantum Computing
+  family-names: Ghaffari
+  given-names: Layla
+- affiliation: Amazon Center for Quantum Computing
+  family-names: Lapointe
+  given-names: Simon
+- affiliation: Amazon Center for Quantum Computing
+  family-names: Keller
+  given-names: Andrew
+  orcid: 0000-0003-3030-1149
+cff-version: 1.2.0
+date-released: '2025-02-28'
+doi: 10.5281/zenodo.19849070
+identifiers:
+- type: swh
+  value: swh:1:dir:496179643596ecb4ccbe2140531bfc5665dc0cdd;origin=https://doi.org/10.5281/zenodo.19849069;visit=swh:1:snp:d0a433665de07a6d4591fa016bcefd5e5475592e;anchor=swh:1:rel:b50cc0e4ab53e4a5ffad5800fbd8c533b3dc5472;path=DeviceLayout.jl-1.13.0
+license:
+- mit
+message: If you use this software, please cite it using the metadata from this file.
+title: DeviceLayout.jl
+type: software
+version: 1.13.0

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![CI](https://github.com/aws-cqc/DeviceLayout.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/aws-cqc/DeviceLayout.jl/actions/workflows/CI.yml)
 [![Aqua](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 [![codecov](https://codecov.io/gh/aws-cqc/DeviceLayout.jl/graph/badge.svg?token=D3EQ7I4LP0)](https://codecov.io/gh/aws-cqc/DeviceLayout.jl)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19849070.svg)](https://doi.org/10.5281/zenodo.19849070)
 
 DeviceLayout.jl is a [Julia](http://julialang.org) package for computer-aided design (CAD) of quantum integrated circuits, developed at the AWS Center for Quantum Computing. The package supports 
 

--- a/docs/src/concepts/paths.md
+++ b/docs/src/concepts/paths.md
@@ -168,7 +168,7 @@ For now, one intersection style is implemented, but the heavy-lifting to add mor
 done already. Here's an example (consult the [Intersection API reference](@ref api-path-intersection) for further information):
 
 ```@example 1
-pa1 = Path(μm)
+pa1 = Path()
 turn!(pa1, -360°, 100μm, Paths.CPW(10μm, 6μm))
 pa2 = Path(Point(0, 100)μm, α0=-90°)
 straight!(pa2, 400μm, Paths.CPW(10μm, 6μm))

--- a/docs/src/concepts/polygons.md
+++ b/docs/src/concepts/polygons.md
@@ -85,7 +85,7 @@ rounding at the transitions.
 
 #### Selecting line-arc corners
 
-[`line_arc_cornerindices`](@ref) identifies vertices where a straight edge meets a curve.
+[`Curvilinear.line_arc_cornerindices`](@ref) identifies vertices where a straight edge meets a curve.
 This is useful for components that need to round only arc-to-straight transitions while leaving other corners sharp:
 
 ```julia

--- a/docs/src/reference/api.md
+++ b/docs/src/reference/api.md
@@ -183,7 +183,7 @@
     xor2d
     xor2d_layerwise
     clip
-    clip_tiled
+    Polygons.clip_tiled
     Polygons.StyleDict
 ```
 

--- a/src/clipping.jl
+++ b/src/clipping.jl
@@ -792,7 +792,7 @@ for func in ("union2d", "difference2d", "intersect2d", "xor2d")
 
     Return a `Dict` of `meta => [$(func)(obj => meta, tool => meta)]` for each unique element metadata `meta` in `obj` and `tool`.
 
-    Entities with metadata matching `only_layers` or `ignore_layers` are included or excluded based on [`layer_inclusion`](@ref).
+    Entities with metadata matching `only_layers` or `ignore_layers` are included or excluded based on [`layer_inclusion`](@ref DeviceLayout.layer_inclusion).
 
     Entities in references up to a depth of `depth` are included, where `depth=0` uses only top-level entities in `obj` and `tool`.
     Depth is unlimited by default.


### PR DESCRIPTION
Add DOI badge for Zenodo record and CITATION.cff for standardized citations. Also bump setup-julia action, add .gitattributes to make merging changelogs easier, and fix minor issues in docs build.