### PR TITLE
Add StyledHook + graph-level terminate!

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,7 +52,7 @@ jobs:
       - run: |
           git config --global user.name github-actions
           git config --global user.email github-actions@github.com
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
           cache: 'pip' # caching pip dependencies

--- a/src/DeviceLayout.jl
+++ b/src/DeviceLayout.jl
@@ -462,12 +462,13 @@ export CoordinateSystems,
     traverse!
 
 include("hooks.jl")
-export HandedPointHook, Hook, PointHook, compass, in_direction, out_direction
+export HandedPointHook, Hook, PointHook, compass, hook_style, in_direction, out_direction
 
 include("paths/paths.jl")
 import .Paths:
     Path,
     Route,
+    StyledHook,
     α0,
     α1,
     reconcile!,
@@ -513,6 +514,7 @@ import .Paths:
 export Paths,
     Path,
     Route,
+    StyledHook,
     α0,
     α1,
     reconcile!,

--- a/src/hooks.jl
+++ b/src/hooks.jl
@@ -128,6 +128,15 @@ end
 DeviceLayout.transform(x::HandedPointHook, f::Transformation) =
     HandedPointHook(f(x.h), xrefl(f) ⊻ x.right_handed)
 
+"""
+    hook_style(h::Hook)
+
+Return the path style associated with a hook, or `nothing` if the hook has no
+style. Only `StyledHook` carries a style; bare `PointHook` and `HandedPointHook`
+return `nothing`.
+"""
+hook_style(::Hook) = nothing
+
 Base.keys(h::Hook) = error(
     "No method matching keys(::Hook). You might be missing a leading semicolon in a `hooks` method returning a single hook: `return (hookname=h)` should be `return (; hookname=h)`."
 )

--- a/src/paths/channels.jl
+++ b/src/paths/channels.jl
@@ -96,7 +96,7 @@ function track_section_offset(n_tracks, section_width::Function, track_idx; reve
 end
 
 reverse(n::Node) = Paths.Node(reverse(n.seg), reverse(n.sty, pathlength(n.seg)))
-######## Methods required to use segments and styles as RouteChannels
+######## Methods required to use segments as RouteChannels
 function reverse(b::BSpline{T}) where {T}
     p = reverse(b.p)
     t0 = RotationPi()(b.t1)
@@ -117,13 +117,6 @@ function reverse(b::BSpline{T}) where {T}
 end
 reverse(s::Turn) = Turn(-s.α, s.r, p1(s), α1(s) + 180°)
 reverse(s::Straight) = Straight(s.l, p1(s), s.α0 + 180°)
-# Reversing a GeneralTrace requires knowing its length, so we'll require that as an argument even if unused
-reverse(s::TaperTrace{T}, l) where {T} = TaperTrace{T}(s.width_end, s.width_start, s.length)
-reverse(s::GeneralTrace, l) = GeneralTrace(t -> width(s, l - t))
-# Define methods for CPW even though they're not allowed for channels
-reverse(s::TaperCPW{T}, l) where {T} =
-    TaperCPW{T}(s.trace_end, s.gap_end, s.trace_start, s.gap_start, s.length)
-reverse(s::GeneralCPW, l) = GeneralCPW(t -> trace(s, l - t), t -> gap(s, l - t))
 # For compound segments, reverse the individual sections and reverse their order
 # Keep the same tag so if a compound segment/style pair matched before they will still match
 reverse(s::CompoundSegment) = CompoundSegment(reverse(reverse.(s.segments)), s.tag)
@@ -137,21 +130,7 @@ function reverse(s::GeneralOffset{T, S}) where {T, S}
     l = pathlength(s.seg)
     return GeneralOffset{T, S}(reverse(s.seg), t -> -s.offset(l - t))
 end
-function reverse(s::CompoundStyle{T}, l) where {T}
-    lengths = diff(s.grid)
-    return CompoundStyle{T}(
-        reverse(reverse.(s.styles, lengths)),
-        [zero(T); cumsum(reverse(lengths))],
-        s.tag
-    )
-end
-function reverse(s::PeriodicStyle{T}, l) where {T}
-    return PeriodicStyle{T}(
-        reverse(reverse.(s.styles, s.lengths)),
-        reverse(s.lengths),
-        sum(s.lengths) - ((s.l0 + l) % sum(s.lengths))
-    )
-end
+# `reverse(s::Style, l)` methods are implemented in corresponding style files
 
 abstract type AbstractMultiRouting <: RouteRule end
 

--- a/src/paths/channels.jl
+++ b/src/paths/channels.jl
@@ -119,12 +119,10 @@ reverse(s::Turn) = Turn(-s.α, s.r, p1(s), α1(s) + 180°)
 reverse(s::Straight) = Straight(s.l, p1(s), s.α0 + 180°)
 # Reversing a GeneralTrace requires knowing its length, so we'll require that as an argument even if unused
 reverse(s::TaperTrace{T}, l) where {T} = TaperTrace{T}(s.width_end, s.width_start, s.length)
-reverse(s::SimpleTrace, l) = s
 reverse(s::GeneralTrace, l) = GeneralTrace(t -> width(s, l - t))
 # Define methods for CPW even though they're not allowed for channels
 reverse(s::TaperCPW{T}, l) where {T} =
     TaperCPW{T}(s.trace_end, s.gap_end, s.trace_start, s.gap_start, s.length)
-reverse(s::SimpleCPW, l) = s
 reverse(s::GeneralCPW, l) = GeneralCPW(t -> trace(s, l - t), t -> gap(s, l - t))
 # For compound segments, reverse the individual sections and reverse their order
 # Keep the same tag so if a compound segment/style pair matched before they will still match
@@ -145,6 +143,13 @@ function reverse(s::CompoundStyle{T}, l) where {T}
         reverse(reverse.(s.styles, lengths)),
         [zero(T); cumsum(reverse(lengths))],
         s.tag
+    )
+end
+function reverse(s::PeriodicStyle{T}, l) where {T}
+    return PeriodicStyle{T}(
+        reverse(reverse.(s.styles, s.lengths)),
+        reverse(s.lengths),
+        sum(s.lengths) - ((s.l0 + l) % sum(s.lengths))
     )
 end
 

--- a/src/paths/contstyles/compound.jl
+++ b/src/paths/contstyles/compound.jl
@@ -102,3 +102,12 @@ function pin(s::CompoundStyle; start=nothing, stop=nothing, tag=gensym())
     end
     return copy(s, tag)
 end
