### PR TITLE
Rework set_parameters API and add templates-aliasing pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ The format of this changelog is based on
     through `_build_subcomponents` via `parameter_set(graph)` and
     `create_component(T, ps, address)`
   - Fixed incorrect loading of GDS array references with nonzero origin
+  - Added `set_parameters(c, ps, address; kwargs...)` and the scoped form
+    `set_parameters(c, sub::ParameterSet)` for the templates-aliasing pattern:
+    overlay `ParameterSet` leaves on top of a template instance, with optional
+    composite-level kwargs winning over the overlay. Unknown leaves under the
+    address surface as `ArgumentError` at composite-build time
+  - `create_component(T; kwargs...)` now rejects `MissingNamespace` and
+    `ParameterSet` kwarg values with actionable errors at the call site,
+    rather than letting them flow into the constructor
 
 ## 1.13.0 (2026-04-28)
 

--- a/docs/src/concepts/styleguide.md
+++ b/docs/src/concepts/styleguide.md
@@ -195,16 +195,16 @@ end
 Example with templates and `ParameterSet` (alternative to `filter_parameters`):
 
 ```julia
+@compdef struct MySubComponent <: Component
+    width = 1mm
+    length = 2mm
+end
+
 @compdef struct MyCompositeComponent <: CompositeComponent
     templates = (;
         subcomp1=MySubComponent(; name="subcomp1"),
         subcomp2=MySubComponent(; name="subcomp2")
     )
-    length = 2mm
-end
-
-@compdef struct MySubComponent <: Component
-    width = 1mm
     length = 2mm
 end
 
@@ -222,12 +222,12 @@ function SchematicDrivenLayout._build_subcomponents(cc::MyCompositeComponent)
 end
 ```
 
-The two patterns differ in where per-subcomponent values live:
+The two patterns differ in where per-subcomponent values live and how typos are surfaced:
 
