### PR TITLE
Apply style guide to ExamplePDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ The format of this changelog is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+  - Renamed `ExamplePDK` component parameters to follow the component style guide
+    (`<feature>_<dimension>` naming, `_count`/`_trace`/`_radius`/`_gap` suffixes, no
+    `w_`/`h_`/`l_`/`n_` prefixes or non-searchable names) and added length-type
+    annotations to absolute `rounding` parameters. Affected components include
+    `ExampleChip`, `ExampleSeriesClawCapacitor`/`ExampleShuntClawCapacitor`,
+    `ExampleSimpleJunction`/`ExampleSimpleSQUID`, `ExampleTappedHairpin`,
+    `ExampleFilteredHairpinReadout`, `ExampleClawedMeanderReadout`, `ExampleStarTransmon`,
+    `ExampleStarIsland`, and `ExampleRectangleTransmon`/`ExampleRectangleIsland`. Magic
+    numbers in `ExampleStarTransmon`/`ExampleStarIsland` geometry were extracted to
+    parameters. `ExamplePDK` makes no API-stability guarantee, so these are not treated
+    as breaking changes to DeviceLayout.jl.
+
 ## 1.14.0 (2026-05-28)
 
   - Added `ParameterSet`, a nested dictionary wrapper with dot-access for reading and

--- a/docs/src/examples/qpu17.md
+++ b/docs/src/examples/qpu17.md
@@ -257,8 +257,12 @@ Here's how we define our main components, in `assemble_schematic_graph!`. The `@
 end
 ### Readout
 @component readout[1:5, 1:5] = ExampleFilteredHairpinReadout begin
-    filter_total_effective_length .= p.readout.RO_EFFECTIVE_LENGTH
-    readout_total_effective_length .= p.readout.RO_EFFECTIVE_LENGTH
+    # The components are parameterized by physical path length. Mapping a target frequency
+    # (here a tabulated effective quarter-wavelength) to a physical length is a device-level
+    # concern: subtract the ~1mm of effective length contributed by bends, bridges, and
+    # coupling capacitors that the resonators do not lay down as physical path.
+    filter_total_length .= p.readout.RO_EFFECTIVE_LENGTH .- 1.0mm
+    readout_total_length .= p.readout.RO_EFFECTIVE_LENGTH .- 1.0mm
     resonator_style = resonator_style
     resonator_bridge = RESONATOR_BRIDGE
     feedline_style = FEEDLINE_STYLE
@@ -266,17 +270,17 @@ end
     feedline_bridge = FEEDLINE_BRIDGE
 end
 # Manually set a few exceptions for floorplanning convenience
-readout[3, 1] = readout[3, 1](; extra_filter_l1=400μm)
-readout[2, 5] = readout[2, 5](; extra_filter_l1=700μm)
+readout[3, 1] = readout[3, 1](; extra_filter_length_1=400μm)
+readout[2, 5] = readout[2, 5](; extra_filter_length_1=700μm)
 readout[3, 3] = readout[3, 3](;
-    extra_filter_l1=550μm,
+    extra_filter_length_1=550μm,
     tap_position=0.45mm,
-    extra_filter_l2=710μm,
-    extra_filter_θ1=45°,
-    extra_filter_θ2=-45°,
+    extra_filter_length_2=710μm,
+    extra_filter_angle_1=45°,
+    extra_filter_angle_2=-45°,
     straight_length=1.0mm
 )
-readout[4, 1] = readout[4, 1](; extra_filter_l1=700μm)
+readout[4, 1] = readout[4, 1](; extra_filter_length_1=700μm)
 ```
 
 ### Connecting components

--- a/docs/src/tutorials/composite_components.md
+++ b/docs/src/tutorials/composite_components.md
@@ -62,13 +62,13 @@ A `CompositeComponent` uses `@compdef` just like a regular `Component`, but inhe
     junction_gap = 12μm
     junction_pos = :bottom
     island_rounding = 0μm
-    w_jj = 1μm
-    h_jj = 1μm
+    junction_width = 1μm
+    junction_lead_gap = 1μm
 end
 nothing # hide
 ```
 
-The parameters include both island parameters (`cap_width`, `cap_length`, `cap_gap`, `junction_pos`, `island_rounding`) and junction parameters (`w_jj`, `h_jj`). The composite owns all parameters and forwards the relevant subset to each subcomponent. The `junction_gap` parameter is shared — it controls both the island's gap on the junction side and the junction's total height.
+The parameters include both island parameters (`cap_width`, `cap_length`, `cap_gap`, `junction_pos`, `island_rounding`) and junction parameters (`junction_width`, `junction_lead_gap`). The composite owns all parameters and forwards the relevant subset to each subcomponent. The `junction_gap` parameter is shared — it controls both the island's gap on the junction side and the junction's total length.
 
 ## Step 3: Build the Subcomponents
 
@@ -88,9 +88,9 @@ function SchematicDrivenLayout._build_subcomponents(tr::SimpleTransmon)
 
     # Create the junction, forwarding its parameters
     @component junction = ExampleSimpleJunction(
-        w_jj = tr.w_jj,
-        h_jj = tr.h_jj,
-        h_ground_island = tr.junction_gap,
+        junction_width = tr.junction_width,
+        junction_lead_gap = tr.junction_lead_gap,
+        ground_island_length = tr.junction_gap,
     )
 
     return (island, junction)
@@ -98,7 +98,7 @@ end
 nothing # hide
 ```
 
-We use the `@component` macro to create each subcomponent — this automatically sets the component's `name` from the variable name. Notice how `junction_gap` on the composite maps to `junction_gap` on the island and `h_ground_island` on the junction — the composite provides a unified interface even when subcomponents use different parameter names for related or derived quantities.
+We use the `@component` macro to create each subcomponent — this automatically sets the component's `name` from the variable name. Notice how `junction_gap` on the composite maps to `junction_gap` on the island and `ground_island_length` on the junction — the composite provides a unified interface even when subcomponents use different parameter names for related or derived quantities.
 
 !!! tip "filter_parameters in real PDKs"
     DeviceLayout provides [`filter_parameters`](@ref) to automatically find parameters that share names between the composite and a subcomponent. This is convenient when many parameters pass through unchanged, but for this tutorial, explicit forwarding is clearer. See `ExampleRectangleTransmon` in the ExamplePDK source for this pattern.

--- a/docs/src/tutorials/parameter_set.md
+++ b/docs/src/tutorials/parameter_set.md
@@ -47,8 +47,8 @@ ps.components.capacitor.finger_width = 5μm
 ps.components.capacitor.finger_gap = 3μm
 ps.components.capacitor.finger_count = 6
 
-ps.components.junction.w_jj = 1μm
-ps.components.junction.h_jj = 1μm
+ps.components.junction.junction_width = 1μm
+ps.components.junction.junction_lead_gap = 1μm
 ```
 
 If you have the `YAML` package installed, you can load directly from a file:
@@ -66,8 +66,8 @@ components:
     finger_gap: 3μm
     finger_count: 6
   junction:
-    w_jj: 1μm
-    h_jj: 1μm
+    junction_width: 1μm
+    junction_lead_gap: 1μm
 ```
 
 ```julia
@@ -187,8 +187,8 @@ ps.components.transmon.island.cap_width = 24μm
 ps.components.transmon.island.cap_length = 520μm
 ps.components.transmon.island.cap_gap = 30μm
 