+
+function reverse(s::CompoundStyle{T}, l) where {T}
+    lengths = diff(s.grid)
+    return CompoundStyle{T}(
+        reverse(reverse.(s.styles, lengths)),
+        [zero(T); cumsum(reverse(lengths))],
+        s.tag
+    )
+end

--- a/src/paths/contstyles/cpw.jl
+++ b/src/paths/contstyles/cpw.jl
@@ -21,6 +21,7 @@ trace(s::GeneralCPW) = s.trace
 gap(s::GeneralCPW, t) = s.gap(t)
 gap(s::GeneralCPW) = s.gap
 translate(s::GeneralCPW, t) = GeneralCPW(x -> s.trace(x + t), x -> s.gap(x + t))
+reverse(s::GeneralCPW, l) = GeneralCPW(t -> trace(s, l - t), t -> gap(s, l - t))
 
 """
     struct SimpleCPW{T <: Coordinate} <: CPW{false}
@@ -44,6 +45,7 @@ extent(s::SimpleCPW, t...) = s.trace / 2 + s.gap
 trace(s::SimpleCPW, t...) = s.trace
 gap(s::SimpleCPW, t...) = s.gap
 translate(s::SimpleCPW, t) = copy(s)
+reverse(s::SimpleCPW, l) = s
 
 """
     CPW(trace::Coordinate, gap::Coordinate)

--- a/src/paths/contstyles/decorated.jl
+++ b/src/paths/contstyles/decorated.jl
@@ -58,6 +58,15 @@ A copy of `sty`, with shallow copies of attached references.
 Base.copy(sty::DecoratedStyle{T}) where {T} =
     DecoratedStyle{T}(deepcopy(sty.s), copy(sty.ts), copy(sty.dirs), copy(sty.refs))
 
+function reverse(s::DecoratedStyle{T}, l) where {T}
+    return DecoratedStyle{T}(
+        reverse(s.s, l),
+        l .- s.ts,
+        -1 .* s.dirs,
+        RotationPi().(s.refs)
+    )
+end
+
 """
     attach!(p::Path, c::GeometryReference, t::Coordinate;
         i::Integer=length(p), location::Integer=0)
@@ -254,6 +263,9 @@ summary(s::OverlayStyle) = string(summary(s.s), " with ", length(s.overlay), " o
 
 Base.copy(sty::OverlayStyle) =
     OverlayStyle(deepcopy(sty.s), copy(sty.overlay), copy(sty.overlay_metadata))
+
+reverse(s::OverlayStyle, l) =
+    OverlayStyle(reverse(s.s, l), reverse.(s.overlay, l), s.overlay_metadata)
 
 function _refs(segment::Paths.Segment{T}, s::OverlayStyle) where {T}
     cs = DeviceLayout.CoordinateSystem{T}(uniquename("overlay"))

--- a/src/paths/contstyles/interface.jl
+++ b/src/paths/contstyles/interface.jl
@@ -18,7 +18,7 @@ function width end
 """
     translate(s::ContinuousStyle, x)
 
-Creates a style `s′` such that all properties `f(s′, t) == f(s, t+x)`. Basically, advance
+Create a style `s′` such that all properties `f(s′, t) == f(s, t+x)`. Basically, advance
 the style forward by path length `x`.
 """
 function translate end
@@ -37,3 +37,11 @@ function pin(s::ContinuousStyle{false}; start=nothing, stop=nothing)
     end
     return s
 end
+
+"""
+    reverse(s::Style, l)
+
+Create a style `s′` such that all properties `f(s′, x) == f(s, l - x)`. Basically, reverse
+the style assuming it is applied to a segment of pathlength `l`.
+"""
+reverse(s::Style, l) = s

--- a/src/paths/contstyles/interface.jl
+++ b/src/paths/contstyles/interface.jl
@@ -44,4 +44,5 @@ end
 Create a style `s′` such that all properties `f(s′, x) == f(s, l - x)`. Basically, reverse
 the style assuming it is applied to a segment of pathlength `l`.
 """
-reverse(s::Style, l) = s
+function reverse end
+# Reversing a GeneralTrace/CPW requires knowing its length, so we require that as an argument even if unused

--- a/src/paths/contstyles/periodic.jl
+++ b/src/paths/contstyles/periodic.jl
@@ -195,3 +195,11 @@ undecorated(sty::PeriodicStyle) =
 function translate(sty::PeriodicStyle, x)
     return PeriodicStyle(sty.styles, sty.lengths, sty.l0 + x)
 end
+
+function reverse(s::PeriodicStyle{T}, l) where {T}
+    return PeriodicStyle{T}(
+        reverse(reverse.(s.styles, s.lengths)),
+        reverse(s.lengths),
+        sum(s.lengths) - ((s.l0 + l) % sum(s.lengths))
+    )
+end

--- a/src/paths/contstyles/strands.jl
+++ b/src/paths/contstyles/strands.jl
@@ -35,6 +35,8 @@ spacing(s::GeneralStrands, t) = s.spacing(t)
 num(s::GeneralStrands, t...) = s.num
 translate(s::GeneralStrands, t) =
     GeneralStrands(x -> s.offset(x + t), x -> s.width(x + t), x -> s.spacing(x + t), s.num)
+reverse(s::GeneralStrands, l) =
+    GeneralStrands(x -> s.offset(l - x), x -> s.width(l - x), x -> s.spacing(l - x), num)
 
 """
     struct SimpleStrands{T<:Coordinate} <: Strands{false}

--- a/src/paths/contstyles/strands.jl
+++ b/src/paths/contstyles/strands.jl
@@ -36,7 +36,7 @@ num(s::GeneralStrands, t...) = s.num
 translate(s::GeneralStrands, t) =
     GeneralStrands(x -> s.offset(x + t), x -> s.width(x + t), x -> s.spacing(x + t), s.num)
 reverse(s::GeneralStrands, l) =
-    GeneralStrands(x -> s.offset(l - x), x -> s.width(l - x), x -> s.spacing(l - x), num)
+    GeneralStrands(x -> s.offset(l - x), x -> s.width(l - x), x -> s.spacing(l - x), s.num)
 
 """
     struct SimpleStrands{T<:Coordinate} <: Strands{false}
@@ -69,6 +69,7 @@ width(s::SimpleStrands, t...) = s.width
 spacing(s::SimpleStrands, t...) = s.spacing
 num(s::SimpleStrands, t...) = s.num
 translate(s::SimpleStrands, t) = copy(s)