-  - `filter_parameters` keeps shared and prefixed pass-through values as fields on the composite struct, so the composite is the single source of truth for both shared and per-subcomponent overrides.
-  - Templates-aliasing externalizes per-subcomponent values to the `ParameterSet` (addressed by the subcomponent's path) and reserves the composite struct for parameters it actually needs to reconcile or override. The composite no longer carries a `subcomp1_width`-style field for every pass-through value.
+  - `filter_parameters` keeps shared and prefixed pass-through values as fields on the composite struct, so the composite is the single source of truth for both shared and per-subcomponent overrides. Typos in pass-through field names fail at the composite-construction call site.
+  - Templates-aliasing externalizes per-subcomponent values to the `ParameterSet` (addressed by the subcomponent's path) and reserves the composite struct for parameters it actually needs to reconcile or override. The composite no longer carries a `subcomp1_width`-style field for every pass-through value. Typos in `ParameterSet` leaf names — under a subcomponent's namespace — surface as an `ArgumentError` at composite-build time, naming both the unknown leaf and the valid parameters of that subcomponent type.
 
-Precedence under templates-aliasing is `template defaults < ParameterSet overlay < trailing composite kwargs`, so composite invariants (the trailing `set_parameters(subcomp1; length=cc.length)` above) always win over `ParameterSet` contents.
+Precedence under templates-aliasing is `template defaults < ParameterSet overlay < trailing composite kwargs`, so composite invariants (the trailing `length=cc.length` kwarg) always win over `ParameterSet` contents.
 
 ### Other special cases
 

--- a/docs/src/concepts/styleguide.md
+++ b/docs/src/concepts/styleguide.md
@@ -134,6 +134,11 @@ In more detail:
       + If the parameter is inherited by multiple subcomponents, use the same name as in the subcomponents
       + If the parameter is used for one specific subcomponent, add prefix for the subcomponent
       + Use [`SchematicDrivenLayout.filter_parameters`](@ref) to get a collection of either kind of shared parameters
+      + Alternatively, store per-subcomponent parameters in a [`ParameterSet`](@ref SchematicDrivenLayout.ParameterSet)
+        addressed by the subcomponent's path and overlay them onto a template via
+        [`set_parameters(c, ps, address)`](@ref SchematicDrivenLayout.set_parameters); this avoids declaring a
+        pass-through field on the composite for every forwarded value (see the
+        [templates-aliasing tutorial](../tutorials/parameter_set.md#Templates-Aliasing-for-Composite-Subcomponents))
 
   - If you have a large number of parameters to pass through to a subcomponent, or want to maintain
     flexibility over parameters that are not usually important, use a `templates` NamedTuple parameter
@@ -142,6 +147,13 @@ In more detail:
         (with the subcomponent name as the key) that provides defaults
       + Parameters you’d often want to override or reconcile with other parameters are set at
         the CompositeComponent parameter level
+      + As an alternative to `filter_parameters` for forwarding subcomponent parameters, overlay a
+        [`ParameterSet`](@ref SchematicDrivenLayout.ParameterSet) onto each template via
+        [`set_parameters(c, ps, address)`](@ref SchematicDrivenLayout.set_parameters). This keeps the
+        composite struct free of pass-through fields and externalizes per-subcomponent values to the
+        `ParameterSet`. See the
+        [Templates-Aliasing section of the ParameterSet tutorial](../tutorials/parameter_set.md#Templates-Aliasing-for-Composite-Subcomponents)
+        for the full pattern.
 
 Example of template usage in `_build_subcomponents`:
 
@@ -179,6 +191,43 @@ function SchematicDrivenLayout._build_subcomponents(cc::MyCompositeComponent)
     return (subcomp1, subcomp2)
 end
 ```
+
+Example with templates and `ParameterSet` (alternative to `filter_parameters`):
+
+```julia
+@compdef struct MyCompositeComponent <: CompositeComponent
+    templates = (;
+        subcomp1=MySubComponent(; name="subcomp1"),
+        subcomp2=MySubComponent(; name="subcomp2")
+    )
+    length = 2mm
+end
+
+@compdef struct MySubComponent <: Component
+    width = 1mm
+    length = 2mm
+end
+
+function SchematicDrivenLayout._build_subcomponents(cc::MyCompositeComponent)
+    ps = parameter_set(cc._graph)
+    # ParameterSet leaves at `components.<cc>.subcompN` overlay each template;
+    # trailing kwargs are composite-level overrides that win over the ParameterSet.
+    subcomp1 = set_parameters(
+        cc.templates.subcomp1, ps, "components.$(name(cc)).subcomp1"; length=cc.length,
+    )
+    subcomp2 = set_parameters(
+        cc.templates.subcomp2, ps, "components.$(name(cc)).subcomp2"; length=cc.length,
+    )
+    return (subcomp1, subcomp2)
+end
+```
+
+The two patterns differ in where per-subcomponent values live:
+
+  - `filter_parameters` keeps shared and prefixed pass-through values as fields on the composite struct, so the composite is the single source of truth for both shared and per-subcomponent overrides.
+  - Templates-aliasing externalizes per-subcomponent values to the `ParameterSet` (addressed by the subcomponent's path) and reserves the composite struct for parameters it actually needs to reconcile or override. The composite no longer carries a `subcomp1_width`-style field for every pass-through value.
+
+Precedence under templates-aliasing is `template defaults < ParameterSet overlay < trailing composite kwargs`, so composite invariants (the trailing `set_parameters(subcomp1; length=cc.length)` above) always win over `ParameterSet` contents.
 
 ### Other special cases
 

--- a/docs/src/reference/parameter_set_api.md
+++ b/docs/src/reference/parameter_set_api.md
@@ -16,5 +16,6 @@ DeviceLayout.SchematicDrivenLayout.save_parameter_set
 ```@docs
 SchematicDrivenLayout.create_component(::Type{T}, ::DeviceLayout.SchematicDrivenLayout.ParameterSet, ::String) where {T <: DeviceLayout.SchematicDrivenLayout.AbstractComponent}
 SchematicDrivenLayout.create_component(::Type{T}, ::DeviceLayout.SchematicDrivenLayout.ParameterSet) where {T <: DeviceLayout.SchematicDrivenLayout.AbstractComponent}
-SchematicDrivenLayout.set_parameters(::DeviceLayout.SchematicDrivenLayout.AbstractComponent, ::Pair{<:Any, Symbol}...)
+SchematicDrivenLayout.set_parameters(::DeviceLayout.SchematicDrivenLayout.AbstractComponent, ::DeviceLayout.SchematicDrivenLayout.ParameterSet, ::String)
+SchematicDrivenLayout.set_parameters(::DeviceLayout.SchematicDrivenLayout.AbstractComponent, ::DeviceLayout.SchematicDrivenLayout.ParameterSet)
 ```

--- a/docs/src/tutorials/parameter_set.md
+++ b/docs/src/tutorials/parameter_set.md
@@ -191,7 +191,7 @@ ps.components.transmon.junction.w_jj = 1μm
 ps.components.transmon.junction.h_jj = 1μm
 ```
 
-Inside `_build_subcomponents`, use `parameter_set(g)` to access the graph's `ParameterSet`, then `create_component` to instantiate each subcomponent from its subtree. The shared `junction_gap` is read from the parameter set and forwarded to both subcomponents under their respective parameter names using the `value => :name` form of `set_parameters`:
+Inside `_build_subcomponents`, use `parameter_set(g)` to access the graph's `ParameterSet`, then `create_component` to instantiate each subcomponent from its subtree. The shared `junction_gap` is read from the parameter set and forwarded to both subcomponents under their respective parameter names using `set_parameters` kwargs:
 
 ```julia
 function SchematicDrivenLayout._build_subcomponents(tr::SimpleTransmon)
@@ -201,12 +201,13 @@ function SchematicDrivenLayout._build_subcomponents(tr::SimpleTransmon)
     # Forward shared parameter from under the parent component
     # No need to count its access here because it has been accessed
     # during the CC construction
-    island = set_parameters(island, junction_gap = tr.junction_gap)
+    island = set_parameters(island; junction_gap=tr.junction_gap)
 
     junction = create_component(ExampleSimpleJunction, ps, "components.transmon.junction")
     # Forward shared parameter from parameter set to the junction component
-    # Access to the parameter is logged, allowing PS verification
-    junction = set_parameters(junction, ps.components.transmon.junction_gap => :h_ground_island)
+    # under a different parameter name. A missing PS lookup would surface as
+    # ParameterKeyError at this call site.
+    junction = set_parameters(junction; h_ground_island=ps.components.transmon.junction_gap)
 
     return (island, junction)
 end
@@ -224,6 +225,51 @@ transmon_node = add_node!(g, transmon)
 ```
 
 The `ParameterSet` is preserved when graphs are copied — for example, inside `BasicCompositeComponent` or during `_flatten` operations. This means subcomponents at any depth can access the same parameter set.
+
+## Templates-Aliasing for Composite Subcomponents
+
+The `create_component(T, ps, address)` pattern above hardcodes the subcomponent type at each call site. A composite can instead declare its subcomponents in a `templates::NamedTuple` field — the type and any designer-chosen defaults live on the composite, and `ParameterSet` values overlay on top of the template:
+
+```julia
+@compdef struct SimpleTransmon <: CompositeComponent
+    name = "transmon"
+    junction_gap = 12μm
+    templates = (
+        island = ExampleRectangleIsland(name="island", cap_width=30μm),  # designer default
+        junction = ExampleSimpleJunction(name="junction"),
+    )
+end
+```
+
+Use the three-argument form of `set_parameters` inside `_build_subcomponents` to apply the `ParameterSet` at the subcomponent's address on top of the template. Trailing keyword arguments are composite-level overrides that win over the `ParameterSet`:
+
+```julia
+function SchematicDrivenLayout._build_subcomponents(tr::SimpleTransmon)
+    ps = parameter_set(tr._graph)
+
+    island = set_parameters(
+        tr.templates.island, ps, "components.$(name(tr)).island";
+        junction_gap=tr.junction_gap,
+    )
+
+    junction = set_parameters(
+        tr.templates.junction, ps, "components.$(name(tr)).junction";
+        h_ground_island=tr.junction_gap,
+    )
+
+    return (island, junction)
+end
+```
+
+Precedence is explicit and layered:
+
+1. **Template defaults** — whatever `tr.templates.island` was constructed with (e.g. `cap_width=30μm`).
+2. **`ParameterSet` overrides the template** — every leaf under `components.transmon.island` overwrites the matching template field.
+3. **Composite overrides the `ParameterSet`** — trailing kwargs to `set_parameters(c, ps, address; …)` always win, so composite invariants (e.g. "the island's `junction_gap` is whatever the composite decides") can never be silently undermined by `ParameterSet` contents.
+
+Typos surface early: if the `ParameterSet` carries a leaf at `components.transmon.island.fictional_param` and `ExampleRectangleIsland` has no such field, `set_parameters(tr.templates.island, ps, ...)` throws `ArgumentError` naming the unknown leaf — rather than silently ignoring it or erroring later inside the constructor.
+
+`set_parameters(c, ps, address)` also has a scoped-view sibling `set_parameters(c, ps.components.transmon.island)` for cases where the scoped `ParameterSet` is already in hand.
 
 ## Access Tracking
 

--- a/docs/src/tutorials/parameter_set.md
+++ b/docs/src/tutorials/parameter_set.md
@@ -231,7 +231,7 @@ The `ParameterSet` is preserved when graphs are copied — for example, inside `
 The `create_component(T, ps, address)` pattern above hardcodes the subcomponent type at each call site. A composite can instead declare its subcomponents in a `templates::NamedTuple` field — the type and any designer-chosen defaults live on the composite, and `ParameterSet` values overlay on top of the template:
 
 ```julia
-@compdef struct SimpleTransmon <: CompositeComponent
+@compdef struct SimpleTransmonTemplated <: CompositeComponent
     name = "transmon"
     junction_gap = 12μm
     templates = (
@@ -244,7 +244,7 @@ end
 Use the three-argument form of `set_parameters` inside `_build_subcomponents` to apply the `ParameterSet` at the subcomponent's address on top of the template. Trailing keyword arguments are composite-level overrides that win over the `ParameterSet`:
 
 ```julia
-function SchematicDrivenLayout._build_subcomponents(tr::SimpleTransmon)
+function SchematicDrivenLayout._build_subcomponents(tr::SimpleTransmonTemplated)
     ps = parameter_set(tr._graph)
 
     island = set_parameters(

--- a/src/schematics/components/components.jl
+++ b/src/schematics/components/components.jl
@@ -47,6 +47,25 @@ function create_component(
     base_parameters::NamedTuple=default_parameters(T);
     kwargs...
 ) where {T <: AbstractComponent}
+    # Surface ParameterSet-shaped values at the call site rather than silently
+    # storing them in the component and erroring later.
+    for (k, v) in kwargs
+        # Failed PS lookup (typo or stale address) — surface the qualified path.
+        v isa MissingNamespace &&
+            throw(ParameterKeyError(getfield(v, :key), _namespace_path(v)))
+        # A ParameterSet (root or scoped view) is never a valid component-field
+        # value; the user almost certainly forgot a leaf access. Templates-aliasing
+        # is the right entry point for overlaying a ParameterSet subtree.
+        v isa ParameterSet && throw(
+            ArgumentError(
+                "kwarg `$k` received a `ParameterSet`. Did you forget a leaf " *
+                "access (e.g. `ps.components.x.length` instead of `ps.components.x`)? " *
+                "To overlay an entire ParameterSet subtree onto a template, use " *
+                "`set_parameters(c, ps, address)` rather than passing the subtree " *
+                "as a kwarg."
+            )
+        )
+    end
     p = merge_recursive(base_parameters, (; name=name, pairs(kwargs)...))
     return (T)(; p...)
 end
@@ -184,28 +203,99 @@ function set_parameters(
 end
 
 """
-    set_parameters(c::AbstractComponent, pairs::Pair{<:Any, Symbol}...; kwargs...)
+    set_parameters(c::AbstractComponent, ps::ParameterSet, address::String; kwargs...)
 
-Create an instance of type `typeof(c)` with selected parameters overridden using
-reversed `value => :name` pairs. Each pair's first element is the value to assign
-and its second element is the parameter name (a `Symbol`) on the component.
-This ordering makes it natural to forward a value from one source into a parameter
-with a different name, e.g. to route `ParameterSet` entries into subcomponent fields.
+Apply `ParameterSet` leaves at `address` on top of the template instance `c`,
+optionally followed by composite-level keyword overrides.
+
+Starting from `c`'s parameters as the base, each leaf under `resolve(ps, address)`
+overrides the corresponding field. Nested namespaces below `address` are ignored —
+scope at the level whose leaves match `c`'s parameters. Any `kwargs` are then
+applied on top of the `ParameterSet` overlay, so precedence is:
+template defaults < `ParameterSet` overlay < `kwargs`.
+
+Throws `ParameterKeyError` if `address` doesn't resolve to a namespace, or if
+a `kwarg` value is a `MissingNamespace` (failed PS lookup).
+Throws `ArgumentError` listing unknown leaves if any leaf under `address` is not
+a parameter of `typeof(c)` — surfaces typos at aliasing time rather than as a
+`MethodError` inside the constructor. Also throws `ArgumentError` if a `kwarg`
+value is itself a `ParameterSet`: a subtree is never a valid component-field
+value and almost always indicates a missing leaf access.
+
+Consumed leaves are recorded in `ps.accessed` as fully qualified paths.
+
+This is the "templates-aliasing" entry point: a composite declares subcomponent
+defaults in a `templates` field, then `_build_subcomponents` overlays `ParameterSet`
+values on top of each template via this overload, optionally with trailing
+composite-level kwargs to enforce composite invariants.
 
 ```julia
-island = set_parameters(island, ps.components.transmon.junction_gap => :junction_gap)
+function _build_subcomponents(tr::MyTransmon)
+    ps = parameter_set(tr._graph)
+    island = set_parameters(
+        tr.templates.island,
+        ps,
+        "components.\$(name(tr)).island";
+        junction_gap=tr.junction_gap
+    )
+    return (island,)
+end
 ```
-
-Additional `kwargs` are forwarded to the main `set_parameters` method.
 """
-function set_parameters(c::AbstractComponent, pairs::Pair{<:Any, Symbol}...; kwargs...)
-    # Surface missing ParameterSet lookups at the call site rather than silently
-    # storing a MissingNamespace in the component and erroring later.
-    for p in pairs
-        p.first isa MissingNamespace &&
-            throw(ParameterKeyError(getfield(p.first, :key), _namespace_path(p.first)))
+function set_parameters(c::AbstractComponent, ps::ParameterSet, address::String; kwargs...)
+    sub = resolve(ps, address)
+    sub isa MissingNamespace &&
+        throw(ParameterKeyError(getfield(sub, :key), _namespace_path(sub)))
+    overlaid = set_parameters(c, sub)
+    isempty(kwargs) && return overlaid
+    return set_parameters(overlaid; kwargs...)
+end
+
+"""
+    set_parameters(c::AbstractComponent, sub::ParameterSet)
+
+Apply leaves from a scoped `ParameterSet` on top of `c`.
+
+`sub` must be a scoped view (non-empty prefix, typically reached via chained-dot
+access like `ps.components.transmon.island`). For a root `ParameterSet` use the
+address-string form instead.
+
+Throws `ArgumentError` if any leaf in `sub` is not a parameter of `typeof(c)`,
+surfacing typos in the `ParameterSet` source early.
+"""
+function set_parameters(c::AbstractComponent, sub::ParameterSet)
+    prefix = getfield(sub, :prefix)
+    isempty(prefix) && throw(
+        ArgumentError(
+            "set_parameters(c, ::ParameterSet) requires a scoped view " *
+            "(e.g. `ps.components.transmon.island`). For a root ParameterSet " *
+            "use `set_parameters(c, ps, address)` with an explicit address."
+        )
+    )
+    kw = leaf_params(sub)
+    names_c = parameter_names(typeof(c))
+    unknown = [String(k) for k in keys(kw) if !(k in names_c)]
+    if !isempty(unknown)
+        throw(
+            ArgumentError(
+                "ParameterSet at \"$prefix\" has unknown leaves for " *
+                "$(typeof(c)): $(join(unknown, ", ")). " *
+                "Valid parameters: $(join(names_c, ", "))."
+            )
+        )
     end
-    return set_parameters(c; (p.second => p.first for p in pairs)..., kwargs...)
+    accessed = getfield(sub, :accessed)
+    for k in keys(kw)
+        push!(accessed, prefix * "." * String(k))
+    end
+    return set_parameters(c; pairs(kw)...)
+end
+
+# Reached when `set_parameters(c, ps, address)` targets a path that does not exist
+# and the intermediate navigation yields a `MissingNamespace`. Surface the qualified
+# path in a `ParameterKeyError` rather than a generic `MethodError`.
+function set_parameters(::AbstractComponent, sub::MissingNamespace)
+    return throw(ParameterKeyError(getfield(sub, :key), _namespace_path(sub)))
 end
 
 Base.show(io::IO, ::MIME"text/plain", c::T) where {T <: AbstractComponent} =

--- a/src/schematics/components/components.jl
+++ b/src/schematics/components/components.jl
@@ -214,15 +214,20 @@ scope at the level whose leaves match `c`'s parameters. Any `kwargs` are then
 applied on top of the `ParameterSet` overlay, so precedence is:
 template defaults < `ParameterSet` overlay < `kwargs`.
 
-Throws `ParameterKeyError` if `address` doesn't resolve to a namespace, or if
-a `kwarg` value is a `MissingNamespace` (failed PS lookup).
-Throws `ArgumentError` listing unknown leaves if any leaf under `address` is not
-a parameter of `typeof(c)` — surfaces typos at aliasing time rather than as a
-`MethodError` inside the constructor. Also throws `ArgumentError` if a `kwarg`
-value is itself a `ParameterSet`: a subtree is never a valid component-field
-value and almost always indicates a missing leaf access.
+Throws `ParameterKeyError` if `address` doesn't resolve to anything (no such
+namespace), or if a `kwarg` value is a `MissingNamespace` (failed PS lookup).
+Throws `ArgumentError` if `address` resolves to a leaf scalar rather than a
+namespace, if any leaf under `address` is not a parameter of `typeof(c)`
+(surfaces typos at aliasing time rather than as a `MethodError` inside the
+constructor), or if a `kwarg` value is itself a `ParameterSet` (a subtree is
+never a valid component-field value and almost always indicates a missing
+leaf access).
 
-Consumed leaves are recorded in `ps.accessed` as fully qualified paths.
+Every PS leaf under `address` is recorded in `ps.accessed` as a fully qualified
+path — including leaves whose value happens to equal the template's default and
+leaves that are subsequently shadowed by a trailing `kwarg`. The audit semantics
+is "the loader read this PS leaf during build", not "this value reached the
+final component". A trailing `kwarg` that overrides a PS leaf does not unmark it.
 
 This is the "templates-aliasing" entry point: a composite declares subcomponent
 defaults in a `templates` field, then `_build_subcomponents` overlays `ParameterSet`
@@ -243,9 +248,32 @@ end
 ```
 """
 function set_parameters(c::AbstractComponent, ps::ParameterSet, address::String; kwargs...)
+    # An empty address would hand the root `ps` to the scoped form, which
+    # rejects roots with a message telling the caller to use the address-form
+    # — confusing when they just did. Reject empty addresses up front.
+    isempty(address) && throw(
+        ArgumentError(
+            "set_parameters(c, ps, address): `address` must be non-empty. " *
+            "Pass the dot-separated path to the namespace whose leaves " *
+            "match `c`'s parameters (e.g. \"components.transmon.island\")."
+        )
+    )
     sub = resolve(ps, address)
     sub isa MissingNamespace &&
         throw(ParameterKeyError(getfield(sub, :key), _namespace_path(sub)))
+    # `resolve` returns a leaf value when the address terminates at a scalar
+    # (e.g. "components.x.junction_gap"). That's never a valid argument to the
+    # scoped form below — surface it directly with an actionable message rather
+    # than letting dispatch fall through to a generic MethodError.
+    sub isa ParameterSet || throw(
+        ArgumentError(
+            "address \"$address\" resolves to a leaf value ($(typeof(sub))), " *
+            "not a ParameterSet namespace. `set_parameters(c, ps, address)` " *
+            "expects `address` to point at the namespace whose leaves match " *
+            "`c`'s parameters; pass a leaf as a kwarg instead, e.g. " *
+            "`set_parameters(c; <param>=resolve(ps, \"$address\"))`."
+        )
+    )
     overlaid = set_parameters(c, sub)
     isempty(kwargs) && return overlaid
     return set_parameters(overlaid; kwargs...)
@@ -262,6 +290,11 @@ address-string form instead.
 
 Throws `ArgumentError` if any leaf in `sub` is not a parameter of `typeof(c)`,
 surfacing typos in the `ParameterSet` source early.
+
+Every leaf in `sub` is pushed into `ps.accessed` with its qualified path, even
+when the leaf's value happens to equal the field's existing value on `c`. The
+recorded fact is "the loader read this PS leaf", not "the value differed from
+the template default".
 """
 function set_parameters(c::AbstractComponent, sub::ParameterSet)
     prefix = getfield(sub, :prefix)
@@ -291,9 +324,12 @@ function set_parameters(c::AbstractComponent, sub::ParameterSet)
     return set_parameters(c; pairs(kw)...)
 end
 
-# Reached when `set_parameters(c, ps, address)` targets a path that does not exist
-# and the intermediate navigation yields a `MissingNamespace`. Surface the qualified
-# path in a `ParameterKeyError` rather than a generic `MethodError`.
+# Reached when a caller passes a chained-dot lookup that fizzled, e.g.
+# `set_parameters(c, ps.foo.bar)` where `foo` (or any segment after) is not a
+# namespace in `ps`. The address-form `set_parameters(c, ps, address)` already
+# guards `MissingNamespace` before delegating, so this method exists as
+# defense-in-depth for the direct-invocation path. Surface the qualified path
+# in a `ParameterKeyError` rather than a generic `MethodError`.
 function set_parameters(::AbstractComponent, sub::MissingNamespace)
     return throw(ParameterKeyError(getfield(sub, :key), _namespace_path(sub)))
 end

--- a/test/test_parameter_set.jl
+++ b/test/test_parameter_set.jl
@@ -492,7 +492,7 @@ end
         @test_throws ArgumentError create_component(ExampleRectangleIsland, ps4, "")
     end
 
-    @testset "set_parameters with value => :name pairs" begin
+    @testset "set_parameters with ParameterSet-sourced kwargs" begin
         using DeviceLayout.SchematicDrivenLayout: parameters, set_parameters
         using DeviceLayout.SchematicDrivenLayout.ExamplePDK.Transmons:
             ExampleRectangleIsland
@@ -502,52 +502,47 @@ end
         ps.components.transmon.junction_gap = 15μm
 
         island = ExampleRectangleIsland()
-        # Reversed pair: value => :param_name
-        island2 =
-            set_parameters(island, ps.components.transmon.junction_gap => :junction_gap)
+        # Forwarding a PS leaf into the same-named parameter
+        island2 = set_parameters(island; junction_gap=ps.components.transmon.junction_gap)
         @test parameters(island2).junction_gap == 15μm
 
         # Forwarding a value under a different parameter name
-        island3 = set_parameters(island, ps.components.transmon.junction_gap => :cap_gap)
+        island3 = set_parameters(island; cap_gap=ps.components.transmon.junction_gap)
         @test parameters(island3).cap_gap == 15μm
         # Untouched parameters keep their previous values
         @test parameters(island3).cap_width == parameters(island).cap_width
 
-        # Multiple pairs
-        island4 = set_parameters(island, 40μm => :cap_width, 600μm => :cap_length)
+        # Multiple kwargs
+        island4 = set_parameters(island; cap_width=40μm, cap_length=600μm)
         @test parameters(island4).cap_width == 40μm
         @test parameters(island4).cap_length == 600μm
 
-        # Pairs combine with trailing kwargs (distinct keys)
-        island5 = set_parameters(island, 40μm => :cap_width; cap_length=600μm)
-        @test parameters(island5).cap_width == 40μm
-        @test parameters(island5).cap_length == 600μm
-
-        # Zero pairs is a no-op copy
+        # Zero kwargs is a no-op copy
         island6 = set_parameters(island)
         @test parameters(island6).cap_width == parameters(island).cap_width
 
         # Reading a value from the ParameterSet for forwarding records it in
-        # `accessed` with the fully qualified path - so `set_parameters` with a
-        # `value => :name` pair sourced from `ps` contributes to the audit trail.
+        # `accessed` with the fully qualified path.
         ps_audit = ParameterSet()
         ps_audit.components.transmon.junction_gap = 15μm
         @test isempty(ps_audit.accessed)
 
-        _ = set_parameters(
-            island,
-            ps_audit.components.transmon.junction_gap => :junction_gap
-        )
+        _ = set_parameters(island; junction_gap=ps_audit.components.transmon.junction_gap)
         @test "components.transmon.junction_gap" in ps_audit.accessed
 
-        # Forwarding a MissingNamespace (lookup in the ParameterSet failed) must
+        # Passing a MissingNamespace (PS lookup failed) as a kwarg value must
         # throw ParameterKeyError at the set_parameters call site, not silently
         # store the MissingNamespace as the component's parameter value.
         using DeviceLayout.SchematicDrivenLayout: ParameterKeyError
         ps_missing = ParameterSet()
         @test_throws ParameterKeyError("junction_gap", "components.transmon.junction_gap") set_parameters(
-            island,
-            ps_missing.components.transmon.junction_gap => :junction_gap
+            island;
+            junction_gap=ps_missing.components.transmon.junction_gap
+        )
+        # Same guard fires when calling `create_component` directly.
+        @test_throws ParameterKeyError("junction_gap", "components.transmon.junction_gap") create_component(
+            ExampleRectangleIsland;
+            junction_gap=ps_missing.components.transmon.junction_gap
         )
     end
 end
@@ -758,7 +753,7 @@ end
             ps,
             "components.ps_flow_transmon.junction"
         )
-        junction = set_parameters(junction, tr.junction_gap => :h_ground_island)
+        junction = set_parameters(junction; h_ground_island=tr.junction_gap)
         return (island, junction)
     end
 
@@ -842,5 +837,230 @@ end
             PSFlowTestTransmon,
             ps.components.ps_flow_transmon
         )
+    end
+end
+
+@testitem "set_parameters with template + ParameterSet" setup = [CommonTestSetup] begin
+    using .SchematicDrivenLayout
+    import .SchematicDrivenLayout:
+        ParameterSet, ParameterKeyError, parameter_set, parameters, set_parameters
+    using DeviceLayout.SchematicDrivenLayout.ExamplePDK.Transmons: ExampleRectangleIsland
+    using DeviceLayout.SchematicDrivenLayout.ExamplePDK.SimpleJunctions:
+        ExampleSimpleJunction
+    using Unitful: μm
+
+    # Composite that declares subcomponent templates via the new NamedTuple convention.
+    # `_build_subcomponents` overlays PS on top of each template (templates-aliasing)
+    # and then applies composite-level overrides via the pair form.
+    @compdef struct Phase2Transmon <: CompositeComponent
+        name = "phase2_transmon"
+        junction_gap = 12μm
+        templates = (
+            island=ExampleRectangleIsland(name="island", cap_width=30μm),
+            junction=ExampleSimpleJunction(name="junction")
+        )
+    end
+
+    function SchematicDrivenLayout._build_subcomponents(tr::Phase2Transmon)
+        ps = parameter_set(tr._graph)
+        island = set_parameters(tr.templates.island, ps, "components.$(name(tr)).island")
+        island = set_parameters(island; junction_gap=tr.junction_gap)
+        junction =
+            set_parameters(tr.templates.junction, ps, "components.$(name(tr)).junction")
+        junction = set_parameters(junction; h_ground_island=tr.junction_gap)
+        return (island, junction)
+    end
+
+    function SchematicDrivenLayout._graph!(
+        g::SchematicGraph,
+        cc::Phase2Transmon,
+        subcomps::NamedTuple
+    )
+        n = add_node!(g, subcomps.island)
+        fuse!(g, n => :junction, subcomps.junction => :island)
+        return g
+    end
+    SchematicDrivenLayout.map_hooks(::Type{Phase2Transmon}) =
+        Dict{Pair{Int, Symbol}, Symbol}()
+
+    @testset "Happy path — address form" begin
+        ps = ParameterSet()
+        ps.components.phase2_transmon.junction_gap = 15μm
+        ps.components.phase2_transmon.island.cap_length = 600μm
+        ps.components.phase2_transmon.junction.w_jj = 2μm
+
+        tr = create_component(Phase2Transmon, ps, "components.phase2_transmon")
+        island = components(tr)[1]
+        junction = components(tr)[2]
+        @test parameters(island).cap_length == 600μm
+        # Template default for cap_width (30μm) is preserved — PS didn't set it
+        @test parameters(island).cap_width == 30μm
+        @test parameters(junction).w_jj == 2μm
+    end
+
+    @testset "Happy path — scoped form" begin
+        ps = ParameterSet()
+        ps.components.phase2_transmon.island.cap_length = 600μm
+
+        template_island = ExampleRectangleIsland(name="island", cap_width=30μm)
+        island = set_parameters(template_island, ps.components.phase2_transmon.island)
+        @test parameters(island).cap_length == 600μm
+        @test parameters(island).cap_width == 30μm
+    end
+
+    @testset "Precedence: template → PS override" begin
+        ps = ParameterSet()
+        ps.components.phase2_transmon.island.cap_length = 600μm
+
+        template_island = ExampleRectangleIsland(name="island", cap_width=30μm)
+        island = set_parameters(template_island, ps, "components.phase2_transmon.island")
+        # cap_width came from the template (PS didn't set it)
+        @test parameters(island).cap_width == 30μm
+        # cap_length came from PS
+        @test parameters(island).cap_length == 600μm
+    end
+
+    @testset "Precedence: composite override wins over PS" begin
+        ps = ParameterSet()
+        ps.components.phase2_transmon.junction_gap = 15μm
+        # PS tries to set island's junction_gap to 99μm, but the composite then
+        # forwards its own `tr.junction_gap` (15μm) on top via the pair form.
+        ps.components.phase2_transmon.island.junction_gap = 99μm
+        # junction namespace must exist for `set_parameters(..., ps, ".junction")`
+        # to resolve; content is irrelevant here.
+        ps.components.phase2_transmon.junction.w_jj = 1μm
+
+        tr = create_component(Phase2Transmon, ps, "components.phase2_transmon")
+        island = components(tr)[1]
+        # Composite's forwarded value (15μm) wins over PS's 99μm — documented
+        # precedence: template → PS → composite.
+        @test parameters(island).junction_gap == 15μm
+    end
+
+    @testset "Typo detection — address form" begin
+        ps = ParameterSet()
+        ps.components.phase2_transmon.island.cap_length = 600μm
+        ps.components.phase2_transmon.island.fictional_param = 5μm
+
+        template_island = ExampleRectangleIsland(name="island")
+        err = try
+            set_parameters(template_island, ps, "components.phase2_transmon.island")
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        @test occursin("fictional_param", err.msg)
+        @test occursin("ExampleRectangleIsland", err.msg)
+    end
+
+    @testset "Typo detection — scoped form" begin
+        ps = ParameterSet()
+        ps.components.phase2_transmon.island.cap_length = 600μm
+        ps.components.phase2_transmon.island.fictional_param = 5μm
+
+        template_island = ExampleRectangleIsland(name="island")
+        err = try
+            set_parameters(template_island, ps.components.phase2_transmon.island)
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        @test occursin("fictional_param", err.msg)
+    end
+
+    @testset "Missing address throws ParameterKeyError" begin
+        ps = ParameterSet()
+        template_island = ExampleRectangleIsland(name="island")
+        @test_throws ParameterKeyError set_parameters(
+            template_island,
+            ps,
+            "components.does_not_exist"
+        )
+    end
+
+    @testset "Combined form: kwargs apply on top of PS overlay" begin
+        ps = ParameterSet()
+        ps.components.phase2_transmon.island.cap_length = 600μm
+        ps.components.phase2_transmon.island.junction_gap = 99μm
+
+        template_island = ExampleRectangleIsland(name="island", cap_width=30μm)
+        island = set_parameters(
+            template_island,
+            ps,
+            "components.phase2_transmon.island";
+            junction_gap=15μm
+        )
+        # Template default preserved
+        @test parameters(island).cap_width == 30μm
+        # PS overlay
+        @test parameters(island).cap_length == 600μm
+        # kwargs win over PS
+        @test parameters(island).junction_gap == 15μm
+    end
+
+    @testset "Combined form: ParameterSet as kwarg value is rejected" begin
+        ps = ParameterSet()
+        ps.components.phase2_transmon.island.cap_length = 600μm
+        ps.parent_component.junction_gap = 15μm
+
+        template_island = ExampleRectangleIsland(name="island")
+        # Forgot the leaf: passes a scoped ParameterSet rather than its `.junction_gap`
+        @test_throws ArgumentError set_parameters(
+            template_island,
+            ps,
+            "components.phase2_transmon.island";
+            junction_gap=ps.parent_component
+        )
+    end
+
+    @testset "Combined form: MissingNamespace as kwarg value is rejected" begin
+        ps = ParameterSet()
+        ps.components.phase2_transmon.island.cap_length = 600μm
+        # No `parent_component` namespace — `ps.parent_component.junction_gap`
+        # returns a MissingNamespace.
+
+        template_island = ExampleRectangleIsland(name="island")
+        @test_throws ParameterKeyError set_parameters(
+            template_island,
+            ps,
+            "components.phase2_transmon.island";
+            junction_gap=ps.parent_component.junction_gap
+        )
+    end
+
+    @testset "Root ParameterSet rejected by scoped form" begin
+        ps = ParameterSet()
+        template_island = ExampleRectangleIsland(name="island")
+        @test_throws ArgumentError set_parameters(template_island, ps)
+    end
+
+    @testset "Access tracking records PS leaves only" begin
+        ps = ParameterSet()
+        ps.components.phase2_transmon.island.cap_length = 600μm
+
+        template_island = ExampleRectangleIsland(name="island", cap_width=30μm)
+        @test isempty(ps.accessed)
+        _ = set_parameters(template_island, ps, "components.phase2_transmon.island")
+        # PS leaf is tracked with the qualified path
+        @test "components.phase2_transmon.island.cap_length" in ps.accessed
+        # Template-only defaults (cap_width, junction_gap, ...) are NOT tracked —
+        # they never flowed through the PS.
+        @test !("components.phase2_transmon.island.cap_width" in ps.accessed)
+        @test !("components.phase2_transmon.island.junction_gap" in ps.accessed)
+    end
+
+    @testset "plan(g) runs end-to-end on templates-aliasing composite" begin
+        ps = ParameterSet()
+        ps.components.phase2_transmon.junction_gap = 10μm
+        ps.components.phase2_transmon.island.cap_length = 500μm
+        ps.components.phase2_transmon.junction.w_jj = 1μm
+
+        g = SchematicGraph("chip_phase2", ps)
+        tr = create_component(Phase2Transmon, ps, "components.phase2_transmon")
+        add_node!(g, tr)
+        floorplan = plan(g; log_dir=nothing)
+        @test floorplan !== nothing
     end
 end

--- a/test/test_parameter_set.jl
+++ b/test/test_parameter_set.jl
@@ -980,6 +980,27 @@ end
         )
     end
 
+    @testset "set_parameters(c, ::MissingNamespace) throws ParameterKeyError" begin
+        ps = ParameterSet()
+        ps.components.phase2_transmon.island.cap_length = 600μm
+        template_island = ExampleRectangleIsland(name="island")
+
+        # Direct call: a MissingNamespace as the second argument surfaces the
+        # qualified path in a ParameterKeyError rather than a generic MethodError.
+        mn = ps.components.does_not_exist
+        @test_throws ParameterKeyError("does_not_exist", "components.does_not_exist") set_parameters(
+            template_island,
+            mn
+        )
+
+        # Deeper missing chain: the qualified path tracks the full lookup.
+        mn_chain = ps.components.phase2_transmon.island.fictional.deeper
+        @test_throws ParameterKeyError(
+            "deeper",
+            "components.phase2_transmon.island.fictional.deeper"
+        ) set_parameters(template_island, mn_chain)
+    end
+
     @testset "Combined form: kwargs apply on top of PS overlay" begin
         ps = ParameterSet()
         ps.components.phase2_transmon.island.cap_length = 600μm

--- a/test/test_parameter_set.jl
+++ b/test/test_parameter_set.jl
@@ -849,11 +849,11 @@ end
         ExampleSimpleJunction
     using Unitful: μm
 
-    # Composite that declares subcomponent templates via the new NamedTuple convention.
+    # Composite that declares subcomponent templates via the NamedTuple convention.
     # `_build_subcomponents` overlays PS on top of each template (templates-aliasing)
-    # and then applies composite-level overrides via the pair form.
-    @compdef struct Phase2Transmon <: CompositeComponent
-        name = "phase2_transmon"
+    # and then applies composite-level overrides via the keyword arguments.
+    @compdef struct TestTemplatesTransmon <: CompositeComponent
+        name = "template_transmon"
         junction_gap = 12μm
         templates = (
             island=ExampleRectangleIsland(name="island", cap_width=30μm),
@@ -861,7 +861,7 @@ end
         )
     end
 
-    function SchematicDrivenLayout._build_subcomponents(tr::Phase2Transmon)
+    function SchematicDrivenLayout._build_subcomponents(tr::TestTemplatesTransmon)
         ps = parameter_set(tr._graph)
         island = set_parameters(tr.templates.island, ps, "components.$(name(tr)).island")
         island = set_parameters(island; junction_gap=tr.junction_gap)
@@ -873,47 +873,47 @@ end
 
     function SchematicDrivenLayout._graph!(
         g::SchematicGraph,
-        cc::Phase2Transmon,
+        cc::TestTemplatesTransmon,
         subcomps::NamedTuple
     )
         n = add_node!(g, subcomps.island)
         fuse!(g, n => :junction, subcomps.junction => :island)
         return g
     end
-    SchematicDrivenLayout.map_hooks(::Type{Phase2Transmon}) =
+    SchematicDrivenLayout.map_hooks(::Type{TestTemplatesTransmon}) =
         Dict{Pair{Int, Symbol}, Symbol}()
 
-    @testset "Happy path — address form" begin
+    @testset "Happy path - address form" begin
         ps = ParameterSet()
-        ps.components.phase2_transmon.junction_gap = 15μm
-        ps.components.phase2_transmon.island.cap_length = 600μm
-        ps.components.phase2_transmon.junction.w_jj = 2μm
+        ps.components.template_transmon.junction_gap = 15μm
+        ps.components.template_transmon.island.cap_length = 600μm
+        ps.components.template_transmon.junction.w_jj = 2μm
 
-        tr = create_component(Phase2Transmon, ps, "components.phase2_transmon")
+        tr = create_component(TestTemplatesTransmon, ps, "components.template_transmon")
         island = components(tr)[1]
         junction = components(tr)[2]
         @test parameters(island).cap_length == 600μm
-        # Template default for cap_width (30μm) is preserved — PS didn't set it
+        # Template default for cap_width (30μm) is preserved - PS didn't set it
         @test parameters(island).cap_width == 30μm
         @test parameters(junction).w_jj == 2μm
     end
 
-    @testset "Happy path — scoped form" begin
+    @testset "Happy path - scoped form" begin
         ps = ParameterSet()
-        ps.components.phase2_transmon.island.cap_length = 600μm
+        ps.components.template_transmon.island.cap_length = 600μm
 
         template_island = ExampleRectangleIsland(name="island", cap_width=30μm)
-        island = set_parameters(template_island, ps.components.phase2_transmon.island)
+        island = set_parameters(template_island, ps.components.template_transmon.island)
         @test parameters(island).cap_length == 600μm
         @test parameters(island).cap_width == 30μm
     end
 
     @testset "Precedence: template → PS override" begin
         ps = ParameterSet()
-        ps.components.phase2_transmon.island.cap_length = 600μm
+        ps.components.template_transmon.island.cap_length = 600μm
 
         template_island = ExampleRectangleIsland(name="island", cap_width=30μm)
-        island = set_parameters(template_island, ps, "components.phase2_transmon.island")
+        island = set_parameters(template_island, ps, "components.template_transmon.island")
         # cap_width came from the template (PS didn't set it)
         @test parameters(island).cap_width == 30μm
         # cap_length came from PS
@@ -922,29 +922,29 @@ end
 
     @testset "Precedence: composite override wins over PS" begin
         ps = ParameterSet()
-        ps.components.phase2_transmon.junction_gap = 15μm
+        ps.components.template_transmon.junction_gap = 15μm
         # PS tries to set island's junction_gap to 99μm, but the composite then
-        # forwards its own `tr.junction_gap` (15μm) on top via the pair form.
-        ps.components.phase2_transmon.island.junction_gap = 99μm
+        # forwards its own `tr.junction_gap` (15μm) on top via the keyword argument.
+        ps.components.template_transmon.island.junction_gap = 99μm
         # junction namespace must exist for `set_parameters(..., ps, ".junction")`
         # to resolve; content is irrelevant here.
-        ps.components.phase2_transmon.junction.w_jj = 1μm
+        ps.components.template_transmon.junction.w_jj = 1μm
 
-        tr = create_component(Phase2Transmon, ps, "components.phase2_transmon")
+        tr = create_component(TestTemplatesTransmon, ps, "components.template_transmon")
         island = components(tr)[1]
-        # Composite's forwarded value (15μm) wins over PS's 99μm — documented
+        # Composite's forwarded value (15μm) wins over PS's 99μm - documented
         # precedence: template → PS → composite.
         @test parameters(island).junction_gap == 15μm
     end
 
-    @testset "Typo detection — address form" begin
+    @testset "Typo detection - address form" begin
         ps = ParameterSet()
-        ps.components.phase2_transmon.island.cap_length = 600μm
-        ps.components.phase2_transmon.island.fictional_param = 5μm
+        ps.components.template_transmon.island.cap_length = 600μm
+        ps.components.template_transmon.island.fictional_param = 5μm
 
         template_island = ExampleRectangleIsland(name="island")
         err = try
-            set_parameters(template_island, ps, "components.phase2_transmon.island")
+            set_parameters(template_island, ps, "components.template_transmon.island")
             nothing
         catch e
             e
@@ -954,14 +954,14 @@ end
         @test occursin("ExampleRectangleIsland", err.msg)
     end
 
-    @testset "Typo detection — scoped form" begin
+    @testset "Typo detection - scoped form" begin
         ps = ParameterSet()
-        ps.components.phase2_transmon.island.cap_length = 600μm
-        ps.components.phase2_transmon.island.fictional_param = 5μm
+        ps.components.template_transmon.island.cap_length = 600μm
+        ps.components.template_transmon.island.fictional_param = 5μm
 
         template_island = ExampleRectangleIsland(name="island")
         err = try
-            set_parameters(template_island, ps.components.phase2_transmon.island)
+            set_parameters(template_island, ps.components.template_transmon.island)
             nothing
         catch e
             e
@@ -980,9 +980,49 @@ end
         )
     end
 
+    @testset "Empty address throws actionable ArgumentError" begin
+        # `resolve(ps, "")` returns root `ps`; without this guard the scoped
+        # form's root rejection would tell the caller to use the address-form
+        # they just called. Reject up front with a message that says what
+        # `address` should be.
+        ps = ParameterSet()
+        ps.components.template_transmon.island.cap_length = 600μm
+        template_island = ExampleRectangleIsland(name="island")
+        err = try
+            set_parameters(template_island, ps, "")
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        @test occursin("non-empty", err.msg)
+    end
+
+    @testset "Leaf address throws ArgumentError" begin
+        # `resolve` returns the leaf scalar, not a namespace; the scoped form
+        # cannot consume that, so the address-form must surface the misuse
+        # directly rather than falling through to a MethodError.
+        ps = ParameterSet()
+        ps.components.template_transmon.island.cap_length = 600μm
+        template_island = ExampleRectangleIsland(name="island")
+        err = try
+            set_parameters(
+                template_island,
+                ps,
+                "components.template_transmon.island.cap_length"
+            )
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        @test occursin("leaf value", err.msg)
+        @test occursin("cap_length", err.msg)
+    end
+
     @testset "set_parameters(c, ::MissingNamespace) throws ParameterKeyError" begin
         ps = ParameterSet()
-        ps.components.phase2_transmon.island.cap_length = 600μm
+        ps.components.template_transmon.island.cap_length = 600μm
         template_island = ExampleRectangleIsland(name="island")
 
         # Direct call: a MissingNamespace as the second argument surfaces the
@@ -994,23 +1034,23 @@ end
         )
 
         # Deeper missing chain: the qualified path tracks the full lookup.
-        mn_chain = ps.components.phase2_transmon.island.fictional.deeper
+        mn_chain = ps.components.template_transmon.island.fictional.deeper
         @test_throws ParameterKeyError(
             "deeper",
-            "components.phase2_transmon.island.fictional.deeper"
+            "components.template_transmon.island.fictional.deeper"
         ) set_parameters(template_island, mn_chain)
     end
 
     @testset "Combined form: kwargs apply on top of PS overlay" begin
         ps = ParameterSet()
-        ps.components.phase2_transmon.island.cap_length = 600μm
-        ps.components.phase2_transmon.island.junction_gap = 99μm
+        ps.components.template_transmon.island.cap_length = 600μm
+        ps.components.template_transmon.island.junction_gap = 99μm
 
         template_island = ExampleRectangleIsland(name="island", cap_width=30μm)
         island = set_parameters(
             template_island,
             ps,
-            "components.phase2_transmon.island";
+            "components.template_transmon.island";
             junction_gap=15μm
         )
         # Template default preserved
@@ -1023,7 +1063,7 @@ end
 
     @testset "Combined form: ParameterSet as kwarg value is rejected" begin
         ps = ParameterSet()
-        ps.components.phase2_transmon.island.cap_length = 600μm
+        ps.components.template_transmon.island.cap_length = 600μm
         ps.parent_component.junction_gap = 15μm
 
         template_island = ExampleRectangleIsland(name="island")
@@ -1031,22 +1071,22 @@ end
         @test_throws ArgumentError set_parameters(
             template_island,
             ps,
-            "components.phase2_transmon.island";
+            "components.template_transmon.island";
             junction_gap=ps.parent_component
         )
     end
 
     @testset "Combined form: MissingNamespace as kwarg value is rejected" begin
         ps = ParameterSet()
-        ps.components.phase2_transmon.island.cap_length = 600μm
-        # No `parent_component` namespace — `ps.parent_component.junction_gap`
+        ps.components.template_transmon.island.cap_length = 600μm
+        # No `parent_component` namespace - `ps.parent_component.junction_gap`
         # returns a MissingNamespace.
 
         template_island = ExampleRectangleIsland(name="island")
         @test_throws ParameterKeyError set_parameters(
             template_island,
             ps,
-            "components.phase2_transmon.island";
+            "components.template_transmon.island";
             junction_gap=ps.parent_component.junction_gap
         )
     end
@@ -1059,28 +1099,138 @@ end
 
     @testset "Access tracking records PS leaves only" begin
         ps = ParameterSet()
-        ps.components.phase2_transmon.island.cap_length = 600μm
+        ps.components.template_transmon.island.cap_length = 600μm
 
         template_island = ExampleRectangleIsland(name="island", cap_width=30μm)
         @test isempty(ps.accessed)
-        _ = set_parameters(template_island, ps, "components.phase2_transmon.island")
+        _ = set_parameters(template_island, ps, "components.template_transmon.island")
         # PS leaf is tracked with the qualified path
-        @test "components.phase2_transmon.island.cap_length" in ps.accessed
-        # Template-only defaults (cap_width, junction_gap, ...) are NOT tracked —
+        @test "components.template_transmon.island.cap_length" in ps.accessed
+        # Template-only defaults (cap_width, junction_gap, ...) are NOT tracked
         # they never flowed through the PS.
-        @test !("components.phase2_transmon.island.cap_width" in ps.accessed)
-        @test !("components.phase2_transmon.island.junction_gap" in ps.accessed)
+        @test !("components.template_transmon.island.cap_width" in ps.accessed)
+        @test !("components.template_transmon.island.junction_gap" in ps.accessed)
+    end
+
+    @testset "Access tracking: PS leaf equal to template default is still recorded" begin
+        # Documented audit semantics: `accessed` records "the loader read this
+        # PS leaf", not "the value differed from the template default".
+        ps = ParameterSet()
+        ps.components.template_transmon.island.cap_width = 30μm  # same as template
+
+        template_island = ExampleRectangleIsland(name="island", cap_width=30μm)
+        _ = set_parameters(template_island, ps, "components.template_transmon.island")
+        @test "components.template_transmon.island.cap_width" in ps.accessed
+    end
+
+    @testset "Access tracking: PS leaf shadowed by trailing kwarg is still recorded" begin
+        # A kwarg that wins over a PS leaf does NOT unmark the leaf — the
+        # documented semantics is "PS was read", regardless of what eventually
+        # reached the component.
+        ps = ParameterSet()
+        ps.components.template_transmon.island.junction_gap = 99μm
+
+        template_island = ExampleRectangleIsland(name="island")
+        _ = set_parameters(
+            template_island,
+            ps,
+            "components.template_transmon.island";
+            junction_gap=15μm
+        )
+        @test "components.template_transmon.island.junction_gap" in ps.accessed
     end
 
     @testset "plan(g) runs end-to-end on templates-aliasing composite" begin
         ps = ParameterSet()
-        ps.components.phase2_transmon.junction_gap = 10μm
-        ps.components.phase2_transmon.island.cap_length = 500μm
-        ps.components.phase2_transmon.junction.w_jj = 1μm
+        ps.components.template_transmon.junction_gap = 10μm
+        ps.components.template_transmon.island.cap_length = 500μm
+        ps.components.template_transmon.junction.w_jj = 1μm
 
         g = SchematicGraph("chip_phase2", ps)
-        tr = create_component(Phase2Transmon, ps, "components.phase2_transmon")
+        tr = create_component(TestTemplatesTransmon, ps, "components.template_transmon")
         add_node!(g, tr)
+        floorplan = plan(g; log_dir=nothing)
+        @test floorplan !== nothing
+        # PS values actually flowed to subcomponent fields (not just "plan didn't throw").
+        comps = components(tr)
+        island = comps[1]
+        junction = comps[2]
+        @test parameters(island).cap_length == 500μm
+        @test parameters(junction).w_jj == 1μm
+        # Composite override wins over PS for shared parameter.
+        @test parameters(island).junction_gap == 10μm
+        @test parameters(junction).h_ground_island == 10μm
+    end
+
+    # The tutorial promises "subcomponents at any depth can access the same
+    # parameter set." Wrap the templates-aliasing composite inside another
+    # composite and verify PS leaves under the inner composite's address still
+    # reach the inner subcomponents. This guards against a PS-threading
+    # regression in nested `_graph` copies.
+    #
+    # `TestTemplatesTransmon._build_subcomponents` reads templates at
+    # `"components.$(name(tr)).{island,junction}"`. To keep the outer/inner
+    # PS layout coherent, the outer overrides the inner's `name` to match the
+    # path it was created from (`"inner"`), so the inner's templates live at
+    # `"components.inner.*"`.
+    @compdef struct OuterTemplatesComposite <: CompositeComponent
+        name = "outer"
+    end
+
+    function SchematicDrivenLayout._build_subcomponents(o::OuterTemplatesComposite)
+        ps = parameter_set(o._graph)
+        # `create_component(T, ps, address)` requires `address` to resolve.
+        # We populate `ps.components.outer.inner.*` in the test so the
+        # namespace exists; the inner composite's `name` leaf there steers
+        # its templates path.
+        inner = create_component(TestTemplatesTransmon, ps, "components.outer.inner")
+        return (inner,)
+    end
+
+    function SchematicDrivenLayout._graph!(
+        g::SchematicGraph,
+        o::OuterTemplatesComposite,
+        subcomps::NamedTuple
+    )
+        add_node!(g, subcomps.inner)
+        return g
+    end
+    SchematicDrivenLayout.map_hooks(::Type{OuterTemplatesComposite}) =
+        Dict{Pair{Int, Symbol}, Symbol}()
+
+    @testset "Templates-aliasing composes at depth 2" begin
+        ps = ParameterSet()
+        # Inner composite's own leaves at the depth-2 address. Setting `name`
+        # here aligns the inner's templates path with `"components.inner.*"`.
+        ps.components.outer.inner.name = "inner"
+        ps.components.outer.inner.junction_gap = 13μm
+        # Inner composite's templates - read at `"components.$(name(inner)).*"`.
+        ps.components.inner.island.cap_length = 700μm
+        ps.components.inner.junction.w_jj = 3μm
+
+        g = SchematicGraph("chip_nested", ps)
+        outer = create_component(OuterTemplatesComposite, ps, "components.outer")
+        add_node!(g, outer)
+
+        # Depth-1: the inner composite consumed its own scalar leaves at the
+        # depth-2 address.
+        inner = components(outer)[1]
+        @test inner isa TestTemplatesTransmon
+        @test name(inner) == "inner"
+        @test parameters(inner).junction_gap == 13μm
+
+        # Depth-2: PS leaves under `"components.inner.{island,junction}"`
+        # reached the inner's subcomponents through templates-aliasing.
+        inner_island = components(inner)[1]
+        inner_junction = components(inner)[2]
+        @test parameters(inner_island).cap_length == 700μm
+        @test parameters(inner_junction).w_jj == 3μm
+
+        # Inner-composite override propagates to its subcomponents.
+        @test parameters(inner_island).junction_gap == 13μm
+        @test parameters(inner_junction).h_ground_island == 13μm
+
+        # `plan` runs end-to-end with nested PS-driven composites.
         floorplan = plan(g; log_dir=nothing)
         @test floorplan !== nothing
     end


### PR DESCRIPTION
## Summary

- Replace the `value => :name` `Pair` form of `set_parameters` with a kwarg API and add a three-argument overload `set_parameters(c, ps, address; kwargs...)` that overlays a `ParameterSet` subtree on top of a template component, with trailing kwargs as composite-level overrides. Precedence is template defaults < `ParameterSet` overlay < kwargs.
- Reject `ParameterSet` and `MissingNamespace` values when passed as kwargs to `create_component` / `set_parameters`. A scoped `ParameterSet` as a kwarg almost always means a forgotten leaf access (e.g. `length=ps.parent_component` instead of `length=ps.parent_component.length`); surface that at the call site rather than storing the subtree silently.
- Introduce the **templates-aliasing** pattern for composite subcomponents — designer defaults live on the composite via a `templates::NamedTuple` field, and `_build_subcomponents` overlays the matching `ParameterSet` subtree at build time:

  ```julia
  function _build_subcomponents(tr::MyTransmon)
      ps = parameter_set(tr._graph)
      island = set_parameters(
          tr.templates.island, ps, "components.$(name(tr)).island";
          junction_gap=tr.junction_gap,
      )
      return (island,)
  end
  ```

- Docs:
  - New tutorial section *Templates-Aliasing for Composite Subcomponents* in [`docs/src/tutorials/parameter_set.md`](../blob/main/docs/src/tutorials/parameter_set.md).
  - Styleguide gains a `ParameterSet` alternative bullet under *For parameters passed through to subcomponents* and a side-by-side example next to the existing `filter_parameters`-based one.
  - `set_parameters` docstring covers the kwargs + rejection rules.

## Test plan

- [x] `julia --project=. -e 'using Pkg; Pkg.test("DeviceLayout"; test_args=["ParameterSet"])'` — 206/206 ParameterSet tests pass locally on this branch.
- [x] New tests in `test/test_parameter_set.jl` (testitem `set_parameters with template + ParameterSet`):
  - *Combined form: kwargs apply on top of PS overlay* — three-way precedence end-to-end.
  - *Combined form: ParameterSet as kwarg value is rejected* — `@test_throws ArgumentError` when a scoped `ParameterSet` is passed as a kwarg.
  - *Combined form: MissingNamespace as kwarg value is rejected* — `@test_throws ParameterKeyError` when a typo'd PS path is passed as a kwarg.
- [x] Build the docs locally (`julia --project=docs docs/make.jl`) and skim the new tutorial section + the styleguide composite-components section for rendering and link targets.