-ps.components.transmon.junction.w_jj = 1μm
-ps.components.transmon.junction.h_jj = 1μm
+ps.components.transmon.junction.junction_width = 1μm
+ps.components.transmon.junction.junction_lead_gap = 1μm
 ```
 
 Inside `_build_subcomponents`, use `parameter_set(g)` to access the graph's `ParameterSet`, then `create_component` to instantiate each subcomponent from its subtree. The shared `junction_gap` is read from the parameter set and forwarded to both subcomponents under their respective parameter names using `set_parameters` kwargs:
@@ -207,7 +207,7 @@ function SchematicDrivenLayout._build_subcomponents(tr::SimpleTransmon)
     # Forward shared parameter from parameter set to the junction component
     # under a different parameter name. A missing PS lookup would surface as
     # ParameterKeyError at this call site.
-    junction = set_parameters(junction; h_ground_island=ps.components.transmon.junction_gap)
+    junction = set_parameters(junction; ground_island_length=ps.components.transmon.junction_gap)
 
     return (island, junction)
 end
@@ -254,7 +254,7 @@ function SchematicDrivenLayout._build_subcomponents(tr::SimpleTransmonTemplated)
 
     junction = set_parameters(
         tr.templates.junction, ps, "components.$(name(tr)).junction";
-        h_ground_island=tr.junction_gap,
+        ground_island_length=tr.junction_gap,
     )
 
     return (island, junction)

--- a/examples/DemoQPU17/DemoQPU17.jl
+++ b/examples/DemoQPU17/DemoQPU17.jl
@@ -59,8 +59,12 @@ function assemble_schematic_graph!(g, p)
     end
     ### Readout
     @component readout[1:5, 1:5] = ExampleFilteredHairpinReadout begin
-        filter_total_effective_length .= p.readout.RO_EFFECTIVE_LENGTH
-        readout_total_effective_length .= p.readout.RO_EFFECTIVE_LENGTH
+        # The components are parameterized by physical path length. Mapping a target frequency
+        # (here a tabulated effective quarter-wavelength) to a physical length is a device-level
+        # concern: subtract the ~1mm of effective length contributed by bends, bridges, and
+        # coupling capacitors that the resonators do not lay down as physical path.
+        filter_total_length .= p.readout.RO_EFFECTIVE_LENGTH .- 1.0mm
+        readout_total_length .= p.readout.RO_EFFECTIVE_LENGTH .- 1.0mm
         resonator_style = resonator_style
         resonator_bridge = RESONATOR_BRIDGE
         feedline_style = FEEDLINE_STYLE
@@ -68,17 +72,17 @@ function assemble_schematic_graph!(g, p)
         feedline_bridge = FEEDLINE_BRIDGE
     end
     # Manually set a few exceptions for floorplanning convenience
-    readout[3, 1] = readout[3, 1](; extra_filter_l1=400μm)
-    readout[2, 5] = readout[2, 5](; extra_filter_l1=700μm)
+    readout[3, 1] = readout[3, 1](; extra_filter_length_1=400μm)
+    readout[2, 5] = readout[2, 5](; extra_filter_length_1=700μm)
     readout[3, 3] = readout[3, 3](;
-        extra_filter_l1=550μm,
+        extra_filter_length_1=550μm,
         tap_position=0.45mm,
-        extra_filter_l2=710μm,
-        extra_filter_θ1=45°,
-        extra_filter_θ2=-45°,
+        extra_filter_length_2=710μm,
+        extra_filter_angle_1=45°,
+        extra_filter_angle_2=-45°,
         straight_length=1.0mm
     )
-    readout[4, 1] = readout[4, 1](; extra_filter_l1=700μm)
+    readout[4, 1] = readout[4, 1](; extra_filter_length_1=700μm)
 
     ##### Assemble schematic
     ### Chip and launchers

--- a/examples/DemoQPU17/routing.jl
+++ b/examples/DemoQPU17/routing.jl
@@ -120,8 +120,10 @@ function calculate_readout_lengths(readout_nodes, readout_route_nodes, p)
             # Readout component contains feedline length; resonator is coupled halfway
             pathlength_from_input += readout_node.feedline_length / 2
             println("Length at $(site): $(uconvert(mm, pathlength_from_input))")
-            # Calculate remaining length to filter halfwavelength
-            filter_halfwavelength = 2 * readout_node.filter_total_effective_length
+            # Calculate remaining length to filter halfwavelength. The readout components are
+            # parameterized by physical length; add back the ~1mm device-level effective-length
+            # allowance (bends, bridges, coupling) to approximate the effective half-wavelength.
+            filter_halfwavelength = 2 * (readout_node.filter_total_length + 1.0mm)
             remainder = rem(pathlength_from_input, filter_halfwavelength)
             next_halfwave = filter_halfwavelength - remainder
             println(

--- a/examples/SingleTransmon/SingleTransmon.jl
+++ b/examples/SingleTransmon/SingleTransmon.jl
@@ -15,14 +15,14 @@ using PRIMA
 
 """
     single_transmon(
-        w_shield=2μm,
+        shield_width=2μm,
         claw_gap=6μm,
-        w_claw=34μm,
-        l_claw=121μm,
+        claw_trace=34μm,
+        claw_length=121μm,
         cap_width=24μm,
         cap_length=620μm,
         cap_gap=30μm,
-        n_meander_turns=5,
+        meander_turn_count=5,
         hanger_length=500μm,
         bend_radius=50μm,
         wave_ports::Bool=false,
@@ -32,15 +32,15 @@ using PRIMA
 Generate a SolidModel and mesh for a single transmon design, using a rectangular transmon island and claw resonator.
 """
 function single_transmon(;
-    w_shield=2μm,
+    shield_width=2μm,
     claw_gap=6μm,
-    w_claw=34μm,
-    l_claw=121μm,
+    claw_trace=34μm,
+    claw_length=121μm,
     cap_width=24μm,
     cap_length=620μm,
     cap_gap=30μm,
     total_length=5000μm,
-    n_meander_turns=5,
+    meander_turn_count=5,
     hanger_length=500μm,
     bend_radius=50μm,
     wave_ports::Bool=false,
@@ -58,14 +58,14 @@ function single_transmon(;
     PATH_STYLE = Paths.SimpleCPW(cpw_width, cpw_gap)
     BRIDGE_STYLE = ExamplePDK.bridge_geometry(PATH_STYLE)
     coupling_gap = 5μm
-    w_grasp = cap_width + 2 * cap_gap
+    grasp_width = cap_width + 2 * cap_gap
     arm_length = 428μm # straight length from meander exit to claw
-    total_height =
+    total_y_length =
         arm_length +
         coupling_gap +
         Paths.extent(PATH_STYLE) +
         hanger_length +
-        (3 + n_meander_turns * 2) * bend_radius
+        (3 + meander_turn_count * 2) * bend_radius
     ### Create abstract components
     ## Transmon
     qubit = ExampleRectangleTransmon(;
@@ -81,13 +81,13 @@ function single_transmon(;
         coupling_length=400μm,
         coupling_gap,
         total_length,
-        w_shield,
-        w_claw,
-        l_claw,
+        shield_width,
+        claw_trace,
+        claw_length,
         claw_gap,
-        w_grasp,
-        n_meander_turns,
-        total_height,
+        grasp_width,
+        meander_turn_count,
+        total_y_length,
         hanger_length,
         bend_radius,
         bridge=BRIDGE_STYLE

--- a/src/schematics/ExamplePDK/components/ChipTemplates/ChipTemplates.jl
+++ b/src/schematics/ExamplePDK/components/ChipTemplates/ChipTemplates.jl
@@ -25,14 +25,14 @@ A `Component` with rectangular geometry in the CHIP_AREA layer and uniformly spa
 # Parameters
 
   - `name = "chip"`: Name of component
-  - `num_ports_lr = 12`: Number of ports on the left and right edges
-  - `num_ports_tb = 12`: Number of ports on the top and bottom edges
-  - `length_x = 15mm`: x length of chip
-  - `length_y = 15mm`: y length of chip
-  - `dx = 1mm`: x spacing of ports on top and bottom
-  - `dy = 1mm`: y spacing of ports on left and right
-  - `edge_gap_lr = 0.050mm`: Gap between chip edge and ports on left and right
-  - `edge_gap_tb = 0.050mm`: Gap between chip edge and ports on top and bottom
+  - `port_lr_count = 12`: Number of ports on the left and right edges
+  - `port_tb_count = 12`: Number of ports on the top and bottom edges
+  - `chip_x_length = 15mm`: x length of chip
+  - `chip_y_length = 15mm`: y length of chip
+  - `port_tb_pitch = 1mm`: x spacing of ports on top and bottom
+  - `port_lr_pitch = 1mm`: y spacing of ports on left and right
+  - `port_lr_edge_gap = 0.050mm`: Gap between chip edge and ports on left and right
+  - `port_tb_edge_gap = 0.050mm`: Gap between chip edge and ports on top and bottom
 
 # Hooks
 
@@ -41,18 +41,18 @@ A `Component` with rectangular geometry in the CHIP_AREA layer and uniformly spa
 """
 @compdef struct ExampleChip <: Component
     name = "chip"
-    num_ports_lr = 12
-    num_ports_tb = 12
-    length_x = 15mm
-    length_y = 15mm
-    dx = 1mm
-    dy = 1mm
-    edge_gap_lr = 0.050mm
-    edge_gap_tb = 0.050mm
+    port_lr_count = 12
+    port_tb_count = 12
+    chip_x_length = 15mm
+    chip_y_length = 15mm
+    port_tb_pitch = 1mm
+    port_lr_pitch = 1mm
+    port_lr_edge_gap = 0.050mm
+    port_tb_edge_gap = 0.050mm
 end
 
 function SchematicDrivenLayout._geometry!(cs::CoordinateSystem, c::ExampleChip)
-    chip_rect = centered(Rectangle(c.length_x, c.length_y))
+    chip_rect = centered(Rectangle(c.chip_x_length, c.chip_y_length))
     # only_simulated would make these invisible to `bounds`, which we don't want
     # so these render by default and ignore for artwork
     not_artwork =
@@ -62,24 +62,24 @@ function SchematicDrivenLayout._geometry!(cs::CoordinateSystem, c::ExampleChip)
 end
 
 function SchematicDrivenLayout.hooks(c::ExampleChip)
-    x0 = c.dx * (c.num_ports_lr - 1) / 2
-    y0 = c.dy * (c.num_ports_tb - 1) / 2
+    x0 = c.port_tb_pitch * (c.port_lr_count - 1) / 2
+    y0 = c.port_lr_pitch * (c.port_tb_count - 1) / 2
     # Clockwise from left corner of top edge
-    xt = range(-x0, step=c.dx, length=c.num_ports_tb)
+    xt = range(-x0, step=c.port_tb_pitch, length=c.port_tb_count)
     xb = -xt
-    xl = fill(-c.length_x / 2 + c.edge_gap_lr, c.num_ports_lr)
+    xl = fill(-c.chip_x_length / 2 + c.port_lr_edge_gap, c.port_lr_count)
     xr = -xl
-    yb = fill(-c.length_y / 2 + c.edge_gap_tb, c.num_ports_tb)
+    yb = fill(-c.chip_y_length / 2 + c.port_tb_edge_gap, c.port_tb_count)
     yt = -yb
-    yl = range(-y0, step=c.dy, length=c.num_ports_lr)
+    yl = range(-y0, step=c.port_lr_pitch, length=c.port_lr_count)
     yr = -yl
     x = vcat(xt, xr, xb, xl)
     y = vcat(yt, yr, yb, yl)
     dirs = vcat(
-        fill(90°, c.num_ports_tb),
-        fill(0°, c.num_ports_lr),
-        fill(270°, c.num_ports_tb),
-        fill(180°, c.num_ports_lr)
+        fill(90°, c.port_tb_count),
+        fill(0°, c.port_lr_count),
+        fill(270°, c.port_tb_count),
+        fill(180°, c.port_lr_count)
     )
     return (; port=PointHook.(Point.(x, y), dirs), origin=PointHook(0mm, 0mm, -180°))
 end

--- a/src/schematics/ExamplePDK/components/ClawCapacitors/ClawCapacitors.jl
+++ b/src/schematics/ExamplePDK/components/ClawCapacitors/ClawCapacitors.jl
@@ -42,8 +42,8 @@ This component is intended for use in demonstrations.
     ████████████████  ████ | ████████        ↕ output_style.gap        
                   ██  ████ ↓ ████  ██
                   ██  ███████████  ██  
-                  ██←→███████████  ██ 
-                  ██claw_width↕    ██
+                  ██←→███████████  ██
+                  ██claw_trace↕    ██
                  ↕███████████████████
     claw_outer_gap←→      ←—→ inner_cap_width
 
@@ -55,7 +55,7 @@ This component is intended for use in demonstrations.
   - `inner_cap_width = 20μm`: Width (short dimension, usually) of inner capacitor pad
   - `inner_cap_length = 200μm`: Length (long dimension) of inner capacitor pad
   - `claw_inner_gap = 5μm`: Gap between claw and inner pad
-  - `claw_width = 10μm`: Width of claw metal trace
+  - `claw_trace = 10μm`: Width of claw metal trace
   - `claw_outer_gap = 20μm`: Outer gap around claw
   - `output_style = Paths.CPW(10μm, 6μm)`: Style of output path
   - `rounding = 2μm`: Rounding radius applied to the capacitor
@@ -74,10 +74,10 @@ This component is intended for use in demonstrations.
     inner_cap_width = 20μm
     inner_cap_length = 200μm
     claw_inner_gap = 5μm
-    claw_width = 10μm
+    claw_trace::typeof(1.0μm) = 10μm
     claw_outer_gap = 20μm
     output_style = Paths.CPW(10μm, 6μm)
-    rounding = 2μm
+    rounding::typeof(1.0μm) = 2μm
 end
 
 function SchematicDrivenLayout._geometry!(
@@ -99,7 +99,7 @@ function _path(cc::ExampleSeriesClawCapacitor)
         input_style,
         rounding,
         claw_outer_gap,
-        claw_width,
+        claw_trace,
         claw_inner_gap,
         inner_cap_width
     ) = cc
@@ -109,7 +109,7 @@ function _path(cc::ExampleSeriesClawCapacitor)
     end
     straight!(
         pa,
-        2 * (claw_outer_gap + claw_width + claw_inner_gap + rounding) + inner_cap_width,
+        2 * (claw_outer_gap + claw_trace + claw_inner_gap + rounding) + inner_cap_width,
         Paths.NoRender()
     )
     return pa
@@ -120,13 +120,15 @@ function SchematicDrivenLayout.hooks(cc::ExampleSeriesClawCapacitor)
     return hooks(path)
 end
 
+# Shared by ExampleSeriesClawCapacitor and ExampleShuntClawCapacitor (the latter is
+# defined below, so the argument is left untyped to avoid a forward reference)
 function _series_claw(cc)
     (;
         input_style,
         inner_cap_width,
         inner_cap_length,
         claw_inner_gap,
-        claw_width,
+        claw_trace,
         claw_outer_gap,
         output_style,
         rounding
@@ -137,7 +139,7 @@ function _series_claw(cc)
     inner_pad = centered(Rectangle(inner_cap_length, inner_cap_width))
     output_trace = Rectangle(
         output_style.trace,
-        claw_inner_gap + claw_width + claw_outer_gap + rounding
+        claw_inner_gap + claw_trace + claw_outer_gap + rounding
     )
     output_trace = Align.below(output_trace, inner_pad; centered=true)
 
@@ -145,10 +147,10 @@ function _series_claw(cc)
     # Use `halo` to get larger rectangle around original
     # Halo returns a vector, but we know it's length 1
     inner_hole = only(halo(inner_pad, claw_inner_gap))
-    output_trace_hole = Rectangle(output_style.trace + 2 * claw_inner_gap, claw_width)
+    output_trace_hole = Rectangle(output_style.trace + 2 * claw_inner_gap, claw_trace)
     output_trace_hole = Align.below(output_trace_hole, inner_hole; centered=true)
     # Claw positive
-    claw_rect = only(halo(inner_hole, claw_width))
+    claw_rect = only(halo(inner_hole, claw_trace))
     claw_poly = only(to_polygons(difference2d(claw_rect, [inner_hole, output_trace_hole])))
     input_trace = Rectangle(input_style.trace, claw_outer_gap + rounding)
     input_trace = Align.above(input_trace, claw_poly; centered=true)
@@ -182,6 +184,8 @@ function _series_claw(cc)
     return rounded(cutout_poly)
 end
 
+# Shared by both claw capacitor types (see `_series_claw`); argument left untyped
+# because ExampleShuntClawCapacitor is defined below.
 function critical_dimension(cc)
     return min(
         cc.input_style.trace,
@@ -189,7 +193,7 @@ function critical_dimension(cc)
         cc.inner_cap_width,
         cc.inner_cap_length,
         cc.claw_inner_gap,
-        cc.claw_width,
+        cc.claw_trace,
         cc.claw_outer_gap,
         cc.output_style.trace,
         cc.output_style.gap
@@ -218,7 +222,7 @@ This component is intended for use in demonstrations.
   - `inner_cap_width = 20μm`: Width (short dimension, usually) of inner capacitor pad
   - `inner_cap_length = 200μm`: Length (long dimension) of inner capacitor pad
   - `claw_inner_gap = 5μm`: Gap between claw and inner pad
-  - `claw_width = 10μm`: Width of claw metal trace
+  - `claw_trace = 10μm`: Width of claw metal trace
   - `claw_outer_gap = 20μm`: Outer gap around claw
   - `output_style = Paths.CPW(10μm, 6μm)`: Style of output path
   - `rounding = 2μm`: Rounding radius applied to the capacitor
@@ -243,10 +247,10 @@ This component is intended for use in demonstrations.
     inner_cap_width = 20μm
     inner_cap_length = 200μm
     claw_inner_gap = 5μm
-    claw_width = 10μm
+    claw_trace::typeof(1.0μm) = 10μm
     claw_outer_gap = 20μm
     output_style = Paths.CPW(10μm, 10μm)
-    rounding = 2μm
+    rounding::typeof(1.0μm) = 2μm
     bridge = nothing
 end
 
@@ -282,11 +286,11 @@ function _paths(cc::ExampleShuntClawCapacitor)
 end
 
 function SchematicDrivenLayout.hooks(cc::ExampleShuntClawCapacitor)
-    (; inner_cap_width, claw_inner_gap, claw_width, claw_outer_gap, rounding) = cc
+    (; inner_cap_width, claw_inner_gap, claw_trace, claw_outer_gap, rounding) = cc
     pa, tap = _paths(cc) # Generate another copy of the paths so we can use their hooks
     straight!(
         tap, # Extend tap to get to the connection point on the other side
-        inner_cap_width + 2 * (rounding + claw_outer_gap + claw_width + claw_inner_gap)
+        inner_cap_width + 2 * (rounding + claw_outer_gap + claw_trace + claw_inner_gap)
     )
     return merge(hooks(pa), (; p2=p1_hook(tap), p2_lh=p1_hook(tap, false)))
 end

--- a/src/schematics/ExamplePDK/components/ReadoutResonators/ReadoutResonators.jl
+++ b/src/schematics/ExamplePDK/components/ReadoutResonators/ReadoutResonators.jl
@@ -52,36 +52,35 @@ This component is intended for use in demonstrations with `ExampleStarTransmon`.
       + `inner_cap_width = 20μm`
       + `inner_cap_length = 200μm`
       + `claw_inner_gap = 5μm`
-      + `claw_width = 10μm`
+      + `claw_trace = 10μm`
       + `claw_outer_gap = 20μm`
       + `rounding = 2μm`
   - Extra claw-to-filter path
 
-      + `extra_filter_l1 = 300μm`: Initial straight length
-      + `extra_filter_θ1 = 0°`: Bend angle following initial straight
-      + `extra_filter_l2 = 0μm`: Straight length following first bend
-      + `extra_filter_θ2 = 0°`: Second bend following second straight
+      + `extra_filter_length_1 = 300μm`: Initial straight length
+      + `extra_filter_angle_1 = 0°`: Bend angle following initial straight
+      + `extra_filter_length_2 = 0μm`: Straight length following first bend
+      + `extra_filter_angle_2 = 0°`: Second bend following second straight
   - Resonators (see [`ExampleTappedHairpin`](@ref))
 
       + `resonator_style = Paths.CPW(10μm, 10μm)`
-      + `r_bend = 50μm`
+      + `bend_radius = 50μm`
       + `straight_length = 1.5mm # Long straight segment`