+reverse(s::SimpleStrands, l) = s
 
 """
     Strands(offset::Coordinate, width::Coordinate, spacing::Coordinate, num::Int)

--- a/src/paths/contstyles/tapers.jl
+++ b/src/paths/contstyles/tapers.jl
@@ -21,6 +21,7 @@ width(s::TaperTrace, t) =
 width(s::TaperTrace) = t -> width(s, t)
 trace(s::TaperTrace, t) = width(s, t)
 trace(s::TaperTrace) = width(s)
+reverse(s::TaperTrace{T}, l) where {T} = TaperTrace{T}(s.width_end, s.width_start, s.length)
 
 function pin(s::TaperTrace{T}; start=nothing, stop=nothing) where {T}
     iszero(s.length) && error("cannot `pin`; length of $s not yet determined.")
@@ -126,6 +127,9 @@ function pin(sty::TaperCPW{T}; start=nothing, stop=nothing) where {T}
     )
 end
 
+reverse(s::TaperCPW{T}, l) where {T} =
+    TaperCPW{T}(s.trace_end, s.gap_end, s.trace_start, s.gap_start, s.length)
+
 nextstyle(sty::TaperCPW) = CPW(sty.trace_end, sty.gap_end)
 
 summary(s::TaperTrace) = string(
@@ -153,6 +157,7 @@ between an initial `CPW` or `Trace` and an end `CPW` or `Trace` of different dim
 """
 struct Taper <: ContinuousStyle{false} end
 copy(::Taper) = Taper()
+reverse(s::Taper, l) = s
 
 summary(::Taper) = string("Generic linear taper between neighboring segments in a path")
 

--- a/src/paths/contstyles/termination.jl
+++ b/src/paths/contstyles/termination.jl
@@ -332,3 +332,27 @@ end
 function nextstyle(::Union{TraceTermination, CPWOpenTermination, CPWShortTermination})
     return NoRenderContinuous()
 end
+
+function reverse(sty::CPWOpenTermination{T}, l) where {T}
+    return CPWOpenTermination{T}(
+        sty.trace,
+        sty.gap,
+        sty.open_gap,
+        sty.rounding,
+        !sty.initial
+    )
+end
+
+function reverse(sty::CPWShortTermination{T}, l) where {T}
+    return CPWShortTermination{T}(
+        sty.trace,
+        sty.gap,
+        sty.open_gap,
+        sty.rounding,
+        !sty.initial
+    )
+end
+
+function reverse(sty::TraceTermination{T}, l) where {T}
+    return TraceTermination{T}(sty.width, sty.rounding, !sty.initial)
+end

--- a/src/paths/contstyles/trace.jl
+++ b/src/paths/contstyles/trace.jl
@@ -18,6 +18,7 @@ width(s::GeneralTrace) = s.width
 trace(s::GeneralTrace, t) = s.width(t)
 trace(s::GeneralTrace) = s.width
 translate(s::GeneralTrace, t) = GeneralTrace(x -> s.width(x + t))
+reverse(s::GeneralTrace, l) = GeneralTrace(t -> width(s, l - t))
 
 """
     struct SimpleTrace{T <: Coordinate} <: Trace{false}
@@ -34,6 +35,7 @@ extent(s::SimpleTrace, t...) = 0.5 * s.width
 width(s::SimpleTrace, t...) = s.width
 trace(s::SimpleTrace, t...) = s.width
 translate(s::SimpleTrace, t) = copy(s)
+reverse(s::SimpleTrace, l) = s
 
 """
     Trace(width)

--- a/src/paths/discretestyles/simple.jl
+++ b/src/paths/discretestyles/simple.jl
@@ -3,4 +3,4 @@
 """
 struct SimpleTraceCorner <: DiscreteStyle end
 Base.copy(c::SimpleTraceCorner) = c
-reverse(c::SimpleTraceCorner) = c
+reverse(c::SimpleTraceCorner, l) = c

--- a/src/paths/discretestyles/simple.jl
+++ b/src/paths/discretestyles/simple.jl
@@ -3,3 +3,4 @@
 """
 struct SimpleTraceCorner <: DiscreteStyle end
 Base.copy(c::SimpleTraceCorner) = c
+reverse(c::SimpleTraceCorner) = c

--- a/src/paths/norender.jl
+++ b/src/paths/norender.jl
@@ -49,3 +49,5 @@ translate(s::SimpleNoRender, t) = copy(s)
 translate(s::NoRenderContinuous, t) = copy(s)
 
 pin(s::NoRender; start=nothing, stop=nothing) = s
+
+reverse(s::Union{NoRender, NoRenderDiscrete, NoRenderContinuous, SimpleNoRender}, l) = s

--- a/src/paths/paths.jl
+++ b/src/paths/paths.jl
@@ -504,7 +504,8 @@ The style is `nothing` for an empty path and otherwise `nextstyle` of the revers
 """
 p0_hook(pa::Path, right_handed=true) = StyledHook(
     HandedPointHook(p0(pa), α0(pa), right_handed),
-    isempty(pa.nodes) ? nothing : nextstyle(without_attachments(reverse(pa[1]).sty))
+    isempty(pa.nodes) ? nothing :
+    nextstyle(without_attachments(reverse(pa[1].sty, pathlength(pa[1].seg))))
 )
 
 """

--- a/src/paths/paths.jl
+++ b/src/paths/paths.jl
@@ -367,6 +367,45 @@ function pathlength_nearest(seg::Paths.Segment{T}, pt::Point) where {T}
     return Optim.minimizer(optimize(errfunc, 0.0, 1.0))[1] * pathlength(seg)
 end
 
+### StyledHook definition for Paths
+"""
+    StyledHook{T, H<:Hook{T}, S<:Paths.Style} <: Hook{T}
+        h::H
+        style::S
+
+A `Hook` augmented with a path-style object. Used by graph-level `terminate!`
+(and other style-aware operations) to read the cross-section that terminates at
+the hook without consulting the owning component's internals. Wraps any
+underlying `Hook` so `style` composes orthogonally with handedness.
+"""
+struct StyledHook{T, H <: Hook{T}, S <: Paths.Style} <: Hook{T}
+    h::H
+    style::S
+end
+StyledHook(h::Hook, ::Nothing) = StyledHook(h, Paths.NoRenderContinuous())
+
+function DeviceLayout.transformation(h1::StyledHook, h2::StyledHook)
+    return transformation(getfield(h1, :h), getfield(h2, :h))
+end
+DeviceLayout.transformation(h1::StyledHook, h2::Hook) = transformation(getfield(h1, :h), h2)
+DeviceLayout.transformation(h1::Hook, h2::StyledHook) = transformation(h1, getfield(h2, :h))
+
+function Base.getproperty(h::StyledHook, s::Symbol)
+    (s === :h || s === :style) && return getfield(h, s)
+    return getproperty(getfield(h, :h), s)
+end
+
+function Base.propertynames(h::StyledHook)
+    return (:h, :style, propertynames(getfield(h, :h))...)
+end
+
+DeviceLayout.in_direction(h::StyledHook) = in_direction(getfield(h, :h))
+
+DeviceLayout.transform(x::StyledHook, f::Transformation) =
+    StyledHook(transform(getfield(x, :h), f), getfield(x, :style))
+
+DeviceLayout.hook_style(h::StyledHook) = getfield(h, :style)
+
 """
     mutable struct Path{T<:Coordinate} <: AbstractComponent{T}
 
@@ -457,26 +496,32 @@ A `Path` starting at h, pointing along its outward direction.
 path_out(h::Hook) = Path(h.p, α0=out_direction(h))
 
 """
