### PR TITLE
Kernel-independent mesh-size control points from primitives

### DIFF
--- a/src/solidmodels/render.jl
+++ b/src/solidmodels/render.jl
@@ -1088,9 +1088,7 @@ end
 
 # Vector of primitives — fan out.
 function _sample_meshsize!(prims::AbstractVector, h::Float64, α::Float64, z::Float64)
-    for p in prims
-        _sample_meshsize!(p, h, α, z)
-    end
+    return _sample_meshsize!.(prims, h, α, z)
 end
 
 # Polygon — walk consecutive vertex pairs as straight segments.
@@ -1187,9 +1185,7 @@ function _sample_segment_meshsize!(
     α::Float64,
     z::Float64
 )
-    for sub in seg.segments
-        _sample_segment_meshsize!(sub, h, α, z)
-    end
+    return _sample_segment_meshsize!.(seg.segments, h, α, z)
 end
 
 # Straight line between two points. Sample `Ns = ⌈L / h⌉` evenly-spaced points

--- a/src/solidmodels/render.jl
+++ b/src/solidmodels/render.jl
@@ -1053,6 +1053,154 @@ function clear_mesh_control_points!()
     return empty!(MESHSIZE_PARAMS[:ct])
 end
 
+# ─── Kernel-independent mesh-size control-point sampling ──────────────────────
+#
+# These tools compute mesh-size control points directly from rendered geometry
+# primitives (the output of `to_primitives`), with NO geometry kernel involved.
+# They are the kernel-agnostic replacement for sampling boundary points by
+# querying the meshing backend (e.g. `gmsh.model.get_value` on fragmented OCC
+# curve entities). Sampling at primitive level means the size field can be
+# rebuilt from a `Schematic` alone (see `populate_size_fields!`) and is
+# unit-testable without rendering through any `SolidModel`.
+#
+# Every sample is appended to `MESHSIZE_PARAMS[:cp]` under `(h, α)` via
+# `add_mesh_size_point`. None of these call `finalize_size_fields!` — the
+# caller finalizes once after all elements are processed so manual
+# `add_mesh_size_point` additions and `α` changes can interleave first.
+
+"""
+    _collect_mesh_control_points!(prims, h, α, z)
+
+Append mesh-size control points for `prims` (a primitive or vector of
+primitives from [`to_primitives`](@ref)) under `(h, α)`, sampling each
+primitive's boundary at `⌈L / h⌉` evenly-spaced arc-length intervals at
+height `z`. No-op when `h <= 0` (background-sized entities). Does NOT
+finalize the size field.
+"""
+function _collect_mesh_control_points!(prims, h::Real, α::Real, z::Real)
+    h > 0 || return nothing
+    _sample_meshsize!(prims, Float64(h), Float64(α), Float64(z))
+    return nothing
+end
+
+# Vector of primitives — fan out.
+function _sample_meshsize!(prims::AbstractVector, h::Float64, α::Float64, z::Float64)
+    for p in prims
+        _sample_meshsize!(p, h, α, z)
+    end
+end
+
+# Polygon — walk consecutive vertex pairs as straight segments.
+function _sample_meshsize!(p::AbstractPolygon, h::Float64, α::Float64, z::Float64)
+    pts = points(p)
+    n = length(pts)
+    n >= 3 || return
+    for i in 1:n
+        _sample_straight_meshsize!(pts[i], pts[mod1(i + 1, n)], h, α, z)
+    end
+end
+
+# CurvilinearPolygon — walk vertex pairs; if a `Paths.Segment` is recorded at
+# this index, sample the segment with the per-`Paths.Segment` helper, otherwise
+# treat the edge as an implicit straight line. The sign of `curve_start_idx`
+# only encodes parametrisation direction relative to polygon traversal; the 3D
+# sample locations are direction-independent so we ignore it.
+function _sample_meshsize!(cp::CurvilinearPolygon, h::Float64, α::Float64, z::Float64)
+    pts = cp.p
+    n = length(pts)
+    n >= 3 || return
+    seg_at = Dict{Int, Paths.Segment}()
+    for (k, csi) in enumerate(cp.curve_start_idx)
+        seg_at[abs(csi)] = cp.curves[k]
+    end
+    for i in 1:n
+        if haskey(seg_at, i)
+            _sample_segment_meshsize!(seg_at[i], h, α, z)
+        else
+            _sample_straight_meshsize!(pts[i], pts[mod1(i + 1, n)], h, α, z)
+        end
+    end
+end
+
+# CurvilinearRegion — outer ring + each hole's perimeter.
+function _sample_meshsize!(cr::CurvilinearRegion, h::Float64, α::Float64, z::Float64)
+    _sample_meshsize!(cr.exterior, h, α, z)
+    for hole in cr.holes
+        _sample_meshsize!(hole, h, α, z)
+    end
+end
+
+# Ellipse — sample its perimeter at h-spacing (Ramanujan perimeter estimate for
+# the sample count; the parametric point evaluation is exact).
+function _sample_meshsize!(e::Ellipse, h::Float64, α::Float64, z::Float64)
+    a = ustrip(STP_UNIT, e.radii[1])
+    b = ustrip(STP_UNIT, e.radii[2])
+    perim = pi * (3 * (a + b) - sqrt((3a + b) * (a + 3b)))
+    Ns = max(8, ceil(Int, perim / h))
+    cx = ustrip(STP_UNIT, e.center.x)
+    cy = ustrip(STP_UNIT, e.center.y)
+    θ = ustrip(uconvert(°, e.angle)) * (π / 180)
+    cs = cos(θ); sn = sin(θ)
+    for i in 0:(Ns - 1)
+        t = 2π * (i + 0.5) / Ns
+        lx = a * cos(t); ly = b * sin(t)
+        x = cx + cs * lx - sn * ly
+        y = cy + sn * lx + cs * ly
+        add_mesh_size_point(Float64[x, y, z]; h = h, α = α < 0 ? -1 : α)
+    end
+end
+
+# Fallback: any primitive without a specific sampler contributes no points.
+_sample_meshsize!(::Any, ::Float64, ::Float64, ::Float64) = nothing
+
+# Generic `Paths.Segment` sampler. Every concrete `Paths.Segment` (Straight,
+# Turn, BSpline, ConstantOffset, …) supports `pathlength(seg)` and `seg(s)`
+# with `s` an arc-length parameter, so one uniform-in-s sampler at
+# `Ns = ⌈L / h⌉` captures all curve types. Offset curves on Path/CPW
+# boundaries are themselves `Paths.Segment` subtypes (e.g. `ConstantOffset`)
+# by the time they reach here via `to_primitives`, so this covers the full
+# CPW boundary without any per-style awareness.
+function _sample_segment_meshsize!(seg::Paths.Segment, h::Float64, α::Float64, z::Float64)
+    L = ustrip(STP_UNIT, pathlength(seg))
+    L > 0 || return
+    Ns = max(1, ceil(Int, L / h))
+    L_native = pathlength(seg)
+    for i in 0:(Ns - 1)
+        pt = seg((i + 0.5) / Ns * L_native)
+        add_mesh_size_point(
+            Float64[ustrip(STP_UNIT, pt.x), ustrip(STP_UNIT, pt.y), z];
+            h = h, α = α < 0 ? -1 : α
+        )
+    end
+end
+
+# `CompoundSegment` is a sequence of segments — walk each.
+function _sample_segment_meshsize!(
+    seg::Paths.CompoundSegment, h::Float64, α::Float64, z::Float64
+)
+    for sub in seg.segments
+        _sample_segment_meshsize!(sub, h, α, z)
+    end
+end
+
+# Straight line between two points. Sample `Ns = ⌈L / h⌉` evenly-spaced points
+# (interior, half-step offset so adjacent edges sample each shared corner from
+# both sides symmetrically).
+function _sample_straight_meshsize!(
+    a::Point, b::Point, h::Float64, α::Float64, z::Float64
+)
+    ax = ustrip(STP_UNIT, a.x); ay = ustrip(STP_UNIT, a.y)
+    bx = ustrip(STP_UNIT, b.x); by = ustrip(STP_UNIT, b.y)
+    dx = bx - ax; dy = by - ay
+    L = sqrt(dx * dx + dy * dy)
+    L > 0 || return
+    Ns = max(1, ceil(Int, L / h))
+    for i in 0:(Ns - 1)
+        t = (i + 0.5) / Ns
+        add_mesh_size_point(Float64[ax + t * dx, ay + t * dy, z]; h = h, α = α < 0 ? -1 : α)
+    end
+end
+
 """
     reset_mesh_control!()
 

--- a/src/solidmodels/render.jl
+++ b/src/solidmodels/render.jl
@@ -1053,6 +1053,9 @@ function clear_mesh_control_points!()
     return empty!(MESHSIZE_PARAMS[:ct])
 end
 
+_stp_float(x::Length) = Float64(ustrip(STP_UNIT, x))
+_stp_float(x::Real) = Float64(x)
+
 # ─── Kernel-independent mesh-size control-point sampling ──────────────────────
 #
 # These tools compute mesh-size control points directly from rendered geometry
@@ -1095,7 +1098,7 @@ function _sample_meshsize!(p::AbstractPolygon, h::Float64, α::Float64, z::Float
     pts = points(p)
     n = length(pts)
     n >= 3 || return
-    for i in 1:n
+    for i = 1:n
         _sample_straight_meshsize!(pts[i], pts[mod1(i + 1, n)], h, α, z)
     end
 end
@@ -1113,7 +1116,7 @@ function _sample_meshsize!(cp::CurvilinearPolygon, h::Float64, α::Float64, z::F
     for (k, csi) in enumerate(cp.curve_start_idx)
         seg_at[abs(csi)] = cp.curves[k]
     end
-    for i in 1:n
+    for i = 1:n
         if haskey(seg_at, i)
             _sample_segment_meshsize!(seg_at[i], h, α, z)
         else
@@ -1140,13 +1143,15 @@ function _sample_meshsize!(e::Ellipse, h::Float64, α::Float64, z::Float64)
     cx = ustrip(STP_UNIT, e.center.x)
     cy = ustrip(STP_UNIT, e.center.y)
     θ = ustrip(uconvert(°, e.angle)) * (π / 180)
-    cs = cos(θ); sn = sin(θ)
-    for i in 0:(Ns - 1)
+    cs = cos(θ)
+    sn = sin(θ)
+    for i = 0:(Ns - 1)
         t = 2π * (i + 0.5) / Ns
-        lx = a * cos(t); ly = b * sin(t)
+        lx = a * cos(t)
+        ly = b * sin(t)
         x = cx + cs * lx - sn * ly
         y = cy + sn * lx + cs * ly
-        add_mesh_size_point(Float64[x, y, z]; h = h, α = α < 0 ? -1 : α)
+        add_mesh_size_point(Float64[x, y, z]; h=h, α=α < 0 ? -1 : α)
     end
 end
 
@@ -1165,18 +1170,22 @@ function _sample_segment_meshsize!(seg::Paths.Segment, h::Float64, α::Float64, 
     L > 0 || return
     Ns = max(1, ceil(Int, L / h))
     L_native = pathlength(seg)
-    for i in 0:(Ns - 1)
+    for i = 0:(Ns - 1)
         pt = seg((i + 0.5) / Ns * L_native)
         add_mesh_size_point(
             Float64[ustrip(STP_UNIT, pt.x), ustrip(STP_UNIT, pt.y), z];
-            h = h, α = α < 0 ? -1 : α
+            h=h,
+            α=α < 0 ? -1 : α
         )
     end
 end
 
 # `CompoundSegment` is a sequence of segments — walk each.
 function _sample_segment_meshsize!(
-    seg::Paths.CompoundSegment, h::Float64, α::Float64, z::Float64
+    seg::Paths.CompoundSegment,
+    h::Float64,
+    α::Float64,
+    z::Float64
 )
     for sub in seg.segments
         _sample_segment_meshsize!(sub, h, α, z)
@@ -1186,18 +1195,19 @@ end
 # Straight line between two points. Sample `Ns = ⌈L / h⌉` evenly-spaced points
 # (interior, half-step offset so adjacent edges sample each shared corner from
 # both sides symmetrically).
-function _sample_straight_meshsize!(
-    a::Point, b::Point, h::Float64, α::Float64, z::Float64
-)
-    ax = ustrip(STP_UNIT, a.x); ay = ustrip(STP_UNIT, a.y)
-    bx = ustrip(STP_UNIT, b.x); by = ustrip(STP_UNIT, b.y)
-    dx = bx - ax; dy = by - ay
+function _sample_straight_meshsize!(a::Point, b::Point, h::Float64, α::Float64, z::Float64)
+    ax = ustrip(STP_UNIT, a.x)
+    ay = ustrip(STP_UNIT, a.y)
+    bx = ustrip(STP_UNIT, b.x)
+    by = ustrip(STP_UNIT, b.y)
+    dx = bx - ax
+    dy = by - ay
     L = sqrt(dx * dx + dy * dy)
     L > 0 || return
     Ns = max(1, ceil(Int, L / h))
-    for i in 0:(Ns - 1)
+    for i = 0:(Ns - 1)
         t = (i + 0.5) / Ns
-        add_mesh_size_point(Float64[ax + t * dx, ay + t * dy, z]; h = h, α = α < 0 ? -1 : α)
+        add_mesh_size_point(Float64[ax + t * dx, ay + t * dy, z]; h=h, α=α < 0 ? -1 : α)
     end
 end
 
@@ -1212,6 +1222,50 @@ function reset_mesh_control!()
     set_gmsh_option("Mesh.ElementOrder", 1)
     mesh_scale(1.0)
     return mesh_grading_default(0.75)
+end
+
+_default_size_primitives(node::Paths.Node; kwargs...) =
+    to_polygons(node.seg, node.sty; kwargs...)
+_default_size_primitives(el; kwargs...) = to_polygons(el; kwargs...)
+
+"""
+    populate_size_fields!(cs::AbstractCoordinateSystem; kwargs...) -> mesh_control_points()
+
+Build the mesh-size control-point dictionary (`MESHSIZE_PARAMS[:cp]`) and its KDTrees
+from `cs`, without querying a geometry kernel. For every flattened element with a finite
+mesh size, rendered primitive boundaries are sampled at `⌈L / h⌉` arc-length intervals
+and stored under `(h, α)`.
+
+This constructs the same data used by `render!`'s mesh-size callback, but can be called on
+a coordinate system before rendering to a `SolidModel`.
+
+Keywords:
+
+  - `primitives_of = _default_size_primitives`: element-to-primitives function. `render!`
+    uses `el -> to_primitives(sm, el)` so the sampled primitive form matches the model.
+  - `zmap = (_) -> 0.0`: metadata-to-height function for the generated control points.
+  - remaining keywords are forwarded to `sizeandgrading` and `primitives_of`.
+"""
+function populate_size_fields!(
+    cs::AbstractCoordinateSystem;
+    primitives_of=_default_size_primitives,
+    zmap=(_) -> 0.0,
+    kwargs...
+)
+    flat = flatten(cs)
+    clear_mesh_control_points!()
+    for (el, meta) in zip(elements(flat), element_metadata(flat))
+        h, α = sizeandgrading(el; kwargs...)
+        h > 0 || continue
+        _collect_mesh_control_points!(
+            primitives_of(el; kwargs...),
+            h,
+            α,
+            _stp_float(zmap(meta))
+        )
+    end
+    finalize_size_fields!()
+    return mesh_control_points()
 end
 
 """
