### PR TITLE
Fix incorrect loading of GDS array references with nonzero origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format of this changelog is based on
   - Added `SchematicGraph(name, ps)` to carry a `ParameterSet` on the graph, plumbed
     through `_build_subcomponents` via `parameter_set(graph)` and
     `create_component(T, ps, address)`
+  - Fixed incorrect loading of GDS array references with nonzero origin
 
 ## 1.13.0 (2026-04-28)
 

--- a/src/backends/gds.jl
+++ b/src/backends/gds.jl
@@ -1342,8 +1342,8 @@ function aref(s, dbs, verbose, nounits)
     return (
         name=str,
         origin=o,
-        deltacol=ec / col,
-        deltarow=er / row,
+        deltacol=(ec - o) / col,
+        deltarow=(er - o) / row,
         col=col,
         row=row,
         xrefl=xrefl,

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -1051,6 +1051,36 @@ end
             rm(path, force=true)
         end
 
+        # Round-trip test: ArrayReference with nonzero origin (#222)
+        let c = Cell("main"), c2 = Cell("sub")
+            render!(c2, Rectangle(1μm, 2μm), GDSMeta(0))
+            c2ref = aref(
+                c2,
+                Point(5, -5)μm;
+                xrefl=true,
+                rot=90°,
+                nrow=3,
+                ncol=2,
+                drow=Point(0, 10)μm,
+                dcol=Point(10, 0)μm,
+                mag=2.0
+            )
+            push!(c.refs, c2ref)
+            path = joinpath(tdir, "test_aref_roundtrip.gds")
+            save(path, c)
+            c_rt = load(path)["main"]
+            c2ref_rt = c_rt.refs[1]
+            @test c2ref_rt.origin == c2ref.origin
+            @test c2ref_rt.deltacol == c2ref.deltacol
+            @test c2ref_rt.deltarow == c2ref.deltarow
+            @test c2ref_rt.col == c2ref.col
+            @test c2ref_rt.row == c2ref.row
+            @test c2ref_rt.xrefl == c2ref.xrefl
+            @test c2ref_rt.mag == c2ref.mag
+            @test c2ref_rt.rot == c2ref.rot
+            rm(path, force=true)
+        end
+
         # test we can recognize PROPATTR and PROPVALUE tags (though ignored)
         @test_logs (:info, r"PROPATTR: 0") match_mode = :any load(
             joinpath(@__DIR__, "propattr.gds");


### PR DESCRIPTION
Fix #222. The two points at the end of the AREF record are the absolute coordinates of one-step-past-the-last-row/column, so to get `deltarow` and `deltacol` we need to subtract the reference origin before dividing by the number of rows/columns.