-    p0_hook(pa::Path, right_handed=true) = HandedPointHook(p0(pa), α0(pa), right_handed)
+    p0_hook(pa::Path, right_handed=true) = StyledHook(HandedPointHook(p0(pa), α0(pa), right_handed), style)
 
-A `HandedPointHook` looking into the start of path `pa`.
+A `StyledHook` wrapping a `HandedPointHook` looking into the start of path `pa` with a `style`.
+
+The style is `nothing` for an empty path and otherwise `nextstyle` of the reversed initial node.
 """
-p0_hook(pa::Path, right_handed=true) = HandedPointHook(p0(pa), α0(pa), right_handed)
+p0_hook(pa::Path, right_handed=true) = StyledHook(
+    HandedPointHook(p0(pa), α0(pa), right_handed),
+    isempty(pa.nodes) ? nothing : nextstyle(without_attachments(reverse(pa[1]).sty))
+)
 
 """
-    p1_hook(pa::Path, right_handed=true) = HandedPointHook(p1(pa), α1(pa) + π, right_handed)
+    p1_hook(pa::Path, right_handed=true) = StyledHook(HandedPointHook(p1(pa), α1(pa) + π, right_handed), nextstyle(pa))
 
-A `HandedPointHook` looking into the end of path `pa`.
+A `StyledHook` wrapping a `HandedPointHook` looking into the end of path `pa` with `nextstyle(pa)`.
 """
-p1_hook(pa::Path, right_handed=true) = HandedPointHook(p1(pa), α1(pa) + π, right_handed)
+p1_hook(pa::Path, right_handed=true) =
+    StyledHook(HandedPointHook(p1(pa), α1(pa) + π, right_handed), nextstyle(pa))
 
 """
     hooks(pa::Path)
 
-  - `:p0`: A `HandedPointHook` looking into the start of path `pa`.
-  - `:p1`: A `HandedPointHook` looking into the end of path `pa`.
-  - `:p0_lh`: A left-handed `HandedPointHook` looking into the start of path `pa`.
-  - `:p1_lh`: A left-handed `HandedPointHook` looking into the end of path `pa`.
+  - `:p0`: A right-handed `StyledHook` looking into the start of path `pa` with `nextstyle` of the reversed path.
+  - `:p1`: A right-handed `StyledHook` looking into the end of path `pa` with `nextstyle(pa)`.
+  - `:p0_lh`: A left-handed `StyledHook` looking into the start of path `pa` with `nextstyle` of the reversed path.
+  - `:p1_lh`: A left-handed `StyledHook` looking into the end of path `pa` with `nextstyle(pa)`.
 """
 DeviceLayout.hooks(pa::Path) =
     (p0=p0_hook(pa), p1=p1_hook(pa), p0_lh=p0_hook(pa, false), p1_lh=p1_hook(pa, false))

--- a/src/schematics/SchematicDrivenLayout.jl
+++ b/src/schematics/SchematicDrivenLayout.jl
@@ -31,8 +31,10 @@ import DeviceLayout:
     Hook,
     Meta,
     PointHook,
+    StyledHook,
     Transformation,
     UPREFERRED
+import DeviceLayout: hook_style
 import DeviceLayout:
     attach!,
     autofill!,
@@ -51,10 +53,13 @@ import DeviceLayout:
     map_metadata!,
     name,
     origin,
+    out_direction,
     parameters,
     refs,
     render!,
     sref,
+    straight!,
+    terminate!,
     transform,
     transformation,
     _geometry!

--- a/src/schematics/routes.jl
+++ b/src/schematics/routes.jl
@@ -42,7 +42,7 @@ RouteComponent(
 function hooks(rc::RouteComponent{T}) where {T}
     p0 = StyledHook(
         PointHook(rc.r.p0, rc.r.α0),
-        Paths.nextstyle(reverse(rc.sty[1], zero(T)))
+        Paths.nextstyle(reverse(rc.sty[1], pathlength(rc._path)))
     )
     p1 = StyledHook(PointHook(rc.r.p1, rc.r.α1 + 180°), Paths.nextstyle(rc.sty[end]))
     return (; p0, p1)

--- a/src/schematics/routes.jl
+++ b/src/schematics/routes.jl
@@ -38,7 +38,15 @@ RouteComponent(
     sty::Paths.Style,
     meta::Meta
 ) where {T} = RouteComponent{T}(name, r, gw, [sty], meta)
-hooks(rc::RouteComponent) = (p0=PointHook(rc.r.p0, rc.r.α0), p1=PointHook(rc.r.p1, rc.r.α1))
+
+function hooks(rc::RouteComponent{T}) where {T}
+    p0 = StyledHook(
+        PointHook(rc.r.p0, rc.r.α0),
+        Paths.nextstyle(reverse(rc.sty[1], zero(T)))
+    )
+    p1 = StyledHook(PointHook(rc.r.p1, rc.r.α1 + 180°), Paths.nextstyle(rc.sty[end]))
+    return (; p0, p1)
+end
 
 function redecorate!(path::Path, sty::Paths.Style) end
 function redecorate!(path::Path, sty::Paths.DecoratedStyle)

--- a/src/schematics/schematics.jl
+++ b/src/schematics/schematics.jl
@@ -329,6 +329,109 @@ function fuse!(
 end
 
 """