-      + `filter_total_effective_length = 4mm`
-      + `filter_assumed_extra_length = 1.0mm`
-      + `readout_total_effective_length = 4mm`
-      + `readout_assumed_extra_length = 1.0mm`
+      + `filter_total_length = 3mm`: Target physical path length of the Purcell filter hairpin
+        (the extra claw-to-filter path length is subtracted from this when building the filter)
+      + `readout_total_length = 3mm`: Target physical path length of the readout hairpin
       + `readout_initial_snake = Point(600μm, 200μm)`
   - Parameters for tap and coupling capacitor between resonators
 
       + `tap_position = 0.77mm`: Position of tap along initial straight segment
-      + `tap_location = -1`: Side of hairpin for tap (+1 for right-hand side starting from qubit)
+      + `tap_side = -1`: Side of hairpin for tap (+1 for right-hand side starting from qubit)
       + `hairpin_tap_depth = 35μm`: Distance from center of hairpin CPW to end of coupling capacitor
       + `hairpin_tap_style = Paths.CPW(5μm, 25μm)`: Style of hairpin tap path
       + `tap_cap_taper_length = 5μm`: Length of taper from `tap_style` to `tap_cap_style`
       + `tap_cap_length = 10μm`: Length of capacitive pad after taper
       + `tap_cap_style = Paths.CPW(25μm, 15μm)`: Width and gap-width of coupling capacitor as a CPW style
       + `tap_cap_termination_gap = 5μm`: Gap between coupling capacitor metal and ground in the direction of coupling
-      + `tap_cap_coupling_distance = 7.5μm`: Distance from end of capacitor metal to `:tap` hook
+      + `resonator_filter_coupling_gap = 15μm`: Edge-edge gap between filter and readout tap capacitor terminations (should be > 2*termination gap)
 
 # Hooks
 
@@ -101,36 +100,34 @@ This component is intended for use in demonstrations with `ExampleStarTransmon`.
     inner_cap_width = 20μm
     inner_cap_length = 200μm
     claw_inner_gap = 5μm
-    claw_width = 10μm
+    claw_trace = 10μm
     claw_outer_gap = 20μm
     rounding = 2μm
     # Extra claw-to-filter path
-    extra_filter_l1 = 300μm
-    extra_filter_θ1 = 0°
-    extra_filter_l2 = 0μm
-    extra_filter_θ2 = 0°
+    extra_filter_length_1 = 300μm
+    extra_filter_angle_1 = 0°
+    extra_filter_length_2 = 0μm
+    extra_filter_angle_2 = 0°
     # Resonators
     resonator_style = Paths.CPW(10μm, 10μm)
-    r_bend = 50μm
+    bend_radius = 50μm
     straight_length = 1.5mm # Long straight segment
     resonator_bridge = nothing
     # Filter-specific parameters
-    filter_total_effective_length = 4mm
-    filter_assumed_extra_length = 1.0mm
+    filter_total_length = 3mm
     # Resonator-specific parameters
-    readout_total_effective_length = 4mm
-    readout_assumed_extra_length = 1.0mm
+    readout_total_length = 3mm
     readout_initial_snake = Point(600μm, 200μm)
     # Parameters for tap and coupling capacitor between resonators
     tap_position = 0.77mm
-    tap_location = -1 # +1 for right hand side starting from open end
+    tap_side = -1 # +1 for right hand side starting from open end
     hairpin_tap_depth = 35μm
     hairpin_tap_style = Paths.CPW(5μm, 25μm)
     tap_cap_taper_length = 5μm
     tap_cap_length = 10μm
     tap_cap_style = Paths.CPW(25μm, 15μm)
     tap_cap_termination_gap = 5μm
-    resonator_filter_coupling_distance = 15μm # should be > 2*termination gap
+    resonator_filter_coupling_gap = 15μm # should be > 2*termination gap
 end
 
 function SchematicDrivenLayout._build_subcomponents(fr::ExampleFilteredHairpinReadout)
