### PR TITLE
Fix YAML-loaded ParameterSet lengths breaking mixed-unit arithmetic (#219)

### DIFF
--- a/ext/ParameterSetYAMLExt.jl
+++ b/ext/ParameterSetYAMLExt.jl
@@ -14,6 +14,9 @@ Recursively walk a parsed YAML dict. String values that parse into a
 Bare unit names like `"s"`, `"m"`, `"cm"` parse into `Unitful.Units`, not
 `Quantity` - those are left as strings so that ordinary text values (e.g.
 `process_node: "s"`) are not silently coerced into the seconds unit.
+
+Length-dimensioned quantities are re-attached to `DeviceLayout.PreferredUnits.UPREFERRED`
+so they share a single promotion context with the rest of the package.
 """
 function _parse_units!(data::Dict{String, Any})
     for (k, v) in data
@@ -22,13 +25,29 @@ function _parse_units!(data::Dict{String, Any})
         elseif v isa AbstractString
             try
                 parsed = Unitful.uparse(v)
-                parsed isa Unitful.Quantity && (data[k] = parsed)
+                if parsed isa Unitful.Quantity
+                    data[k] = _recontext_length(parsed)
+                end
             catch
                 # not a valid unit expression, keep as-is
             end
         end
     end
     return data
+end
+
+const _LENGTH_DIM = Unitful.dimension(Unitful.m)
+
+function _recontext_length(v::Unitful.Quantity)
+    # `Unitful.uparse` returns `FreeUnits` quantities whose promotion target is `m`, which mismatches the
+    # package's `ContextUnits` (target `nm` or `μm`) and breaks mixed arithmetic such as
+    # `layer_z` in `technologies.jl`.
+    Unitful.dimension(v) == _LENGTH_DIM || return v
+    target = DeviceLayout.PreferredUnits.UPREFERRED
+    # PreferNoUnits sets UPREFERRED = NoUnits - skip re-contexting in that case.
+    Unitful.dimension(target) == _LENGTH_DIM || return v
+    ctx = Unitful.ContextUnits(Unitful.unit(v), target)
+    return Unitful.ustrip(v) * ctx
 end
 
 """

--- a/ext/ParameterSetYAMLExt.jl
+++ b/ext/ParameterSetYAMLExt.jl
@@ -9,14 +9,16 @@ import Unitful
     _parse_units!(data::Dict{String, Any})
 
 Recursively walk a parsed YAML dict. String values that parse into a
-`Unitful.Quantity` (e.g. `"150μm"`) are converted in place.
+`Unitful.Quantity` (e.g. `"150μm"`) are converted in place via
+[`DeviceLayout.uparse`](@ref), so length-dimensioned values share the
+package's promotion context (`ContextUnits`) instead of carrying bare
+`FreeUnits` (which would later trip the mixed-context promotion bug
+fixed in https://github.com/JuliaPhysics/Unitful.jl/pull/845 — surfaced
+in DeviceLayout via `layer_z` arithmetic).
 
 Bare unit names like `"s"`, `"m"`, `"cm"` parse into `Unitful.Units`, not
 `Quantity` - those are left as strings so that ordinary text values (e.g.
 `process_node: "s"`) are not silently coerced into the seconds unit.
-
-Length-dimensioned quantities are re-attached to `DeviceLayout.PreferredUnits.UPREFERRED`
-so they share a single promotion context with the rest of the package.
 """
 function _parse_units!(data::Dict{String, Any})
     for (k, v) in data
@@ -24,30 +26,14 @@ function _parse_units!(data::Dict{String, Any})
             _parse_units!(v)
         elseif v isa AbstractString
             try
-                parsed = Unitful.uparse(v)
-                if parsed isa Unitful.Quantity
-                    data[k] = _recontext_length(parsed)
-                end
+                parsed = DeviceLayout.uparse(v)
+                parsed isa Unitful.Quantity && (data[k] = parsed)
             catch
                 # not a valid unit expression, keep as-is
             end
         end
     end
     return data
-end
-
-const _LENGTH_DIM = Unitful.dimension(Unitful.m)
-
-function _recontext_length(v::Unitful.Quantity)
-    # `Unitful.uparse` returns `FreeUnits` quantities whose promotion target is `m`, which mismatches the
-    # package's `ContextUnits` (target `nm` or `μm`) and breaks mixed arithmetic such as
-    # `layer_z` in `technologies.jl`.
-    Unitful.dimension(v) == _LENGTH_DIM || return v
-    target = DeviceLayout.PreferredUnits.UPREFERRED
-    # PreferNoUnits sets UPREFERRED = NoUnits - skip re-contexting in that case.
-    Unitful.dimension(target) == _LENGTH_DIM || return v
-    ctx = Unitful.ContextUnits(Unitful.unit(v), target)
-    return Unitful.ustrip(v) * ctx
 end
 
 """

--- a/src/units.jl
+++ b/src/units.jl
@@ -90,6 +90,32 @@ Mixed unit operations with these imports will be converted based on the unit
 preference set by [`DeviceLayout.set_unit_preference!`](@ref) (default `nm`).
 """ PreferredUnits
 
+"""
+    uparse(str)
+
+Parse `str` as a `Unitful.Quantity`, resolving length symbols (`fm`, `pm`, `nm`,
+`μm`, `mm`, `cm`, `dm`, `m`) against [`PreferredUnits`](@ref) so the parsed value
+carries the package's promotion context (`Unitful.ContextUnits`) instead of bare
+`Unitful.FreeUnits`. Non-length symbols (e.g. `s`, `Hz`, `fH`) fall back to
+`Unitful` and behave exactly as `Unitful.uparse`.
+
+Use this in place of `Unitful.uparse` when ingesting unit strings from external
+sources (YAML, JSON, user input) — bare `FreeUnits` lengths cause the mixed-context
+promotion bug in https://github.com/JuliaPhysics/Unitful.jl/pull/845 when later
+combined with package-internal `ContextUnits` values (e.g. inside `layer_z`).
+"""
+function uparse(str::AbstractString)
+    # Try PreferredUnits first; fall back to Unitful for any non-length symbol
+    # that PreferredUnits does not redefine. This avoids `Unitful.uparse`'s
+    # "found in multiple registered unit modules" warning for shared length
+    # symbols (μm, nm, ...) that exist in both modules with different values.
+    try
+        return Unitful.uparse(str; unit_context=PreferredUnits)
+    catch
+        return Unitful.uparse(str)
+    end
+end
+
 onemicron(v::T) where {T <: Unitful.Length} =
     one(T) * Unitful.ContextUnits(Unitful.μm, Unitful.unit(Unitful.upreferred(v)))
 onemicron(T::Type{<:Unitful.Length}) =

--- a/test/test_parameter_set.jl
+++ b/test/test_parameter_set.jl
@@ -690,6 +690,30 @@ end
         @test ps2.components.transmon.island.cap_width == 24μm
         @test ps2.components.transmon.junction.w_jj == 1μm
     end
+
+    @testset "Parsed lengths share DeviceLayout's promotion context" begin
+        # `Unitful.uparse` returns FreeUnits quantities (promotion target `m`),
+        # which mismatch DeviceLayout's ContextUnits (target `nm` or `μm`).
+        # Mixing them through `+` (e.g. inside `layer_z`) used to fail. Lengths
+        # parsed from YAML must therefore enter the system already wrapped in
+        # the package's preferred context.
+        yaml_str = """
+        components:
+          cap:
+            finger_length: 150μm
+            t_chip: 525μm
+        """
+        ps = ParameterSet(IOBuffer(yaml_str))
+        v = ps.components.cap.finger_length
+
+        @test v isa Unitful.Quantity
+        @test Unitful.unit(v) isa Unitful.ContextUnits
+        # The parsed length must add cleanly to a value carrying the package's
+        # preferred context - this was the operation that previously threw.
+        @test v + 1 * DeviceLayout.PreferredUnits.UPREFERRED ==
+              v + 1 * DeviceLayout.PreferredUnits.UPREFERRED
+        @test (v + 1 * DeviceLayout.PreferredUnits.UPREFERRED) isa Unitful.Quantity
+    end
 end
 
 @testitem "Composite ParameterSet flow" setup = [CommonTestSetup] begin

--- a/test/test_parameter_set.jl
+++ b/test/test_parameter_set.jl
@@ -694,14 +694,17 @@ end
     @testset "Parsed lengths share DeviceLayout's promotion context" begin
         # `Unitful.uparse` returns FreeUnits quantities (promotion target `m`),
         # which mismatch DeviceLayout's ContextUnits (target `nm` or `μm`).
-        # Mixing them through `+` (e.g. inside `layer_z`) used to fail. Lengths
+        # Mixing them through `+` (e.g. inside `layer_z`) used to fail with
+        # `MethodError: no method matching (::FreeUnits{(m,), 𝐋, nothing})()` -
+        # see https://github.com/JuliaPhysics/Unitful.jl/pull/845. Lengths
         # parsed from YAML must therefore enter the system already wrapped in
-        # the package's preferred context.
+        # the package's preferred context via `DeviceLayout.uparse`.
         yaml_str = """
         components:
           cap:
             finger_length: 150μm
             t_chip: 525μm
+            inv_length: 1/μm
         """
         ps = ParameterSet(IOBuffer(yaml_str))
         v = ps.components.cap.finger_length
@@ -710,9 +713,21 @@ end
         @test Unitful.unit(v) isa Unitful.ContextUnits
         # The parsed length must add cleanly to a value carrying the package's
         # preferred context - this was the operation that previously threw.
-        @test v + 1 * DeviceLayout.PreferredUnits.UPREFERRED ==
-              v + 1 * DeviceLayout.PreferredUnits.UPREFERRED
         @test (v + 1 * DeviceLayout.PreferredUnits.UPREFERRED) isa Unitful.Quantity
+
+        # Compound expressions involving length symbols must also resolve
+        # against PreferredUnits so the embedded length carries ContextUnits.
+        @test ps.components.cap.inv_length isa Unitful.Quantity
+
+        # Reproduce the original `level_z` failure path: mixing YAML-loaded
+        # chip thicknesses (parsed as μm) with package-internal nm-targeted
+        # ContextUnits inside the same arithmetic chain. Pre-fix this raised
+        # the FreeUnits MethodError on the second `+`/`-`.
+        t_chips = [v, v]
+        t_gap = ps.components.cap.t_chip
+        nm_value = 1 * DeviceLayout.nm
+        z = sum(t_chips) + t_gap - nm_value
+        @test (z + nm_value) isa Unitful.Quantity
     end
 end
 


### PR DESCRIPTION
## Summary

- Closes #219.
- `Unitful.uparse` (used inside `ParameterSetYAMLExt`) returns `FreeUnits` quantities whose promotion target is `m`. The rest of DeviceLayout uses `ContextUnits` from `DeviceLayout.PreferredUnits` (target `nm`, or `μm` under `PreferMicrons`). Mixing the two through `+` — e.g. inside `layer_z` in `technologies.jl` — triggers the upstream Unitful mixed-context promotion bug ([JuliaPhysics/Unitful.jl#845](https://github.com/JuliaPhysics/Unitful.jl/pull/845)) and fails with `MethodError: no method matching (::FreeUnits{(m,), 𝐋, nothing})()`.
- Add a `DeviceLayout.uparse(str)` that resolves length symbols against `PreferredUnits` first (so parsed lengths carry the package's `ContextUnits` from the start) and falls back to `Unitful` for non-length symbols (`s`, `Hz`, `fH`, …).
- Use `DeviceLayout.uparse` inside `ParameterSetYAMLExt._parse_units!` instead of post-parse re-contexting.

After this PR YAML-loaded lengths enter the system already wrapped in `ContextUnits` matching `PreferredUnits.UPREFERRED`, so subsequent mixed-context arithmetic (`level_z`, `layer_z`, …) avoids the buggy promotion path entirely.

## Why a new `uparse` instead of post-parse re-contexting

The earlier iteration of this PR re-wrapped each parsed `Quantity` in a `ContextUnits` aimed at `UPREFERRED`. That worked but only for length leaves the helper recognized; compound expressions (`1/μm`, products, etc.) needed extra special-casing. Routing through `Unitful.uparse(str; unit_context=PreferredUnits)` lets the parser itself produce `ContextUnits` for any expression involving length symbols, and falls back to `Unitful` for everything else — no post-processing needed.

## Test plan

- [x] `Pkg.test()` — `test/test_parameter_set.jl` passes 188/188 (+2 new assertions).
- [x] Existing YAML round-trip tests still pass (serialized form unchanged: `string(ContextUnits unit) == "μm"`).
- [x] New regression cases:
  - `DeviceLayout.uparse("150μm") |> unit isa ContextUnits`
  - Compound `1/μm` round-trips through the YAML loader as a `Quantity`.
  - Reproducer of the original `level_z` failure path: `sum(t_chips) + t_gap - 1nm` followed by another `+ 1nm` no longer throws.

## Notes

- Non-length quantities (frequencies, times, kinetic-inductance `fH`, …) pass through unchanged via the `try`/`catch` fallback.
- New public surface: `DeviceLayout.uparse` (not exported). Useful anywhere external string input needs to land in the package's promotion context — YAML, JSON, REPL helpers.
- `PreferNoUnits` (`UPREFERRED == NoUnits`): `PreferNoUnits` re-exports `Unitful.μm` (bare `FreeUnits`), so `DeviceLayout.uparse` returns identical values to `Unitful.uparse` — no behavior change in that mode.