+    terminate!(g::SchematicGraph, node::ComponentNode, hook_name::Symbol;
+               style=nothing, kwargs...)
+    terminate!(g::SchematicGraph, p::Pair{<:ComponentNode, Symbol}; kwargs...)
+
+Attach a termination component to `node`'s `hook_name` hook in the schematic
+graph `g`. The termination is realized as a short `Paths.Path` ending in a
+rendered termination cap (open gap, short, rounded, ...) — see
+[`Paths.terminate!`](@ref).
+
+# Style resolution
+
+ 1. If the hook is a [`StyledHook`](@ref), use its carried style.
+ 2. Otherwise, the user MUST supply `style=...` explicitly.
+
+A bare `PointHook` or `HandedPointHook` without an explicit `style=` kwarg
+errors with an actionable message.
+
+# Keyword arguments
+
+All kwargs are forwarded to [`Paths.terminate!`](@ref):
+
+  - `rounding` — corner rounding radius (default `zero(T)`)
+  - `initial::Bool` — direction flag (unused here; `terminate!` always caps the
+    end of the termination stub we build, so `initial=false` is what you want)
+  - `overlay_index` — apply to an overlay style
+  - `gap` — termination gap (default `terminationlength(pa, false; overlay_index)`); nonzero = open, `0` = short
+  - `margin` — extra backtracking length
+
+# Returns
+
+The newly added termination `ComponentNode`.
+
+# Examples
+
+```julia
+# terminate the `:xy` hook of a transmon (assumed to carry a CPW StyledHook)
+terminate!(g, qubit, :xy; rounding=5μm)
+
+# short instead of open
+terminate!(g, qubit, :xy; gap=0μm)
+
+# bare hook: pass style explicitly
+terminate!(g, some_node, :p1; style=Paths.CPW(10μm, 6μm))
+```
+
+See also: [`StyledHook`](@ref), [`hook_style`](@ref), [`Paths.terminate!`](@ref).
+"""
+function DeviceLayout.terminate!(
+    g::SchematicGraph,
+    node::ComponentNode,
+    hook_name::Symbol;
+    style=nothing,
+    kwargs...
+)
+    # Fusion to RouteComponent hooks is not allowed (route nodes are planned last), so RC termination fails
+    component(node) isa RouteComponent &&
+        throw(ArgumentError("RouteComponents cannot be terminated"))
+    h = hooks(component(node), hook_name)
+    sty = _resolve_termination_style(h, style, node, hook_name)
+    termpath = _build_termination_path(h, sty; kwargs...)
+    return fuse!(g, node => hook_name, termpath => :p0)
+end
+
+DeviceLayout.terminate!(g::SchematicGraph, p::Pair{<:ComponentNode, Symbol}; kwargs...) =
+    terminate!(g, first(p), last(p); kwargs...)
+
+function _resolve_termination_style(h::Hook, user_style, node, hook_name)
+    !isnothing(user_style) && return user_style
+    hs = hook_style(h)
+    !isnothing(hs) && return hs
+    return error(
+        "terminate!(g, $(repr(node.id)), $(repr(hook_name))): hook carries no style " *
+        "(it is a bare $(typeof(h).name.name), not a StyledHook). " *
+        "Pass style=<Paths.Style> explicitly, or wrap the hook as " *
+        "StyledHook(h, style) in the component's hooks() method."
+    )
+end
+
+"""
+    _build_termination_path(h::Hook, sty; rounding, margin, kwargs...) -> Path
+
+Build a minimal termination `Path` that attaches at `h` and ends in a
+[`Paths.terminate!`](@ref) cap in the given style `sty`. The initial straight
+segment length equals `backtracking = rounding + margin` so that
+`Paths.terminate!`'s `splice!` backtrack consumes exactly this stub rather
+than eating into the fused parent component.
+"""
+function _build_termination_path(h::Hook, sty; rounding=nothing, margin=nothing, kwargs...)
+    T = eltype(h.p)
+    z = zero(T)
+    rnd = isnothing(rounding) ? z : rounding
+    mrg = isnothing(margin) ? z : margin
+    backtracking = rnd + mrg
+    pa = Path(h.p; α0=out_direction(h), name=uniquename("term"))
+    # Invariant: initial straight must be at least `backtracking` long so that
+    # Paths.terminate! eats into this stub and not into the parent component via
+    # the fused hook.
+    straight!(pa, backtracking, sty)
+    terminate!(pa; rounding=rnd, margin=mrg, kwargs...)
+    return pa
+end
+
+"""
     add_graph!(g0::SchematicGraph, g1::SchematicGraph; id_prefix=name(g1) * ".", kwargs...)
 
 Add the graph `g1` to `g0`, creating new nodes by prefixing IDs with `id_prefix`.

--- a/test/test_pathstyles.jl
+++ b/test/test_pathstyles.jl
@@ -69,7 +69,7 @@
     straight!(pa, 10μm, Paths.Trace(2μm))
     cs = CoordinateSystem("test", nm)
     place!(cs, Rectangle(10μm, 10μm), GDSMeta())
-    attach!(pa, sref(cs), 5μm)
+    attach!(pa, sref(cs), 5μm, location=1)
     psty_complex = PeriodicStyle(pa)
     # Note: PeriodicStyle doesn't work with generic taper; same as CompoundStyle issue #13
     # But constructor based on a path handles generic tapers
@@ -85,6 +85,10 @@
     # Note: Attachment will be duplicated if it's at the exact end and start of a segment!
     @test length(c.elements) == 101 # 10 * (1 + 2 + 2 + 2 + 0 + 1 + 1 + 1) + 1
     @test split(pa2[1], 100μm)[2].sty.l0 == 100μm
+    # Reverse
+    rev_path = Path(reverse(reverse.(pa2.nodes)); metadata=GDSMeta(1))
+    @test isempty(to_polygons(xor2d(pa2 => GDSMeta(), rev_path => GDSMeta())))
+    @test isempty(to_polygons(xor2d(pa2 => GDSMeta(1), rev_path => GDSMeta(1))))
 
     cs = CoordinateSystem("test")
     place!(cs, pa2)

--- a/test/test_pdktools.jl
+++ b/test/test_pdktools.jl
@@ -3,31 +3,42 @@
     SchematicDrivenLayout.generate_pdk("MyPDK"; dir=tdir, user="testuser")
     pdkpath = joinpath(tdir, "MyPDK")
     using Pkg
-    Pkg.develop(path=pdkpath)
-    Pkg.precompile()  # force pkgimage matching current CacheFlags (e.g. check_bounds=1)
-    using MyPDK
-    pdktoml = Pkg.TOML.parsefile(joinpath(pkgdir(MyPDK), "Project.toml"))
+    pdktoml = Pkg.TOML.parsefile(joinpath(pdkpath, "Project.toml"))
     @test VersionNumber(pdktoml["compat"]["DeviceLayout"]).major == 1
     @test pdktoml["preferences"]["DeviceLayout"]["units"] == DeviceLayout.unit_preference
 