@@ -146,36 +143,37 @@ function SchematicDrivenLayout._build_subcomponents(fr::ExampleFilteredHairpinRe
 
     ### Extra filter path
     efp = Path(; name="efp", metadata=METAL_NEGATIVE)
-    !iszero(fr.extra_filter_l1) && straight!(efp, fr.extra_filter_l1, fr.resonator_style)
-    !iszero(fr.extra_filter_θ1) &&
-        turn!(efp, fr.extra_filter_θ1, fr.r_bend, fr.resonator_style)
-    !iszero(fr.extra_filter_l2) && straight!(efp, fr.extra_filter_l2, fr.resonator_style)
-    !iszero(fr.extra_filter_θ2) &&
-        turn!(efp, fr.extra_filter_θ2, fr.r_bend, fr.resonator_style)
+    !iszero(fr.extra_filter_length_1) &&
+        straight!(efp, fr.extra_filter_length_1, fr.resonator_style)
+    !iszero(fr.extra_filter_angle_1) &&
+        turn!(efp, fr.extra_filter_angle_1, fr.bend_radius, fr.resonator_style)
+    !iszero(fr.extra_filter_length_2) &&
+        straight!(efp, fr.extra_filter_length_2, fr.resonator_style)
+    !iszero(fr.extra_filter_angle_2) &&
+        turn!(efp, fr.extra_filter_angle_2, fr.bend_radius, fr.resonator_style)
     add_bridges!(efp, fr.resonator_bridge)
-    extra_effective_length = pathlength(efp) # Will modify `assumed_extra_length` in filter
+    extra_path_length = pathlength(efp) # Counts toward the filter's total physical length
 
     ### Hairpins
     hairpin_params = filter_parameters(ExampleTappedHairpin, fr) # Params shared by hairpin
     @component purcell = ExampleTappedHairpin(; hairpin_params...) begin
-        # Params with different names / reparameterization
-        style = fr.resonator_style
-        total_effective_length = fr.filter_total_effective_length
-        assumed_extra_length = fr.filter_assumed_extra_length + extra_effective_length
+        # Params with different names / reparameterization (resonator_style, bend_radius,
+        # straight_length, tap_position, tap_side are forwarded by name via hairpin_params)
+        # The extra claw-to-filter path is part of the filter's length, so subtract it from
+        # the target so the filter meander makes up the remainder.
+        total_length = fr.filter_total_length - extra_path_length
         tap_style = fr.hairpin_tap_style # Would have same name but claw also has tap_style
         tap_depth = fr.hairpin_tap_depth
-        tap_cap_coupling_distance = fr.resonator_filter_coupling_distance / 2
+        tap_cap_coupling_distance = fr.resonator_filter_coupling_gap / 2
         bridge = fr.resonator_bridge
     end
 
     @component readout = ExampleTappedHairpin(; hairpin_params...) begin
         # Params with different names / reparameterization
-        style = fr.resonator_style
-        total_effective_length = fr.readout_total_effective_length
-        assumed_extra_length = fr.readout_assumed_extra_length
+        total_length = fr.readout_total_length
         tap_style = fr.hairpin_tap_style
         tap_depth = fr.hairpin_tap_depth
-        tap_cap_coupling_distance = fr.resonator_filter_coupling_distance / 2
+        tap_cap_coupling_distance = fr.resonator_filter_coupling_gap / 2
         initial_snake = fr.readout_initial_snake
         bridge = fr.resonator_bridge
     end
@@ -194,9 +192,19 @@ function SchematicDrivenLayout._graph!(
     return fuse!(g, filter_node => :tap, subcomps.readout => :tap)
 end
 
+# Graph node indices, in the order subcomponents are returned by `_build_subcomponents`
+# (and added in `_graph!`). Centralizing the index↔subcomponent mapping keeps `map_hooks`
+# from hardcoding bare integers that must track the build order by hand.
+const _FILTERED_HAIRPIN_NODES = (claw=1, efp=2, purcell=3, readout=4)
+
 function SchematicDrivenLayout.map_hooks(tr::ExampleFilteredHairpinReadout)
     ###### Dictionary mapping (graph node index => subcomp hook name) => MyComp hook name
-    return Dict((1 => :p0) => :p0, (1 => :p1) => :p1, (4 => :p0) => :qubit)
+    n = _FILTERED_HAIRPIN_NODES
+    return Dict(
+        (n.claw => :p0) => :p0,
+        (n.claw => :p1) => :p1,
+        (n.readout => :p0) => :qubit
+    )
 end
 ###
 

--- a/src/schematics/ExamplePDK/components/ReadoutResonators/clawed_meander.jl
+++ b/src/schematics/ExamplePDK/components/ReadoutResonators/clawed_meander.jl
@@ -1,5 +1,3 @@
-import DeviceLayout: flushtop, flushleft, flushright, below, above
-
 import .ExamplePDK: tap!
 import .ExamplePDK.Transmons: ExampleRectangleTransmon
 
@@ -13,37 +11,39 @@ This component is intended for use in demonstrations with `ExampleRectangleTrans
 # Parameters
 
   - `name`: Name of component
-  - `style`: Resonator CPW style
+  - `resonator_style`: Resonator CPW style
   - `total_length`: Total length of resonator
   - `coupling_length`: Length of coupling section
   - `coupling_gap`: Width of ground plane between coupling section and coupled line
   - `bend_radius`: Meander bend radius
-  - `n_meander_turns`: Number of meander turns
-  - `total_height`: Total height from top hook to bottom hook
+  - `meander_turn_count`: Number of meander turns
+  - `total_y_length`: Total y length from top hook to bottom hook
   - `hanger_length`: Length of hanger section between coupling section and meander
-  - `w_shield`: Width of claw capacitor ground plane shield
-  - `w_claw`: Claw trace width
-  - `l_claw`: Claw finger length
+  - `shield_width`: Width of claw capacitor ground plane shield
+  - `claw_trace`: Claw trace width
+  - `claw_length`: Claw finger length
   - `claw_gap`: Claw capacitor gap
-  - `w_grasp`: Width between inner edges of ground plane shield
-  - `bridge`: `CoordinateSystem` containing a bridge
+  - `grasp_width`: Width between inner edges of ground plane shield
+  - `bridge = nothing`: `CoordinateSystem` containing a bridge to place along the resonator; if
+    `nothing`, no bridge is attached. Define decorations at the device level and share the same
+    instance across components.
 """
 @compdef struct ExampleClawedMeanderReadout <: Component
-    name            = "rres"
-    style           = DeviceLayout.Paths.SimpleCPW(10.0μm, 6.0μm)
-    total_length    = 5000μm
-    coupling_length = 200μm
-    coupling_gap    = 5μm
-    bend_radius     = 50μm
-    n_meander_turns = 5
-    total_height    = 1656μm # from top hook to bottom hook
-    hanger_length   = 500μm
-    w_shield        = 2μm
-    w_claw          = 32μm
-    l_claw          = 160μm
-    claw_gap        = 6μm
-    w_grasp         = 84μm
-    bridge          = CoordinateSystem("rresbridge", nm)
+    name               = "rres"
+    resonator_style    = DeviceLayout.Paths.SimpleCPW(10.0μm, 6.0μm)
+    total_length       = 5000μm
+    coupling_length    = 200μm
+    coupling_gap       = 5μm
+    bend_radius        = 50μm
+    meander_turn_count = 5
+    total_y_length     = 1656μm # from top hook to bottom hook
+    hanger_length      = 500μm
+    shield_width       = 2μm
+    claw_trace         = 32μm
+    claw_length        = 160μm
+    claw_gap           = 6μm
+    grasp_width        = 84μm
+    bridge             = nothing
 end
 
 function SchematicDrivenLayout._geometry!(
@@ -51,29 +51,34 @@ function SchematicDrivenLayout._geometry!(
     rres::ExampleClawedMeanderReadout
 )
     (;
-        style,
+        resonator_style,
         total_length,
         coupling_length,
         coupling_gap,
         bend_radius,
-        n_meander_turns,
-        total_height,
+        meander_turn_count,
+        total_y_length,
         hanger_length,
-        w_shield,
-        w_claw,
-        l_claw,
+        shield_width,
+        claw_trace,
+        claw_length,
         claw_gap,
-        w_grasp,
+        grasp_width,
         bridge
     ) = rres
     # Center vertical axis is midpoint of coupling section
     pres = Path(
-        Point(-coupling_length / 2, -coupling_gap - style.gap - style.trace / 2),
+        Point(
+            -coupling_length / 2,
+            -coupling_gap - resonator_style.gap - resonator_style.trace / 2
+        ),
         α0=0°
     )
-    n_bends = 3 + 2 * n_meander_turns # number of 90 degree bends
+    n_bends = 3 + 2 * meander_turn_count # number of 90 degree bends
     arm_length = (
-        total_height - hanger_length - n_bends * bend_radius - coupling_gap - style.gap - style.trace / 2 - w_shield - 2 * claw_gap - w_claw
+        total_y_length - hanger_length - n_bends * bend_radius - coupling_gap -
+        resonator_style.gap - resonator_style.trace / 2 - shield_width - 2 * claw_gap -
+        claw_trace
     )
 
     # Length of straight sections in meander
@@ -81,13 +86,14 @@ function SchematicDrivenLayout._geometry!(
         (
             total_length - 3 * coupling_length / 2 - n_bends * pi * bend_radius / 2 -
             arm_length - hanger_length
-        ) / n_meander_turns
+        ) / meander_turn_count
 
     ### CPW path
-    straight!(pres, coupling_length, style)
+    straight!(pres, coupling_length, resonator_style)
     turn!(pres, -90°, bend_radius)
     straight!(pres, hanger_length)
-    attach!(pres, CoordinateSystemReference(bridge), hanger_length / 2)
+    !isnothing(bridge) &&
+        attach!(pres, CoordinateSystemReference(bridge), hanger_length / 2)
     turn!(pres, -90°, bend_radius)
     # Center of the straight section of meander lines up with coupling midpoint (and claw)
     straight!(pres, straight_length / 2 + coupling_length / 2)
@@ -95,38 +101,43 @@ function SchematicDrivenLayout._geometry!(
 
     # Start the meander with a full straight section
     meander_length =
-        (n_meander_turns - 1) * (straight_length + pi * bend_radius) + straight_length / 2 -
-        bend_radius
+        (meander_turn_count - 1) * (straight_length + pi * bend_radius) +
+        straight_length / 2 - bend_radius
     meander!(pres, meander_length, straight_length, bend_radius, -180°)
     turn!(pres, -90°, bend_radius)
     straight!(pres, arm_length)
-    attach!(pres, CoordinateSystemReference(bridge), arm_length / 2)
+    !isnothing(bridge) && attach!(pres, CoordinateSystemReference(bridge), arm_length / 2)
 
     ### Claw
-    arm_trace = style.trace
+    arm_trace = resonator_style.trace
     pt0 = p1(pres.nodes[end].seg)
 
     claw_hole1 = Rectangle(arm_trace, claw_gap) + pt0 + Point(-arm_trace / 2, -claw_gap)
 
-    claw_hole2 =
-        Rectangle(w_grasp + 2 * w_shield + 4 * claw_gap + 2 * w_claw, w_claw + 2 * claw_gap)
-    claw_hole2 = flushtop(claw_hole2, claw_hole1, centered=true)
+    claw_hole2 = Rectangle(
+        grasp_width + 2 * shield_width + 4 * claw_gap + 2 * claw_trace,
+        claw_trace + 2 * claw_gap
+    )
+    claw_hole2 = Align.flushtop(claw_hole2, claw_hole1, centered=true)
 
-    claw_hole3 = Rectangle(w_claw + 2 * claw_gap, w_shield + l_claw + claw_gap)
-    claw_hole3 = flushleft(below(claw_hole3, claw_hole2), claw_hole2)
+    claw_hole3 = Rectangle(claw_trace + 2 * claw_gap, shield_width + claw_length + claw_gap)
+    claw_hole3 = Align.flushleft(Align.below(claw_hole3, claw_hole2), claw_hole2)
 
-    claw_hole4 = flushright(claw_hole3, claw_hole2)
+    claw_hole4 = Align.flushright(claw_hole3, claw_hole2)
 
     claw1 = Rectangle(arm_trace, claw_gap)
-    claw1 = flushtop(claw1, claw_hole1, centered=true)
+    claw1 = Align.flushtop(claw1, claw_hole1, centered=true)
 
-    claw2 = Rectangle(w_grasp + 2 * w_shield + 2 * claw_gap + 2 * w_claw, w_claw)
-    claw2 = below(claw2, claw1, centered=true)
+    claw2 = Rectangle(
+        grasp_width + 2 * shield_width + 2 * claw_gap + 2 * claw_trace,
+        claw_trace
+    )
+    claw2 = Align.below(claw2, claw1, centered=true)
 
-    claw3 = Rectangle(w_claw, claw_gap + w_shield + l_claw)
-    claw3 = flushleft(below(claw3, claw2), claw2)
+    claw3 = Rectangle(claw_trace, claw_gap + shield_width + claw_length)
+    claw3 = Align.flushleft(Align.below(claw3, claw2), claw2)
 
-    claw4 = flushright(claw3, claw2)
+    claw4 = Align.flushright(claw3, claw2)
 
     claw = difference2d(
         [claw_hole1, claw_hole2, claw_hole3, claw_hole4],
@@ -138,14 +149,24 @@ function SchematicDrivenLayout._geometry!(
     # This component creates narrow regions defined by the gap between it and others
     # We should explicitly set mesh sizing since meshing doesn't use proximity
     ### Mesh control on shield ground plane strip
-    shield1 = below(Rectangle(w_grasp + 2 * w_shield, w_shield), claw_hole2, centered=true)
-    shield2 = flushleft(below(Rectangle(w_shield, l_claw + claw_gap), shield1), shield1)
-    shield3 = flushright(below(Rectangle(w_shield, l_claw + claw_gap), shield1), shield1)
+    shield1 = Align.below(
+        Rectangle(grasp_width + 2 * shield_width, shield_width),
+        claw_hole2,
+        centered=true
+    )
+    shield2 = Align.flushleft(
+        Align.below(Rectangle(shield_width, claw_length + claw_gap), shield1),
+        shield1
+    )
+    shield3 = Align.flushright(
+        Align.below(Rectangle(shield_width, claw_length + claw_gap), shield1),
+        shield1
+    )
     shield = union2d([shield1, shield2, shield3])
-    render!(cs, MeshSized(2 * w_shield)(only_simulated(shield)), MESH_CONTROL)
+    render!(cs, MeshSized(2 * shield_width)(only_simulated(shield)), MESH_CONTROL)
 
     ### Mesh control on feedline coupler ground plane strip
-    strip = above(Rectangle(coupling_length, coupling_gap), pres[1], centered=true)
+    strip = Align.above(Rectangle(coupling_length, coupling_gap), pres[1], centered=true)
     render!(cs, MeshSized(2 * coupling_gap)(only_simulated(strip)), MESH_CONTROL)
     return cs
 end
@@ -161,9 +182,9 @@ end
     with the claw.
 """
 function SchematicDrivenLayout.hooks(rres::ExampleClawedMeanderReadout)
-    qubit_hook = PointHook(Point(zero(rres.w_claw), -rres.total_height), 90°)
-    feedline_hook = PointHook(zero(Point{typeof(rres.w_claw)}), -90°)
-    return (qubit=qubit_hook, feedline=feedline_hook)
+    qubit_hook = PointHook(Point(zero(rres.claw_trace), -rres.total_y_length), 90°)
+    feedline_hook = PointHook(zero(Point{typeof(rres.claw_trace)}), -90°)
+    return (; qubit=qubit_hook, feedline=feedline_hook)
 end
 
 SchematicDrivenLayout.matching_hooks(

--- a/src/schematics/ExamplePDK/components/ReadoutResonators/tapped_hairpin.jl
+++ b/src/schematics/ExamplePDK/components/ReadoutResonators/tapped_hairpin.jl
@@ -22,7 +22,7 @@ Hooks are marked with ⋆ and an arrow in their inward direction.
         |← ...                             ██
                                           ██
                ███████████████████████████
-              |← ... total path length + assumed_extra_length = total_effective_length
+              |← ... total physical path length = total_length
 
 # Parameters
 
@@ -31,13 +31,13 @@ most of these defaults are overridden.
 
   - `name = "res"`: Name of component
 
-  - `total_effective_length = 4mm`: Total effective length, such that the resonant frequency
-    occurs when this length is a quarter wavelength at that frequency (assuming some effective index)
-  - `assumed_extra_length = 1.0mm`: Assumed extra effective length such that the physical path
-    length plus `assumed_extra_length` is `total_effective_length`. For example, bends, bridges,
-    and coupling capacitors may affect the effective length.
-  - `r_bend = 50μm`: Radius of hairpin bend
-  - `style = Paths.CPW(10μm, 10μm)`: Path style
+  - `total_length = 3mm`: Total physical path length of the hairpin. The meander is extended
+    until the path reaches this length. Frequency targeting (mapping a desired resonant
+    frequency to a physical length, accounting for the effective index and the extra length
+    contributed by bends, bridges, and coupling capacitors) is a device-level concern and is
+    deliberately left out of this component (see the component style guide).
+  - `bend_radius = 50μm`: Radius of hairpin bend
+  - `resonator_style = Paths.CPW(10μm, 10μm)`: Path style
   - `initial_snake = Point(0μm, 0μm)`: If nonzero, add an initial s-curve to this point (in the
     hairpin coordinate system, where the path starts from the origin pointing along the positive x-axis)
   - `straight_length = 1.25μm`: Length of first long straight section in hairpin
@@ -45,7 +45,7 @@ most of these defaults are overridden.
   - Parameters for tap and coupling capacitor to other resonator
 
       + `tap_position = 0.7mm`: Position of tap along initial straight segment
-      + `tap_location = -1`: Side of hairpin for tap (+1 for right-hand side starting from qubit)
+      + `tap_side = -1`: Side of hairpin for tap (+1 for right-hand side starting from qubit)
       + `tap_depth = 35μm`: Distance from center of hairpin CPW to end of coupling capacitor
       + `tap_style = Paths.CPW(5μm, 25μm)`: Style of tap path
       + `tap_cap_taper_length = 5μm`: Length of taper from `tap_style` to `tap_cap_style`
@@ -62,16 +62,15 @@ most of these defaults are overridden.
 """
 @compdef struct ExampleTappedHairpin <: Component
     name = "res"
-    total_effective_length = 4mm
-    assumed_extra_length = 1.0mm
-    r_bend = 50μm
-    style = Paths.CPW(10μm, 10μm)
+    total_length = 3mm
+    bend_radius = 50μm
+    resonator_style = Paths.CPW(10μm, 10μm)
     initial_snake = Point(0μm, 0μm)
     straight_length = 1.25μm
     bridge = nothing
     # Parameters for tap and coupling capacitor to other resonator
     tap_position = 0.7mm
-    tap_location = -1
+    tap_side = -1
     tap_depth = 35μm
     tap_style = Paths.CPW(5μm, 25μm)
     tap_cap_taper_length = 5μm
@@ -100,24 +99,25 @@ function _paths(mr::ExampleTappedHairpin)
             pa,
             mr.initial_snake,
             0°,
-            Paths.StraightAnd45(min_bend_radius=mr.r_bend),
-            mr.style
+            Paths.StraightAnd45(min_bend_radius=mr.bend_radius),
+            mr.resonator_style
         )
 
     # First straight leg of hairpin
-    straight!(pa, mr.tap_position - Paths.extent(mr.tap_style), mr.style)
-    tap = tap!(pa, mr.tap_style; location=mr.tap_location)
+    straight!(pa, mr.tap_position - Paths.extent(mr.tap_style), mr.resonator_style)
+    tap = tap!(pa, mr.tap_style; location=mr.tap_side)
     straight!(pa, mr.straight_length - mr.tap_position - Paths.extent(mr.tap_style))
-    # Bend and meander with up to straight_length until the total effective length is met
-    turn!(pa, sign(mr.tap_location) * 180°, mr.r_bend)
-    remainder = mr.total_effective_length - mr.assumed_extra_length - pathlength(pa)
-    meander!(pa, remainder, mr.straight_length, mr.r_bend, -sign(mr.tap_location) * 180°)
-    terminate!(pa, gap=0μm, rounding=(mr.style.gap / 2)) # Round the ends of the short
+    # Bend and meander with up to straight_length until the total path length is met
+    turn!(pa, sign(mr.tap_side) * 180°, mr.bend_radius)
+    remainder = mr.total_length - pathlength(pa)
+    meander!(pa, remainder, mr.straight_length, mr.bend_radius, -sign(mr.tap_side) * 180°)
+    terminate!(pa, gap=0μm, rounding=(mr.resonator_style.gap / 2)) # Round the ends of the short
     add_bridges!(pa, mr.bridge)
     # Extend `tap` to make a coupling capacitor
     straight!(
         tap,
-        mr.tap_depth - Paths.extent(mr.style) - mr.tap_cap_length - mr.tap_cap_taper_length
+        mr.tap_depth - Paths.extent(mr.resonator_style) - mr.tap_cap_length -
+        mr.tap_cap_taper_length
     )
     straight!(tap, mr.tap_cap_taper_length, Paths.Taper())
     straight!(tap, mr.tap_cap_length, mr.tap_cap_style)

--- a/src/schematics/ExamplePDK/components/SimpleJunctions/SimpleJunctions.jl
+++ b/src/schematics/ExamplePDK/components/SimpleJunctions/SimpleJunctions.jl
@@ -31,26 +31,26 @@ layer. The "simulation" geometry adds `METAL_POSITIVE` rectangles representing j
 connected by a `LUMPED_ELEMENT` rectangle.
 
      :island hook
-        ↓    
+        ↓
         ⋆           —
-        █           ↑  
+        █           ↑
         █           │
         █           │
-        ▒↕ h_jj     h_ground_island
+        ▒↕ junction_lead_gap  ground_island_length
         █           │
-       →█← w_jj     │
+       →█← junction_width     │
         █           ↓
         ⋆           —
-        ↑    
+        ↑
      :ground hook
 
 # Parameters
 
   - `name = "junction"`: Name of component
-  - `w_jj = 1μm`: Width of JJ and lead
-  - `h_jj = 1μm`: Height of JJ port rectangle / gap between leads
-  - `h_ground_island = 20μm`: Total JJ ground-to-island height
-  - `h_excess = 2μm`: Additional JJ lead height overlapping each of ground and island
+  - `junction_width = 1μm`: Width of JJ and lead
+  - `junction_lead_gap = 1μm`: Length of JJ port rectangle / gap between leads
+  - `ground_island_length = 20μm`: Total JJ ground-to-island length
+  - `lead_excess_length = 2μm`: Additional JJ lead length overlapping each of ground and island
 
 # Hooks
 
@@ -60,25 +60,31 @@ connected by a `LUMPED_ELEMENT` rectangle.
 """
 @compdef struct ExampleSimpleJunction <: Component
     name = "junction"
-    w_jj = 1μm
-    h_jj = 1μm
-    h_ground_island = 20μm
-    h_excess = 2μm
+    junction_width = 1μm
+    junction_lead_gap = 1μm
+    ground_island_length = 20μm
+    lead_excess_length = 2μm
 end
 
 function SchematicDrivenLayout._geometry!(cs::CoordinateSystem, jj::ExampleSimpleJunction)
-    (; w_jj, h_jj, h_ground_island, h_excess) = jj
+    (; junction_width, junction_lead_gap, ground_island_length, lead_excess_length) = jj
     # simulation geometry
-    jj_rect = centered(Rectangle(w_jj, h_jj))
-    top_lead =
-        Align.above(Rectangle(w_jj, (h_ground_island - h_jj) / 2), jj_rect; centered=true)
+    jj_rect = centered(Rectangle(junction_width, junction_lead_gap))
+    top_lead = Align.above(
+        Rectangle(junction_width, (ground_island_length - junction_lead_gap) / 2),
+        jj_rect;
+        centered=true
+    )
     bot_lead = Align.below(top_lead, jj_rect)
     place!(cs, only_simulated(jj_rect), LUMPED_ELEMENT)
-    place!(cs, MeshSized(2 * w_jj)(only_simulated(top_lead)), METAL_POSITIVE)
-    place!(cs, MeshSized(2 * w_jj)(only_simulated(bot_lead)), METAL_POSITIVE)
+    place!(cs, MeshSized(2 * junction_width)(only_simulated(top_lead)), METAL_POSITIVE)
+    place!(cs, MeshSized(2 * junction_width)(only_simulated(bot_lead)), METAL_POSITIVE)
     # artwork geometry
     top_lead_art = Align.above(
-        Rectangle(w_jj, (h_ground_island - h_jj) / 2 + h_excess),
+        Rectangle(
+            junction_width,
+            (ground_island_length - junction_lead_gap) / 2 + lead_excess_length
+        ),
         jj_rect;
         centered=true
     )
@@ -89,8 +95,8 @@ end
 
 function SchematicDrivenLayout.hooks(jj::ExampleSimpleJunction)
     return (;
-        island = PointHook(0μm, jj.h_ground_island / 2, -90°),
-        ground = PointHook(0μm, -jj.h_ground_island / 2, 90°)
+        island = PointHook(0μm, jj.ground_island_length / 2, -90°),
+        ground = PointHook(0μm, -jj.ground_island_length / 2, 90°)
     )
 end
 
@@ -107,14 +113,14 @@ layer. The "simulation" geometry adds `METAL_POSITIVE` rectangles representing j
 connected by a `LUMPED_ELEMENT` rectangle.
 
       :island hook
-         ↓    
+         ↓
          ⋆                —
     █         █           ↑
     █         █           │
     █         █           │
-    ▒         ▒↕ h_jj     h_ground_island
+    ▒         ▒↕ junction_lead_gap  ground_island_length
     █         █           │
-    █        →█← w_jj     │
+    █        →█← junction_width     │
     █         █           ↓
          ⋆                —
          ↑
@@ -126,9 +132,9 @@ connected by a `LUMPED_ELEMENT` rectangle.
   - `jj_templates = (ExampleSimpleJunction(), ExampleSimpleJunction())`: Templates for left and
     right (in the SQUID coordinate system) JJs, respectively, used to specify parameters not
     overridden by the SQUID
-  - `h_ground_island = 20μm`: Total JJ ground-to-island height
-  - `h_excess = 2μm`: Additional JJ lead height overlapping each of ground and island
-  - `w_squid`: Distance between left and right JJs
+  - `ground_island_length = 20μm`: Total JJ ground-to-island length
+  - `lead_excess_length = 2μm`: Additional JJ lead length overlapping each of ground and island
+  - `squid_width`: Distance between left and right JJs
 
 # Hooks
 
@@ -138,24 +144,24 @@ connected by a `LUMPED_ELEMENT` rectangle.
 @compdef struct ExampleSimpleSQUID <: CompositeComponent
     name = "squid"
     jj_templates = (ExampleSimpleJunction(), ExampleSimpleJunction())
-    h_ground_island = 20μm
-    h_excess = 2μm
-    w_squid = 10μm
+    ground_island_length = 20μm
+    lead_excess_length = 2μm
+    squid_width = 10μm
 end
 
 function SchematicDrivenLayout._build_subcomponents(sq::ExampleSimpleSQUID)
     @component jj1 = sq.jj_templates[1] begin
-        h_ground_island = sq.h_ground_island
-        h_excess = sq.h_excess
+        ground_island_length = sq.ground_island_length
+        lead_excess_length = sq.lead_excess_length
     end
     @component jj2 = sq.jj_templates[2] begin
-        h_ground_island = sq.h_ground_island
-        h_excess = sq.h_excess
+        ground_island_length = sq.ground_island_length
+        lead_excess_length = sq.lead_excess_length
     end
     @component spacer_left =
-        Spacer{coordinatetype(sq)}(p1=Point(-sq.w_squid / 2, zero(sq.w_squid)))
+        Spacer{coordinatetype(sq)}(p1=Point(-sq.squid_width / 2, zero(sq.squid_width)))
     @component spacer_right =
-        Spacer{coordinatetype(sq)}(p1=Point(sq.w_squid / 2, zero(sq.w_squid)))
+        Spacer{coordinatetype(sq)}(p1=Point(sq.squid_width / 2, zero(sq.squid_width)))
 
     return (jj1, jj2, spacer_left, spacer_right)
 end
@@ -172,9 +178,15 @@ function SchematicDrivenLayout._graph!(
     return fuse!(g, spacer_left_node => :p0_south, spacer_right_node => :p0_north)
 end
 
+# Graph node indices, in the order subcomponents are returned by `_build_subcomponents`
+# (and added in `_graph!`). Centralizing the index↔subcomponent mapping keeps `map_hooks`
+# from hardcoding a bare integer that must track the build order by hand.
+const _SIMPLE_SQUID_NODES = (jj1=1, jj2=2, spacer_left=3, spacer_right=4)
+
 function SchematicDrivenLayout.map_hooks(tr::ExampleSimpleSQUID)
     ###### Dictionary mapping (graph node index => subcomp hook name) => MyComp hook name
-    return Dict((3 => :p0_south) => :island)
+    n = _SIMPLE_SQUID_NODES
+    return Dict((n.spacer_left => :p0_south) => :island)
 end
 
 SchematicDrivenLayout.check_rotation(::ExampleSimpleSQUID) = true

--- a/src/schematics/ExamplePDK/components/Transmons/Transmons.jl
+++ b/src/schematics/ExamplePDK/components/Transmons/Transmons.jl
@@ -50,12 +50,16 @@ This component is intended for use in demonstrations.
   - `star_tip_width = 50μm`: Width of star tips
   - `rounding = 5μm`: Rounding applied to ground plane geometry
   - `jj_template = ExampleSimpleSQUID()`: Template to generate JJ or SQUID,
-    where `name` and `h_ground_island` will be overridden
+    where `name` and `ground_island_length` will be overridden
   - `lattice_spacing = 1.65mm`: Spacing between transmons (determines coupler length)
   - `right_handed = true`: If `false`, is reflected when attached to right-handed transmons
   - `coupler_style = Paths.CPW(10μm, 10μm)`: `Path` style for couplers
   - `resonator_style = Paths.CPW(10μm, 10μm)`: `Path` style for readout resonator (coupler index `5`
     includes a taper from `coupler_style` to `resonator_style`)
+  - `coupler_bend_radius = 50μm`: Bend radius (and initial straight length) used when routing
+    each coupler away from the island
+  - `coupler_straight_length = 50μm`: Length of the initial straight segment on each coupler
+    before bending toward its destination
   - `grounded_couplers = Int[]`: List of grounded coupler indices (1 to 5, clockwise from 12 o'clock)
   - `coupler_bridge = nothing`: `CoordinateSystem` holding a bridge to place over couplers
   - `feedline_style = Paths.CPW(10μm, 6μm)`: XY/Z control feedline style (before taper)
@@ -102,6 +106,8 @@ This component is intended for use in demonstrations.
     right_handed = true
     coupler_style = Paths.CPW(10μm, 10μm)
     resonator_style = Paths.CPW(10μm, 10μm)
+    coupler_bend_radius = 50μm
+    coupler_straight_length = 50μm
     grounded_couplers = Int[]
     coupler_bridge = nothing
     feedline_style = Paths.CPW(10μm, 6μm)
@@ -120,14 +126,21 @@ function SchematicDrivenLayout._build_subcomponents(tr::ExampleStarTransmon)
     island_params = filter_parameters(ExampleStarIsland, tr)
     @component island = ExampleStarIsland(; island_params...)
     @component junction = tr.jj_template begin
-        h_ground_island = tr.island_ground_gap
+        ground_island_length = tr.island_ground_gap
     end
     # Coupler subcomponents are Paths
     couplers = coupler_paths(tr, island)
     readout_coupler = Path(nm; name="readout_coupler", metadata=METAL_NEGATIVE)
-    straight!(readout_coupler, 50μm, Paths.TaperCPW(tr.coupler_style, tr.resonator_style))
-    !isnothing(tr.coupler_bridge) && attach!(readout_coupler, sref(tr.coupler_bridge), 25μm)
-    turn!(readout_coupler, π / 4 - π / 5, 50μm, tr.resonator_style)
+    straight!(
+        readout_coupler,
+        tr.coupler_straight_length,
+        Paths.TaperCPW(tr.coupler_style, tr.resonator_style)
+    )
+    !isnothing(tr.coupler_bridge) &&
+        attach!(readout_coupler, sref(tr.coupler_bridge), tr.coupler_straight_length / 2)
+    # Turn from the cardinal coupler grid (2π/5 spacing) onto the readout direction (π/4)
+    readout_coupler_turn = π / 4 - π / 5
+    turn!(readout_coupler, readout_coupler_turn, tr.coupler_bend_radius, tr.resonator_style)
     @component xy = ExampleXYTermination(; filter_parameters(ExampleXYTermination, tr)...) begin
         bridge = tr.control_bridge
     end
@@ -156,24 +169,41 @@ function SchematicDrivenLayout._graph!(
     return fuse!(g, island_node => :z, subcomps.z => :qubit)
 end
 
+# Graph node indices, in the order subcomponents are returned by `_build_subcomponents`
+# (and added in `_graph!`). Keeping the index↔subcomponent mapping in one named place means
+# `map_hooks` does not hardcode bare integers that must be kept in sync by hand: if the build
+# order changes, only this NamedTuple needs to be updated.
+const _STAR_TRANSMON_NODES = (
+    island=1,
+    junction=2,
+    readout_coupler=3,
+    coupler_N=4,
+    coupler_E=5,
+    coupler_S=6,
+    coupler_W=7,
+    xy=8,
+    z=9
+)
+
 function SchematicDrivenLayout.map_hooks(tr::ExampleStarTransmon)
     ###### Dictionary mapping (graph node index => subcomp hook name) => MyComp hook name
+    n = _STAR_TRANSMON_NODES
     path_hook = tr.right_handed ? :p1 : :p1_lh
     return Dict(
-        (1 => :origin) => :origin,
-        (3 => :p1) => :readout,
-        (4 => path_hook) => :coupler_N,
-        (5 => path_hook) => :coupler_E,
-        (6 => path_hook) => :coupler_S,
-        (7 => path_hook) => :coupler_W,
-        (8 => :line) => :xy,
-        (9 => :line) => :z
+        (n.island => :origin) => :origin,
+        (n.readout_coupler => :p1) => :readout,
+        (n.coupler_N => path_hook) => :coupler_N,
+        (n.coupler_E => path_hook) => :coupler_E,
+        (n.coupler_S => path_hook) => :coupler_S,
+        (n.coupler_W => path_hook) => :coupler_W,
+        (n.xy => :line) => :xy,
+        (n.z => :line) => :z
     )
 end
 ###
 
 function coupler_paths(tr::ExampleStarTransmon, isl::ExampleStarIsland)
-    (; coupler_style, lattice_spacing) = tr
+    (; coupler_style, lattice_spacing, coupler_bend_radius, coupler_straight_length) = tr
     h0s = hooks(isl).coupler[1:4] # Starting hooks for paths (clockwise from 12 o'clock)
     h_N = PointHook(0μm, lattice_spacing / 2, -90°)
     h1s = [h_N, RotationPi(-1 // 2)(h_N), RotationPi()(h_N), RotationPi(1 // 2)(h_N)]
@@ -184,14 +214,19 @@ function coupler_paths(tr::ExampleStarTransmon, isl::ExampleStarIsland)
         path = path_out(h_start)
         path.name = "coupler_$idx"
         path.metadata = METAL_NEGATIVE
-        straight!(path, 50μm, coupler_style)
+        straight!(path, coupler_straight_length, coupler_style)
         add_bridges!(path, tr.coupler_bridge)
         # Turn to get correct orientation
         α = rem(α_end - α_start, 360°, RoundNearest)
-        !(iszero(α)) && turn!(path, α, 50μm)
+        !(iszero(α)) && turn!(path, α, coupler_bend_radius)
         # Snake to get to correct position
         # If unreachable, reduce above straight length and/or decrease assumed_coupler_extent
-        route!(path, h_end.p, α_end, Paths.StraightAnd45(min_bend_radius=50μm))
+        route!(
+            path,
+            h_end.p,
+            α_end,
+            Paths.StraightAnd45(min_bend_radius=coupler_bend_radius)
+        )
         push!(paths, path)
     end
     return paths
@@ -208,7 +243,7 @@ Transmon component with a rectangular island acting as a shunt capacitor across 
 
   - `name = "tr"`: Name of component
   - `jj_template = ExampleSimpleJunction()`: Template to generate JJ or SQUID,
-    where `name` and `h_ground_island` will be overridden
+    where `name` and `ground_island_length` will be overridden
   - `cap_width = 24μm`: The width of the rectangular island
   - `cap_length = 520μm`: The length of the rectangular island
   - `cap_gap = 30μm`: The gap surrounding the rectangular island, except the side with the junction/SQUID
@@ -234,9 +269,9 @@ Transmon component with a rectangular island acting as a shunt capacitor across 
     cap_width = 24μm
     cap_length = 520μm
     cap_gap = 30μm
-    junction_gap = 12.0μm
+    junction_gap = 12μm
     junction_pos = :bottom
-    island_rounding = 0µm
+    island_rounding::typeof(1.0µm) = 0µm
 end
 
 island(tr::ExampleRectangleTransmon) = component(tr[1])
@@ -246,7 +281,7 @@ function SchematicDrivenLayout._build_subcomponents(tr::ExampleRectangleTransmon
     @component island = ExampleRectangleIsland(; island_params...)
 
     @component junction = tr.jj_template begin
-        h_ground_island = tr.junction_gap
+        ground_island_length = tr.junction_gap
     end
 
     return (island, junction)
@@ -265,8 +300,8 @@ function SchematicDrivenLayout.map_hooks(::Type{ExampleRectangleTransmon})
     return Dict((1 => :readout) => :readout, (1 => :xy) => :xy, (1 => :z) => :z)
 end
 
-check_rotation(::ExampleRectangleTransmon) = true
-allowed_rotation_angles(::ExampleRectangleTransmon) = [0]
+SchematicDrivenLayout.check_rotation(::ExampleRectangleTransmon) = true
+SchematicDrivenLayout.allowed_rotation_angles(::ExampleRectangleTransmon) = [0]
 
 """
     ExampleRectangleIsland <: Component
@@ -303,7 +338,7 @@ overwritten.
     cap_gap = 30μm
     junction_gap = 12μm
     junction_pos = :bottom
-    island_rounding = 0µm
+    island_rounding::typeof(1.0µm) = 0µm
 end
 
 function SchematicDrivenLayout.hooks(r::ExampleRectangleIsland)
@@ -325,17 +360,21 @@ end
 function SchematicDrivenLayout._geometry!(cs::CoordinateSystem, r::ExampleRectangleIsland)
     (; junction_gap, junction_pos, cap_width, cap_length, cap_gap, island_rounding) = r
     sgn = junction_pos == :bottom ? 1 : -1
-    r1 = Rectangle(
+    island_rect = Rectangle(
         Point(-cap_width / 2, sgn * junction_gap),
         Point(cap_width / 2, sgn * (junction_gap + cap_length))
     )
-    r2 = Rectangle(
+    cutout_rect = Rectangle(
         Point(-cap_width / 2 - cap_gap, zero(cap_gap)),
         Point(cap_width / 2 + cap_gap, sgn * (junction_gap + cap_length + cap_gap))
     )
-    diff = Rounded(island_rounding)(difference2d(r2, r1))
+    cutout = Rounded(island_rounding)(difference2d(cutout_rect, island_rect))
 
-    return render!(cs, meshsized_entity(diff, 2 * min(cap_width, cap_gap)), METAL_NEGATIVE)
+    return render!(
+        cs,
+        meshsized_entity(cutout, 2 * min(cap_width, cap_gap)),
+        METAL_NEGATIVE
+    )
 end
 
 end # module

--- a/src/schematics/ExamplePDK/components/Transmons/star_island.jl
+++ b/src/schematics/ExamplePDK/components/Transmons/star_island.jl
@@ -20,6 +20,8 @@ these defaults are overridden.
   - `star_tip_width = 50μm`: Width of star tips
   - `coupler_style = Paths.CPW(10μm, 10μm)`: `Path` style for couplers
   - `rounding = 5μm`: Rounding applied to ground plane geometry
+  - `coupler_lead_overlap = 5μm`: Extra length each coupler lead rectangle extends past the
+    island-ground gap toward the island
 
 # Hooks
 
@@ -40,7 +42,8 @@ these defaults are overridden.
     island_coupler_gap = 15μm
     star_tip_width = 50μm
     coupler_style = Paths.CPW(10μm, 10μm)
-    rounding = 5μm
+    rounding::typeof(1.0μm) = 5μm
+    coupler_lead_overlap = 5μm
 end
 
 function SchematicDrivenLayout._geometry!(cs::CoordinateSystem, isl::ExampleStarIsland)
@@ -51,7 +54,8 @@ function SchematicDrivenLayout._geometry!(cs::CoordinateSystem, isl::ExampleStar
         island_coupler_gap,
         star_tip_width,
         coupler_style,
-        rounding
+        rounding,
+        coupler_lead_overlap
     ) = isl
     θ_outer = range(π / 2, step=2π / 5, length=5)
     θ_inner = θ_outer .+ π / 5
@@ -90,7 +94,7 @@ function SchematicDrivenLayout._geometry!(cs::CoordinateSystem, isl::ExampleStar
     outer, interface_pts = _outer_cutout(isl)
 
     ## Draw the coupler lead rectangles
-    lead = Rectangle(coupler_style.trace, island_ground_gap + 5μm)
+    lead = Rectangle(coupler_style.trace, island_ground_gap + coupler_lead_overlap)
     lead = Align.flushbottom(lead, outer, centered=true)
     append!(positive_polys, [Rotation(θ - π / 2)(lead) for θ in θ_outer])
 

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -1,7 +1,15 @@
 @testitem "ExamplePDK" setup = [CommonTestSetup] begin
     include("../examples/DemoQPU17/DemoQPU17.jl")
     @time "Total" schematic, artwork = DemoQPU17.qpu17_demo(dir=tdir)
-
+    # Check for changes to geometry
+    fingerprint = Cells.geometry_fingerprint(artwork)
+    expected = "d410651b9adfffb19db2182e9713d6599539181fea85644d6c1b3631a17acb9d"
+    @test fingerprint == expected
+    fingerprint != expected && println("""
+        Expected QPU17 artwork fingerprint: $expected
+        Found: $fingerprint
+        If rendering changes were intentional, update the expected fingerprint.
+    """)
     # Check target constructor
     fc_target = SchematicDrivenLayout.ExamplePDK.flipchip_solidmodel_target([
         "port_1",

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -2,14 +2,18 @@
     include("../examples/DemoQPU17/DemoQPU17.jl")
     @time "Total" schematic, artwork = DemoQPU17.qpu17_demo(dir=tdir)
     # Check for changes to geometry
-    fingerprint = Cells.geometry_fingerprint(artwork)
-    expected = "d410651b9adfffb19db2182e9713d6599539181fea85644d6c1b3631a17acb9d"
-    @test fingerprint == expected
-    fingerprint != expected && println("""
-        Expected QPU17 artwork fingerprint: $expected
-        Found: $fingerprint
-        If rendering changes were intentional, update the expected fingerprint.
-    """)
+    if VERSION >= v"1.12-"
+        # Julia v1.10 and v1.11 give different fingerprints
+        # Mainly for flagging unintentional changes, so doesn't need to run on every version
+        fingerprint = Cells.geometry_fingerprint(artwork)
+        expected = "d410651b9adfffb19db2182e9713d6599539181fea85644d6c1b3631a17acb9d"
+        @test fingerprint == expected
+        fingerprint != expected && println("""
+            Expected QPU17 artwork fingerprint: $expected
+            Found: $fingerprint
+            If rendering changes were intentional, update the expected fingerprint.
+        """)
+    end
     # Check target constructor
     fc_target = SchematicDrivenLayout.ExamplePDK.flipchip_solidmodel_target([
         "port_1",

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -22,7 +22,7 @@ end
     @test geometry(q) isa CoordinateSystem{typeof(1.0DeviceLayout.nm)}
     @test geometry(rr) isa CoordinateSystem{typeof(1.0DeviceLayout.nm)}
     @test issubset([:readout, :xy, :z], keys(hooks(q)))
-    @test abs(hooks(rr).qubit.p.y - hooks(rr).feedline.p.y) ≈ rr.total_height
+    @test abs(hooks(rr).qubit.p.y - hooks(rr).feedline.p.y) ≈ rr.total_y_length
 
     import .SchematicDrivenLayout.ExamplePDK: LayerVocabulary
     g = SchematicGraph("single-transmon")

--- a/test/test_parameter_set.jl
+++ b/test/test_parameter_set.jl
@@ -620,8 +620,8 @@ end
     @testset "IO round-trip with Unitful" begin
         ps = ParameterSet()
         ps.global.process_node = "fab_v3"
-        ps.components.jj.w_jj = 1μm
-        ps.components.jj.h_jj = 0.5μm
+        ps.components.jj.junction_width = 1μm
+        ps.components.jj.junction_lead_gap = 0.5μm
         ps.components.jj.count = 2
 
         # Write
@@ -633,8 +633,8 @@ end
         ps2 = ParameterSet(IOBuffer(yaml_bytes))
 
         @test ps2.global.process_node == "fab_v3"
-        @test ps2.components.jj.w_jj == 1μm
-        @test ps2.components.jj.h_jj == 0.5μm
+        @test ps2.components.jj.junction_width == 1μm
+        @test ps2.components.jj.junction_lead_gap == 0.5μm
         @test ps2.components.jj.count == 2
     end
 
@@ -675,7 +675,7 @@ end
         ps = ParameterSet()
         ps.components.transmon.island.cap_length = 520μm
         ps.components.transmon.island.cap_width = 24μm
-        ps.components.transmon.junction.w_jj = 1μm
+        ps.components.transmon.junction.junction_width = 1μm
 
         io = IOBuffer()
         save_parameter_set(io, ps)
@@ -683,7 +683,7 @@ end
 
         @test ps2.components.transmon.island.cap_length == 520μm
         @test ps2.components.transmon.island.cap_width == 24μm
-        @test ps2.components.transmon.junction.w_jj == 1μm
+        @test ps2.components.transmon.junction.junction_width == 1μm
     end
 
     @testset "Parsed lengths share DeviceLayout's promotion context" begin
@@ -753,7 +753,7 @@ end
             ps,
             "components.ps_flow_transmon.junction"
         )
-        junction = set_parameters(junction; h_ground_island=tr.junction_gap)
+        junction = set_parameters(junction; ground_island_length=tr.junction_gap)
         return (island, junction)
     end
 
@@ -774,8 +774,8 @@ end
         ps.components.ps_flow_transmon.junction_gap = 15μm
         ps.components.ps_flow_transmon.island.cap_width = 42μm
         ps.components.ps_flow_transmon.island.cap_length = 600μm
-        ps.components.ps_flow_transmon.junction.w_jj = 2μm
-        ps.components.ps_flow_transmon.junction.h_jj = 2μm
+        ps.components.ps_flow_transmon.junction.junction_width = 2μm
+        ps.components.ps_flow_transmon.junction.junction_lead_gap = 2μm
 
         tr = create_component(PSFlowTestTransmon, ps, "components.ps_flow_transmon")
         # PS is threaded into the composite's private graph - the core fix.
@@ -796,16 +796,16 @@ end
         # Leaf parameters from the PS were applied to the subcomponents.
         @test parameters(island).cap_width == 42μm
         @test parameters(island).cap_length == 600μm
-        @test parameters(junction).w_jj == 2μm
+        @test parameters(junction).junction_width == 2μm
         # Shared parameter forwarded via `set_parameters` from the composite.
         @test parameters(island).junction_gap == 15μm
-        @test parameters(junction).h_ground_island == 15μm
+        @test parameters(junction).ground_island_length == 15μm
 
         # Access tracking records qualified paths (both the composite's own
         # leaf and the subcomponent leaves).
         @test "components.ps_flow_transmon.junction_gap" in ps.accessed
         @test "components.ps_flow_transmon.island.cap_width" in ps.accessed
-        @test "components.ps_flow_transmon.junction.w_jj" in ps.accessed
+        @test "components.ps_flow_transmon.junction.junction_width" in ps.accessed
     end
 
     @testset "Top-level plan runs end-to-end" begin
@@ -813,7 +813,7 @@ end
         ps.components.ps_flow_transmon.junction_gap = 10μm
         ps.components.ps_flow_transmon.island.cap_width = 30μm
         ps.components.ps_flow_transmon.island.cap_length = 500μm
-        ps.components.ps_flow_transmon.junction.w_jj = 1μm
+        ps.components.ps_flow_transmon.junction.junction_width = 1μm
 
         g = SchematicGraph("chip", ps)
         tr = create_component(PSFlowTestTransmon, ps, "components.ps_flow_transmon")
@@ -867,7 +867,7 @@ end
         island = set_parameters(island; junction_gap=tr.junction_gap)
         junction =
             set_parameters(tr.templates.junction, ps, "components.$(name(tr)).junction")
-        junction = set_parameters(junction; h_ground_island=tr.junction_gap)
+        junction = set_parameters(junction; ground_island_length=tr.junction_gap)
         return (island, junction)
     end
 
@@ -887,7 +887,7 @@ end
         ps = ParameterSet()
         ps.components.template_transmon.junction_gap = 15μm
         ps.components.template_transmon.island.cap_length = 600μm
-        ps.components.template_transmon.junction.w_jj = 2μm
+        ps.components.template_transmon.junction.junction_width = 2μm
 
         tr = create_component(TestTemplatesTransmon, ps, "components.template_transmon")
         island = components(tr)[1]
@@ -895,7 +895,7 @@ end
         @test parameters(island).cap_length == 600μm
         # Template default for cap_width (30μm) is preserved - PS didn't set it
         @test parameters(island).cap_width == 30μm
-        @test parameters(junction).w_jj == 2μm
+        @test parameters(junction).junction_width == 2μm
     end
 
     @testset "Happy path - scoped form" begin
@@ -928,7 +928,7 @@ end
         ps.components.template_transmon.island.junction_gap = 99μm
         # junction namespace must exist for `set_parameters(..., ps, ".junction")`
         # to resolve; content is irrelevant here.
-        ps.components.template_transmon.junction.w_jj = 1μm
+        ps.components.template_transmon.junction.junction_width = 1μm
 
         tr = create_component(TestTemplatesTransmon, ps, "components.template_transmon")
         island = components(tr)[1]
@@ -1144,7 +1144,7 @@ end
         ps = ParameterSet()
         ps.components.template_transmon.junction_gap = 10μm
         ps.components.template_transmon.island.cap_length = 500μm
-        ps.components.template_transmon.junction.w_jj = 1μm
+        ps.components.template_transmon.junction.junction_width = 1μm
 
         g = SchematicGraph("chip_phase2", ps)
         tr = create_component(TestTemplatesTransmon, ps, "components.template_transmon")
@@ -1156,10 +1156,10 @@ end
         island = comps[1]
         junction = comps[2]
         @test parameters(island).cap_length == 500μm
-        @test parameters(junction).w_jj == 1μm
+        @test parameters(junction).junction_width == 1μm
         # Composite override wins over PS for shared parameter.
         @test parameters(island).junction_gap == 10μm
-        @test parameters(junction).h_ground_island == 10μm
+        @test parameters(junction).ground_island_length == 10μm
     end
 
     # The tutorial promises "subcomponents at any depth can access the same
@@ -1206,7 +1206,7 @@ end
         ps.components.outer.inner.junction_gap = 13μm
         # Inner composite's templates - read at `"components.$(name(inner)).*"`.
         ps.components.inner.island.cap_length = 700μm
-        ps.components.inner.junction.w_jj = 3μm
+        ps.components.inner.junction.junction_width = 3μm
 
         g = SchematicGraph("chip_nested", ps)
         outer = create_component(OuterTemplatesComposite, ps, "components.outer")
@@ -1224,11 +1224,11 @@ end
         inner_island = components(inner)[1]
         inner_junction = components(inner)[2]
         @test parameters(inner_island).cap_length == 700μm
-        @test parameters(inner_junction).w_jj == 3μm
+        @test parameters(inner_junction).junction_width == 3μm
 
         # Inner-composite override propagates to its subcomponents.
         @test parameters(inner_island).junction_gap == 13μm
-        @test parameters(inner_junction).h_ground_island == 13μm
+        @test parameters(inner_junction).ground_island_length == 13μm
 
         # `plan` runs end-to-end with nested PS-driven composites.
         floorplan = plan(g; log_dir=nothing)


### PR DESCRIPTION
Update `ExamplePDK` component parameters to follow the component style guide -- mostly renames to use `<feature>_<dimension>` naming and dimension name conventions, also turning a couple magic numbers into parameters. There's also a reparameterization of the hairpin resonator to remove the degenerate extra effective length parameter.