### PR TITLE
Fix Path intersections on mixed coordinate contexts

### DIFF
--- a/src/intersect.jl
+++ b/src/intersect.jl
@@ -97,7 +97,11 @@ function intersect_segment_tree(tree1::SegmentTree{T}, tree2::SegmentTree{T}) wh
 end
 
 function intersections(paths::Path...)
-    tree = segment_tree(paths...)
+    # Promote all paths to common coordinate type (fixes mixed-context dispatch on segment_tree).
+    # Dimension mismatch (e.g., Length vs Angle) will throw via promote_type.
+    T_common = promote_type(map(DeviceLayout.coordinatetype, paths)...)
+    paths_promoted = map(p -> convert(Path{T_common}, p), paths)
+    tree = segment_tree(paths_promoted...)
     return intersect_segment_tree(tree, tree)
 end
 

--- a/test/test_intersection.jl
+++ b/test/test_intersection.jl
@@ -81,4 +81,15 @@
     @test pathlength_nearest(turn, Point(1, -0.9)) ≈ 3π / 2
     @test pathlength_nearest(turn, Point(0.9, -2)) ≈ 0
     @test pathlength_nearest(turn, Point(-1, 1)) ≈ 3π / 4
+
+    @testset "mixed coordinate contexts (issue #212)" begin
+        pa1 = Path(μm)  # μm-context
+        Paths.turn!(pa1, -360°, 100μm, Paths.CPW(10μm, 6μm))
+        pa2 = Path(Point(0, 100)μm, α0=-90°)  # nm-context (preferred)
+        Paths.straight!(pa2, 400μm, Paths.CPW(10μm, 6μm))
+        Paths.turn!(pa2, 270°, 200μm)
+        Paths.straight!(pa2, 400μm)
+        # Should not throw MethodError on mixed coordinate contexts
+        @test Intersect.intersections(pa1, pa2) isa Vector
+    end
 end


### PR DESCRIPTION
Close #212. After PR #185, Path(μm) and Path(Point(0,100)μm) produce different coordinate-context types for the same nominal unit -- the former keeps μm FreeUnits as-passed, while the latter normalizes via `_preferred_coordinatetype` to nm ContextUnits (for consistency with Cell/CoordinateSystem's lack of constructors with implicit coordinate type -- usually you want all your structures to match, so the implicit coordinatetype from `p0` was unwanted much more often than wanted). `Intersect.intersections(...)` dispatches to `segment_tree(paths::Path{T}...) where {T}`, whose type constraint requires all paths to share `T`. Mixed contexts fail with a MethodError, breaking the docs example at docs/src/concepts/paths.md:170 and surfacing as a docs CI warning.

Fix by promoting all inputs to a common coordinate type at the `intersections` entry point, using `DeviceLayout.coordinatetype`. Adds a regression test in test/test_intersection.jl that reproduces the failing docs example.