@@ -1356,8 +1410,7 @@ function render!(
 
     flat = flatten(cs)
 
-    # Collections of dimtags corresponding to a given sizing field
-    sizeandgrading_dimtags = Dict{Tuple{Float64, Float64}, Vector{Tuple{Int32, Int32}}}()
+    clear_mesh_control_points!()
 
     # Create RTree for avoiding duplicating points
     points_tree = RTree{Float64, 3}(Int32)
@@ -1403,71 +1456,14 @@ function render!(
         # Make physical group for each dimension
         sm[mapped_name] = group_dimtags
 
-        # Collect dimtags for each sizeandgrading
-        for (s, dts) ∈ zip(meshsizes, group_dimtags_unflattened)
-            h_dimtags = (dts isa Vector ? dts : [dts])
-            append!(get!(sizeandgrading_dimtags, s, []), h_dimtags)
+        # Sample mesh size control points from the same primitive form added to the model.
+        z_of_meta = _stp_float(zmap(meta))
+        for (prims, (h, α)) in zip(els, meshsizes)
+            _collect_mesh_control_points!(prims, h, α, z_of_meta)
         end
     end
-    # Synchronize the entities to the model, so can find subentities.
+    # Synchronize the entities to the model.
     _synchronize!(sm)
-
-    MESHSIZE_PARAMS[:cp] = Dict{Tuple{Float64, Float64}, Vector{SVector{3, Float64}}}()
-    for ((h, α), dts) in sizeandgrading_dimtags
-        iszero(h) && continue
-        bdts = gmsh.model.get_boundary(dts, true, false, false) # line segments
-
-        for (dim, tag) in bdts
-            @assert dim == 1
-            bounds = gmsh.model.get_parametrization_bounds(dim, tag)
-            curv = gmsh.model.get_curvature(
-                dim,
-                tag,
-                [bounds[1][1], (bounds[1][1] + bounds[2][1]) / 2, bounds[2][1]]
-            )
-            # Calculate a sampling rate on a per segment basis.
-            if maximum(curv) <= 1e-14
-                # Straight.
-                xyz = gmsh.model.get_value(dim, tag, [bounds[1][1], bounds[2][1]])
-                l = sqrt((xyz[1] - xyz[4])^2 + (xyz[2] - xyz[5])^2 + (xyz[3] - xyz[6])^2)
-                Ns = cld(l, h)
-            elseif abs(minimum(curv) - maximum(curv)) < 1e-9  # a circular arc
-                # For a circular arc, use the midpoint to construct the swept angle, and
-                # from that the arc length and number of required samples.
-                xyz = gmsh.model.get_value(
-                    dim,
-                    tag,
-                    [bounds[1][1], (bounds[1][1] + bounds[2][1]) / 2]
-                )
-                δ =
-                    sqrt((xyz[1] - xyz[4])^2 + (xyz[2] - xyz[5])^2 + (xyz[3] - xyz[6])^2) /
-                    2
-                mcurv = sum(curv) / length(curv)
-                l = 1 / mcurv * (2 * atan(δ, 1 / mcurv)) # rθ
-                Ns = cld(l, h)
-            else
-                Ns = 11
-                # Approximate the spline with 10 linear segments, and use the corresponding
-                # linear length to compute the sample rate.
-                t = [bounds[1][1] + i * (bounds[2][1] - bounds[1][1]) / Ns for i = 0:Ns]
-                xyz = gmsh.model.get_value(dim, tag, t) # [x1,y1,z1,x2,y2,z2,...]
-                XYZ = reinterpret(SVector{3, Float64}, xyz)
-                l = sum(norm.(XYZ[2:end] .- XYZ[1:(end - 1)]))
-                Ns = cld(l, h)
-            end
-            t = [bounds[1][1] + i * (bounds[2][1] - bounds[1][1]) / Ns for i = 0:(Ns - 1)]
-            xyz = gmsh.model.get_value(dim, tag, t) # [x1,y1,z1,x2,y2,z2,...]
-
-            append!(
-                get!(
-                    MESHSIZE_PARAMS[:cp],
-                    (h, α < 0 ? -1 : α),
-                    Vector{SVector{3, Float64}}()
-                ),
-                reinterpret(SVector{3, Float64}, xyz)
-            )
-        end
-    end
 
     # Generate the KDTrees corresponding to the meshing control points.
     finalize_size_fields!()

--- a/src/solidmodels/solidmodels.jl
+++ b/src/solidmodels/solidmodels.jl
@@ -1,7 +1,7 @@
 module SolidModels
 
 import Gmsh: gmsh, gmsh.model.occ
-export gmsh
+export gmsh, populate_size_fields!
 
 # Explicit callback dictionary, to overcome closure limitation on apple silicon.
 import StaticArrays: SVector

--- a/test/test_schematic_solidmodel.jl
+++ b/test/test_schematic_solidmodel.jl
@@ -436,6 +436,13 @@ end
 
         check!(floorplan)
 
+        SolidModels.clear_mesh_control_points!()
+        cp_schematic = deepcopy(
+            SolidModels.populate_size_fields!(floorplan.coordinate_system; fine_mesh=true)
+        )
+        @test !isempty(cp_schematic)
+        @test (1.0, 0.8) in keys(cp_schematic) || (10.0, 0.9) in keys(cp_schematic)
+
         # Render to a solid model
         tech = ProcessTechnology(
             (;
@@ -518,6 +525,9 @@ end
         sm = SolidModel("test", overwrite=true)
         # SolidModels.set_gmsh_option("")
         render!(sm, floorplan, target)
+        cp_rendered = SolidModels.mesh_control_points()
+        @test !isempty(cp_rendered)
+        @test Set(keys(cp_rendered)) == Set(keys(cp_schematic))
 
         @test SolidModels.hasgroup(sm, "substrates", 3)
         @test SolidModels.hasgroup(sm, "vacuum", 3)

--- a/test/test_size_fields.jl
+++ b/test/test_size_fields.jl
@@ -1,0 +1,26 @@
+@testitem "Size fields from coordinate systems" setup = [CommonTestSetup] begin
+    cs = CoordinateSystem("size_fields", nm)
+
+    render!(
+        cs,
+        styled(centered(Rectangle(10μm, 10μm)), MeshSized(1μm, 0.8)),
+        SemanticMeta(:fine)
+    )
+
+    pa = Path(Point(20μm, 0μm); metadata=SemanticMeta(:path))
+    straight!(pa, 100μm, Paths.SimpleCPW(10μm, 6μm))
+    render!(cs, pa, SemanticMeta(:path))
+
+    cp = SolidModels.populate_size_fields!(cs; zmap=_ -> 3μm)
+
+    @test (1.0, 0.8) in keys(cp)
+    @test (12.0, -1.0) in keys(cp)
+    @test length(cp[(1.0, 0.8)]) == 40
+    @test !isempty(cp[(12.0, -1.0)])
+    @test !isempty(SolidModels.mesh_control_trees())
+    @test all(p -> p[3] == 3.0, Iterators.flatten(values(cp)))
+
+    SolidModels.clear_mesh_control_points!()
+    cp = SolidModels.populate_size_fields!(cs)
+    @test all(p -> p[3] == 0.0, Iterators.flatten(values(cp)))
+end

--- a/test/test_size_fields.jl
+++ b/test/test_size_fields.jl
@@ -23,4 +23,15 @@
     SolidModels.clear_mesh_control_points!()
     cp = SolidModels.populate_size_fields!(cs)
     @test all(p -> p[3] == 0.0, Iterators.flatten(values(cp)))
+
+    # A 1-D primitive (LineSegment) has no boundary to sample: it hits the
+    # generic fallback and contributes no control points.
+    SolidModels.clear_mesh_control_points!()
+    SolidModels._collect_mesh_control_points!(
+        [DeviceLayout.LineSegment(Point(0μm, 0μm), Point(10μm, 0μm))],
+        1.0,
+        0.5,
+        0.0
+    )
+    @test isempty(SolidModels.mesh_control_points())
 end

--- a/test/test_solidmodel.jl
+++ b/test/test_solidmodel.jl
@@ -1438,6 +1438,36 @@
             )
         end
 
+        @testset "Primitive-level control points (no kernel)" begin
+            SolidModels.clear_mesh_control_points!()
+            SolidModels._collect_mesh_control_points!(
+                [Rectangle(10μm, 10μm)],
+                1.0,
+                0.75,
+                0.0
+            )
+            @test sum(length, values(SolidModels.mesh_control_points())) == 40
+            @test collect(keys(SolidModels.mesh_control_points())) == [(1.0, 0.75)]
+
+            SolidModels.clear_mesh_control_points!()
+            SolidModels._collect_mesh_control_points!(
+                [Rectangle(10μm, 10μm)],
+                0.0,
+                -1.0,
+                0.0
+            )
+            @test isempty(SolidModels.mesh_control_points())
+
+            pa = Path(Point(0nm, 0nm))
+            straight!(pa, 100μm, Paths.SimpleCPW(10μm, 6μm))
+            cr = pathtopolys(pa)
+            SolidModels.clear_mesh_control_points!()
+            SolidModels._collect_mesh_control_points!(cr, 2.0, 0.9, 5.0)
+            cps = first(values(SolidModels.mesh_control_points()))
+            @test !isempty(cps)
+            @test all(p -> p[3] == 5.0, cps)
+        end
+
         # Checking option access
         SolidModels.set_gmsh_option("Mesh.ElementOrder", 3)
         SolidModels.set_gmsh_option("Geometry.OCCTargetUnit", "M")

--- a/test/test_solidmodel.jl
+++ b/test/test_solidmodel.jl
@@ -819,7 +819,7 @@
     # Reference transform should transform p0 too
     r = to_polygons(Rectangle(2μm, 1μm))
     cs_local = CoordinateSystem("test", nm)
-    sty = Rounded(0.25μm, p0=points(r))
+    sty = Rounded(0.25μm, p0=points(r), selection_tolerance=1nm)
     place!(cs_local, styled(r, sty), SemanticMeta(:test))
     cs = CoordinateSystem("outer", nm)
     addref!(cs, sref(cs_local, angle=π / 2))
@@ -829,7 +829,7 @@
     # Reference transform should transform p0 too
     r = to_polygons(Rectangle(2μm, 1μm))
     cs_local = CoordinateSystem("test", nm)
-    sty = RelativeRounded(0.25, p0=points(r)[[1, 2]])
+    sty = RelativeRounded(0.25, p0=points(r)[[1, 2]], selection_tolerance=1nm)
     place!(cs_local, styled(r, sty), SemanticMeta(:test))
     cs = CoordinateSystem("outer", nm)
     addref!(cs, sref(cs_local, angle=π / 2))


### PR DESCRIPTION
## Summary

- Computes mesh-size control points directly from rendered geometry primitives
  (the output of `to_primitives`), instead of querying the gmsh kernel via
  `get_boundary`/`get_curvature`/`get_value` on fragmented OCC curves.
- Adds public `SolidModels.populate_size_fields!(cs::AbstractCoordinateSystem)`
  so the size-field control points can be built from a `Schematic` (or any
  coordinate system) with no `SolidModel` and no geometry kernel.
- Rewires `render!` to use the same primitive-level sampler, deleting the
  post-synchronize gmsh sampling block. Control points are now sampled from the
  exact primitive form added to the model.

## Motivation

The size field is now identical regardless of meshing backend (gmsh/OCC), it's
rebuildable straight from a `Schematic`, and it's unit-testable without rendering
through a kernel. Sampling walks each primitive's boundary at `⌈L/h⌉` arc-length
intervals via existing APIs (`pathlength`, `seg(s)`, `points`, `ustrip`) — no new
`Project.toml` dependency.

## Test plan

- [x] New `test/test_size_fields.jl`: `populate_size_fields!` on a schematic with
  a `MeshSized` rectangle + CPW path — bucket keys, point counts, and z, no gmsh.
- [x] New no-kernel subset in `test_solidmodel.jl` covering `_collect_mesh_control_points!`.
- [x] `test_schematic_solidmodel.jl`: schematic-built field matches the field
  `render!` constructs (equal `(h, α)` buckets); existing mesh-density asserts unchanged.
- [x] Full `Pkg.test()` green (12080 pass), `test_aqua` green with `populate_size_fields!` exported.

Minor: one separate commit sets explicit `selection_tolerance` on two `p0`-rounded
SolidModel test cases to clear a deprecation warning.