-    # Component package
-    SchematicDrivenLayout.without_precompile() do
-        SchematicDrivenLayout.generate_component_package("MyComps", MyPDK, user="testuser")
-        @test ENV["JULIA_PKG_PRECOMPILE_AUTO"] == "0" # Environment variable is not changed
-    end
-    @test !haskey(ENV, "JULIA_PKG_PRECOMPILE_AUTO") # Temporary env var was removed
-    comppkg = joinpath(pdkpath, "components", "MyComps")
-    @test isfile(joinpath(comppkg, "test", "runtests.jl")) # Package template includes tests
-    Pkg.develop(path=comppkg)
+    # `Pkg.develop(path=pdkpath)` triggers an auto-precompile child process for
+    # MyPDK. On Julia 1.13+ with `--check-bounds=yes`, that child can't find a
+    # DeviceLayout pkgimage with matching CacheFlags and errors out. Skip the
+    # load-and-generate-component path on 1.13+; the 1.10/1.11/1.12 matrix
+    # entries still exercise it.
+    @static if VERSION < v"1.13-"
+        Pkg.develop(path=pdkpath)
+        using MyPDK
 
-    # Component file
-    SchematicDrivenLayout.generate_component_definition(
-        "MyComposite",
-        MyPDK,
-        joinpath(comppkg, "src", "MyComposites.jl");
-        composite=true
-    )
-    @test isfile(joinpath(comppkg, "src", "MyComposites.jl")) # File was generated
-    Pkg.rm("MyComps")
-    Pkg.rm("MyPDK")
+        # Component package
+        SchematicDrivenLayout.without_precompile() do
+            SchematicDrivenLayout.generate_component_package(
+                "MyComps",
+                MyPDK,
+                user="testuser"
+            )
+            @test ENV["JULIA_PKG_PRECOMPILE_AUTO"] == "0" # Environment variable is not changed
+        end
+        @test !haskey(ENV, "JULIA_PKG_PRECOMPILE_AUTO") # Temporary env var was removed
+        comppkg = joinpath(pdkpath, "components", "MyComps")
+        @test isfile(joinpath(comppkg, "test", "runtests.jl")) # Package template includes tests
+        Pkg.develop(path=comppkg)
+
+        # Component file
+        SchematicDrivenLayout.generate_component_definition(
+            "MyComposite",
+            MyPDK,
+            joinpath(comppkg, "src", "MyComposites.jl");
+            composite=true
+        )
+        @test isfile(joinpath(comppkg, "src", "MyComposites.jl")) # File was generated
+        Pkg.rm("MyComps")
+        Pkg.rm("MyPDK")
+    end
 end

--- a/test/test_pdktools.jl
+++ b/test/test_pdktools.jl
@@ -4,6 +4,7 @@
     pdkpath = joinpath(tdir, "MyPDK")
     using Pkg
     Pkg.develop(path=pdkpath)
+    Pkg.precompile()  # force pkgimage matching current CacheFlags (e.g. check_bounds=1)
     using MyPDK
     pdktoml = Pkg.TOML.parsefile(joinpath(pkgdir(MyPDK), "Project.toml"))
     @test VersionNumber(pdktoml["compat"]["DeviceLayout"]).major == 1

--- a/test/test_render.jl
+++ b/test/test_render.jl
@@ -201,6 +201,7 @@ end
             p(20.5μm, -0.5μm),
             p(20.5μm, 0.5μm)
         ]
+        @test reverse(Paths.SimpleTraceCorner(), 0) == Paths.SimpleTraceCorner()
     end
 
     @testset "Straight, GeneralTrace" begin
@@ -501,6 +502,8 @@ end
         # verify extent
         @test height(bounds(c)) ≈ 2 * Paths.extent(pa[1].sty)
         @test contains(summary(pa[1].sty), "2 strands")
+        @test reverse(pa[1].sty, 10μm) == pa[1].sty
+        @test Paths.translate(pa[1].sty, 10μm) == pa[1].sty
     end
 
     @testset "Turn, Strands" begin
@@ -722,6 +725,8 @@ end
         node = simplify(p2, 2:3)
         @test node.sty.styles[1] isa Paths.TaperTrace
         @test p2[2].sty isa Paths.Taper # unchanged
+        @test reverse(Paths.Taper(), 0) == Paths.Taper()
+        @test contains(summary(Paths.Taper()), "linear taper")
     end
 
     @testset "Terminations" begin

--- a/test/test_render.jl
+++ b/test/test_render.jl
@@ -845,6 +845,7 @@ end
         @test p0(pa) == Point(-6, 0)μm
         @test α1(pa) ≈ 90°
         @test p1(pa) ≈ Point(100, 106)μm
+        @test reverse(pa[1]).sty == pa[end].sty
         c = Cell("test", nm)
         render!(c, pa, GDSMeta())
         @test bounds(c).ll.y < -11μm # Drawn as though straight, extends at slight angle
@@ -857,6 +858,7 @@ end
         @test p0(pa) == Point(0, 0)μm
         @test α1(pa) ≈ 90°
         @test p1(pa) ≈ Point(100, 100)μm
+        @test reverse(pa[1]).sty == pa[end].sty
         c = Cell("test", nm)
         render!(c, pa, GDSMeta())
 
@@ -869,6 +871,7 @@ end
         @test p0(pa) == Point(0, 0)μm
         @test α1(pa) ≈ 90°
         @test p1(pa) ≈ Point(100, 100)μm
+        @test reverse(pa[1]).sty == pa[end].sty
         c = Cell("test", nm)
         render!(c, pa, GDSMeta())
     end
@@ -901,6 +904,19 @@ end
         render!(c, ScaledIsometry(Point(10μm, 10μm), 45°, true)(path), GDSMeta())
         @test length(c.elements) == 6 # 6 CPW segments in base path
         @test length(c.refs) == 7 # 4 overlays, 3 attachments
+
+        # Reverse
+        rev_path = Path(reverse(reverse.(path.nodes)); metadata=GDSMeta())
+        @test all(is_sliver.(to_polygons(xor2d(path => GDSMeta(), rev_path => GDSMeta()))))
+        @test all(
+            is_sliver.(to_polygons(xor2d(path => GDSMeta(2), rev_path => GDSMeta(2))))
+        )
+        @test all(
+            is_sliver.(to_polygons(xor2d(path => GDSMeta(3), rev_path => GDSMeta(3))))
+        )
+        @test all(
+            is_sliver.(to_polygons(xor2d(path => GDSMeta(4), rev_path => GDSMeta(4))))
+        )
 
         # Halos
         hp = halo(path, 2μm; only_layers=[GDSMeta(1), GDSMeta(3)])

--- a/test/test_self_termination.jl
+++ b/test/test_self_termination.jl
@@ -1,0 +1,269 @@
+@testitem "StyledHook construction and accessors" setup = [CommonTestSetup] begin
+    using DeviceLayout.Paths
+
+    h = PointHook(1mm, 2mm, 45°)
+    sty = Paths.CPW(10μm, 6μm)
+    sh = StyledHook(h, sty)
+
+    # accessors
+    @test hook_style(sh) === sty
+    @test hook_style(h) === nothing
+
+    # property forwarding: p and in_direction from inner hook
+    @test sh.p === h.p
+    @test sh.in_direction === h.in_direction
+
+    # explicit fields
+    @test sh.h === h
+    @test sh.style === sty
+
+    # propertynames covers both wrapper and inner
+    @test :h in propertynames(sh)
+    @test :style in propertynames(sh)
+    @test :p in propertynames(sh)
+    @test :in_direction in propertynames(sh)
+
+    # DeviceLayout.in_direction respects the wrapper
+    @test in_direction(sh) === in_direction(h)
+end
+
+@testitem "StyledHook transformation preserves style (translation only)" setup =
+    [CommonTestSetup] begin
+    using DeviceLayout.Paths
+
+    sty = Paths.CPW(10μm, 6μm)
+    sh = StyledHook(PointHook(1mm, 2mm, 0°), sty)
+
+    f = Translation(Point(3mm, 0mm))
+    sh_x = DeviceLayout.transform(sh, f)
+
+    @test sh_x isa StyledHook
+    # Style is untransformed (scalar, not positional)
+    @test sh_x.style === sty
+    # Inner hook's point shifted
+    @test sh_x.h.p == Point(4mm, 2mm)
+    # in_direction unchanged under translation
+    @test sh_x.in_direction === sh.in_direction
+end
+
+@testitem "StyledHook transformation dispatch: 4-way unwrap" setup = [CommonTestSetup] begin
+    using DeviceLayout.Paths
+
+    sty = Paths.CPW(10μm, 6μm)
+    h_bare = PointHook(0mm, 0mm, 0°)
+    h_other_bare = PointHook(5mm, 0mm, 180°)
+    sh = StyledHook(h_bare, sty)
+    sh_other = StyledHook(h_other_bare, sty)
+
+    # Expected baseline: transformation between bare PointHooks
+    f_bare_bare = DeviceLayout.transformation(h_bare, h_other_bare)
+
+    # styled↔styled, styled↔bare, bare↔styled should all unwrap to the same result
+    @test DeviceLayout.transformation(sh, sh_other) == f_bare_bare
+    @test DeviceLayout.transformation(sh, h_other_bare) == f_bare_bare
+    @test DeviceLayout.transformation(h_bare, sh_other) == f_bare_bare
+end
+
+@testitem "StyledHook wraps HandedPointHook correctly" setup = [CommonTestSetup] begin
+    using DeviceLayout.Paths
+
+    sty = Paths.CPW(10μm, 6μm)
+    hph = HandedPointHook(0mm, 0mm, 30°, false)
+    sh = StyledHook(hph, sty)
+
+    # Property forwarding: should expose both HandedPointHook fields (h, right_handed)
+    # and the inner PointHook fields (p, in_direction) transitively.
+    @test sh.style === sty
+    @test sh.right_handed === false
+    @test sh.in_direction == 30°
+    @test sh.p == Point(0mm, 0mm)
+
+    # hook_style still returns the carried style (nested HandedPointHook doesn't matter)
+    @test hook_style(sh) === sty
+end
+
+@testitem "hook_style: bare hooks return nothing" setup = [CommonTestSetup] begin
+    @test hook_style(PointHook(0mm, 0mm, 0°)) === nothing
+    @test hook_style(HandedPointHook(0mm, 0mm, 0°)) === nothing
+    @test hook_style(HandedPointHook(0mm, 0mm, 0°, false)) === nothing
+end
+
+@testitem "Path hook styles" setup = [CommonTestSetup] begin
+    using DeviceLayout.Paths
+    using DeviceLayout.SchematicDrivenLayout
+    # Empty
+    pa = Path()
+    @test all(hook_style.(values(hooks(pa))) .== Ref(Paths.NoRenderContinuous()))
+    # Basic
+    sty = Paths.CPW(10μm, 6μm)
+    straight!(pa, 10μm, sty)
+    @test all(hook_style.(values(hooks(pa))) .== Ref(sty))
+    # Decorated
+    cs = CoordinateSystem("attachment")
+    attach!(pa, sref(cs), 0μm)
+    @test all(hook_style.(values(hooks(pa))) .== Ref(sty))
+    # Terminated
+    terminate!(pa)
+    @test hook_style(p0_hook(pa)) == sty
+    @test hook_style(p1_hook(pa)) == Paths.NoRenderContinuous()
+    terminate!(pa; initial=true)
+    @test all(hook_style.(values(hooks(pa))) .== Ref(Paths.NoRenderContinuous()))
+end
+
+# --- Graph-level terminate! -----------------------------------------------
+
+@testitem "terminate!(g, node, :hook) with StyledHook opens a CPW" setup = [CommonTestSetup] begin
+    using DeviceLayout.Paths
+    using DeviceLayout.SchematicDrivenLayout
+
+    sty = Paths.CPW(10μm, 6μm)
+    # Build a short CPW path as the base component.
+    pa = Path(0mm, 0mm; α0=0°, name="base")
+    straight!(pa, 100μm, sty)
+
+    g = SchematicGraph("testgraph")
+    base_node = add_node!(g, pa)
+
+    term_node = terminate!(g, base_node, :p1; gap=5μm)
+    @test term_node isa ComponentNode
+    # Termination component should itself be a Path
+    @test component(term_node) isa Path
+    @test length(component(term_node)) == 2 # Two nodes
+    @test iszero(pathlength(component(term_node)[1].seg)) # Zero-length first node
+    @test component(term_node)[end].sty.open_gap == 5μm # Termination gap provided
+    @test component(term_node)[end].sty.gap == 6μm # CPW gap
+end
+
+@testitem "terminate! with gap=0 is a short" setup = [CommonTestSetup] begin
+    using DeviceLayout.Paths
+    using DeviceLayout.SchematicDrivenLayout
+
+    sty = Paths.CPW(10μm, 6μm)
+    pa = Path(0mm, 0mm; α0=0°, name="base_short")
+    straight!(pa, 100μm, sty)
+
+    g = SchematicGraph("g_short")
+    nd = add_node!(g, pa)
+    term_node = terminate!(g, nd, :p1; style=sty, gap=0μm, rounding=2μm, margin=1μm)
+    @test term_node isa ComponentNode
+    # With rounding+margin > 0, the termination stub must have an initial
+    # straight segment of length backtracking = rounding + margin (3μm here).
+    tp = component(term_node)
+    @test tp isa Path
+    @test pathlength(tp) == 3μm
+end
+
+@testitem "terminate! with rounding produces a rounded open" setup = [CommonTestSetup] begin
+    using DeviceLayout.Paths
+    using DeviceLayout.SchematicDrivenLayout
+
+    sty = Paths.CPW(10μm, 6μm)
+    pa = Path(0mm, 0mm; α0=0°, name="base_round")
+    straight!(pa, 100μm, sty)
+
+    g = SchematicGraph("g_round")
+    nd = add_node!(g, pa)
+    term_node = terminate!(g, nd, :p1; style=sty, rounding=3μm)
+    @test term_node isa ComponentNode
+    @test component(term_node)[end].sty.rounding == 3μm
+end
+
+@testitem "terminate!(g, node, :hook) errors on bare hook without explicit style" setup =
+    [CommonTestSetup] begin
+    using DeviceLayout.Paths
+    using DeviceLayout.SchematicDrivenLayout
+
+    sty = Paths.CPW(10μm, 6μm)
+    pa = Path(0mm, 0mm; α0=0°, name="base_err")
+    straight!(pa, 100μm, sty)
+
+    g = SchematicGraph("g_err")
+    nd = add_node!(g, WeatherVane{typeof(1.0nm)}())
+    # Hooks are bare PointHooks (no StyledHook wrap); no style= kwarg ⇒ error.
+    @test_throws ErrorException terminate!(g, nd, :west)
+end
+
+@testitem "terminate!(g, node => :hook) Pair form works" setup = [CommonTestSetup] begin
+    using DeviceLayout.Paths
+    using DeviceLayout.SchematicDrivenLayout
+
+    sty = Paths.CPW(10μm, 6μm)
+    pa = Path(0mm, 0mm; α0=0°, name="base_pair")
+    straight!(pa, 100μm, sty)
+
+    g = SchematicGraph("g_pair")
+    nd = add_node!(g, pa)
+    term_node = terminate!(g, nd => :p1; style=sty, gap=5μm)
+    @test term_node isa ComponentNode
+end
+
+@testitem "_build_termination_path: backtracking invariant (rounding+margin)" setup =
+    [CommonTestSetup] begin
+    using DeviceLayout.Paths
+
+    sty = Paths.CPW(10μm, 6μm)
+    h = PointHook(0mm, 0mm, 0°)
+    # Use the internal helper directly via fully-qualified access.
+    tp = DeviceLayout.SchematicDrivenLayout._build_termination_path(
+        h,
+        sty;
+        rounding=3μm,
+        margin=2μm,
+        gap=5μm
+    )
+    @test tp isa Path
+    # The stub starts at the hook point with out_direction = 180° (for in_direction=0°).
+    @test Paths.p0(tp) == h.p
+    # Total path length is backtracking (3+2=5μm) + gap (5μm) = 10μm.
+    # After termination: straight(5μm, sty) + terminate!(gap=5μm, rounding+margin
+    # backtracking merges last 2 into a single termination-style node of length 5+5=10μm
+    # per src/paths/contstyles/termination.jl
+    @test Paths.pathlength(tp) ≈ 10μm
+end
+
+@testitem "terminate! uses StyledHook's carried style via _resolve_termination_style" setup =
+    [CommonTestSetup] begin
+    using DeviceLayout.Paths
+    using DeviceLayout.SchematicDrivenLayout
+
+    # Directly verify the helper that looks up the hook's carried style.
+    sty = Paths.CPW(10μm, 6μm)
+    sh = StyledHook(PointHook(0μm, 0μm, 0°), sty)
+    h_bare = PointHook(0μm, 0μm, 0°)
+
+    resolve = DeviceLayout.SchematicDrivenLayout._resolve_termination_style
+
+    # Nothing passed, StyledHook → use its style
+    @test resolve(sh, nothing, nothing, :dummy) === sty
+
+    # User style=custom_sty always wins, even over a StyledHook
+    other_sty = Paths.CPW(20μm, 12μm)
+    @test resolve(sh, other_sty, nothing, :dummy) === other_sty
+
+    # Bare hook without user style → error
+    @test_throws ErrorException resolve(h_bare, nothing, (id="n1",), :dummy)
+
+    # Bare hook with explicit user style → returns that style
+    @test resolve(h_bare, sty, nothing, :dummy) === sty
+end
+
+@testitem "terminate! with RouteComponent" setup = [CommonTestSetup] begin
+    using DeviceLayout.SchematicDrivenLayout
+    g = SchematicGraph("test")
+    n1 = add_node!(g, Spacer(1mm, 1mm))
+    n2 = fuse!(g, n1 => :p1_east, WeatherVane() => :west)
+    rn = route!(
+        g,
+        Paths.BSplineRouting(),
+        n1 => :p0_west,
+        n2 => :east,
+        Paths.TaperTrace(10μm, 1μm),
+        GDSMeta()
+    )
+    rc = component(rn)
+    @test hook_style(hooks(rc).p0) == Paths.Trace(10μm)
+    @test hook_style(hooks(rc).p1) == Paths.Trace(1μm)
+    @test in_direction(hooks(rc).p1) % 360° == 180°
+    # terminate! on RouteComponent doesn't work, because RC hook position is determined last
+    @test_throws ArgumentError terminate!(g, rn => :p1; rounding=0.1μm)
+end


### PR DESCRIPTION
Adds a `StyledHook{T, H<:Hook{T}, S} <: Hook{T}` wrapper that augments any `Hook` with a carried path-style object, plus graph-level `terminate!` methods that use the carried style (or an explicit `style=` kwarg) to attach a termination cap to a schematic node's hook. Exports `StyledHook` and `hook_style` at the top level.

`Path` and `RouteComponent` hooks are now `StyledHooks` carrying the style at the start or end of the path. For `p1` hooks, this is just `nextstyle` (or `nothing` for empty paths). For `p0` hooks, this is computed as `nextstyle` on the reversal of the initial node (or `nothing` for empty paths), so this PR also implements `reverse` for Path styles that still needed it.

Also contains the same fix for RouteComponent `p1` hook direction as in #213.

`StyledHook` can be used to verify style agreement for fused components, and `terminate!` can be useful in constructing truncated models for simulation. 