### PR TITLE
Parse and serialize Unitful arrays in ParameterSet YAML IO

### DIFF
--- a/ext/ParameterSetYAMLExt.jl
+++ b/ext/ParameterSetYAMLExt.jl
@@ -8,8 +8,9 @@ import Unitful
 """
     _parse_units!(data::Dict{String, Any})
 
-Recursively walk a parsed YAML dict. String values that parse into a
-`Unitful.Quantity` (e.g. `"150μm"`) are converted in place via
+Recursively walk a parsed YAML dict. String values, including strings inside
+array leaves, that parse into a `Unitful.Quantity` (e.g. `"150μm"`) are
+converted via
 [`DeviceLayout.uparse`](@ref), so length-dimensioned values share the
 package's promotion context (`ContextUnits`) instead of carrying bare
 `FreeUnits` (which would later trip the mixed-context promotion bug
@@ -20,18 +21,26 @@ Bare unit names like `"s"`, `"m"`, `"cm"` parse into `Unitful.Units`, not
 `Quantity` - those are left as strings so that ordinary text values (e.g.
 `process_node: "s"`) are not silently coerced into the seconds unit.
 """
+function _parse_unit_value(v::AbstractString)
+    try
+        parsed = DeviceLayout.uparse(v)
+        return parsed isa Unitful.Quantity ? parsed : v
+    catch
+        return v
+    end
+end
+
+function _parse_unit_value(v::Dict{String, Any})
+    _parse_units!(v)
+    return v
+end
+
+_parse_unit_value(v::AbstractVector) = map(_parse_unit_value, v)
+_parse_unit_value(v) = v
+
 function _parse_units!(data::Dict{String, Any})
     for (k, v) in data
-        if v isa Dict{String, Any}
-            _parse_units!(v)
-        elseif v isa AbstractString
-            try
-                parsed = DeviceLayout.uparse(v)
-                parsed isa Unitful.Quantity && (data[k] = parsed)
-            catch
-                # not a valid unit expression, keep as-is
-            end
-        end
+        data[k] = _parse_unit_value(v)
     end
     return data
 end
@@ -39,19 +48,22 @@ end
 """
     _serialize_units(data::Dict{String, Any}) -> Dict{String, Any}
 
-Return a deep copy of `data` with `Unitful.Quantity` values converted to
-strings like `"150μm"` (no space, round-trips through `Unitful.uparse`).
+Return a deep copy of `data` with `Unitful.Quantity` values, including values
+inside arrays, converted to strings like `"150μm"` (no space, round-trips
+through `Unitful.uparse`).
 """
+function _serialize_unit_value(v::Dict{String, Any})
+    return _serialize_units(v)
+end
+
+_serialize_unit_value(v::AbstractVector) = map(_serialize_unit_value, v)
+_serialize_unit_value(v::Unitful.Quantity) = "$(Unitful.ustrip(v))$(Unitful.unit(v))"
+_serialize_unit_value(v) = v
+
 function _serialize_units(data::Dict{String, Any})
     out = Dict{String, Any}()
     for (k, v) in data
-        if v isa Dict{String, Any}
-            out[k] = _serialize_units(v)
-        elseif v isa Unitful.Quantity
-            out[k] = "$(Unitful.ustrip(v))$(Unitful.unit(v))"
-        else
-            out[k] = v
-        end
+        out[k] = _serialize_unit_value(v)
     end
     return out
 end

--- a/test/test_parameter_set.jl
+++ b/test/test_parameter_set.jl
@@ -590,6 +590,36 @@ end
         @test ps.components.qubit.finger_count == 4
     end
 
+    @testset "ParameterSet from IO parses unit arrays" begin
+        # Each element is its own YAML scalar (`0μm`), so the array walk in
+        # `_parse_units!` converts them element-wise to ContextUnits quantities.
+        yaml_str = """
+        components:
+          routing:
+            pad_offsets: [0μm, 25μm, 50μm]
+        """
+        ps = ParameterSet(IOBuffer(yaml_str))
+
+        offsets = ps.components.routing.pad_offsets
+        @test offsets == [0μm, 25μm, 50μm]
+        @test all(x -> x isa Unitful.Quantity, offsets)
+        @test all(x -> Unitful.unit(x) isa Unitful.ContextUnits, offsets)
+        @test leaf_params(ps.components.routing).pad_offsets == offsets
+    end
+
+    @testset "Factored unit after a flow sequence is not valid YAML" begin
+        # `[0, 25, 50]μm` is not a YAML scalar: a token after the closing `]` of
+        # a flow sequence is a syntax error, so YAML.load rejects it before any
+        # unit conversion can run. We deliberately do not preprocess this
+        # notation - write the unit on each element (`[0μm, 25μm, 50μm]`).
+        yaml_str = """
+        components:
+          routing:
+            pad_offsets: [0, 25, 50]μm
+        """
+        @test_throws YAML.ParserError ParameterSet(IOBuffer(yaml_str))
+    end
+
     @testset "Bare unit strings are preserved as strings" begin
         # Strings that `Unitful.uparse` recognizes as bare units (not Quantities)
         # must NOT be coerced - `process_node: "s"` should stay the string "s",

--- a/test/test_parameter_set.jl
+++ b/test/test_parameter_set.jl
@@ -668,6 +668,25 @@ end
         @test ps2.components.jj.count == 2
     end
 
+    @testset "IO round-trip with a Unitful array" begin
+        # Arrays of quantities serialize element-wise to unit strings and parse
+        # back element-wise, so the vector survives the round-trip with its
+        # values intact and re-enters as ContextUnits quantities.
+        ps = ParameterSet()
+        ps.components.routing.pad_offsets = [0μm, 25μm, 50μm]
+
+        io = IOBuffer()
+        save_parameter_set(io, ps)
+        yaml_bytes = take!(io)
+
+        ps2 = ParameterSet(IOBuffer(yaml_bytes))
+
+        offsets = ps2.components.routing.pad_offsets
+        @test offsets == [0μm, 25μm, 50μm]
+        @test all(x -> x isa Unitful.Quantity, offsets)
+        @test all(x -> Unitful.unit(x) isa Unitful.ContextUnits, offsets)
+    end
+
     @testset "ParameterSet from IO with path" begin
         yaml_str = """
         global:


### PR DESCRIPTION
## What

Make `ParameterSet` YAML IO handle arrays of `Unitful` values, not just scalars.

`_parse_units!` and `_serialize_units` now dispatch on the value type and walk
array leaves element-wise. A YAML list of unit scalars — `[0μm, 25μm, 50μm]` —
round-trips through load/save as `ContextUnits` quantities, matching how scalar
values are already handled (parsed via `DeviceLayout.uparse` so lengths share
the package's promotion context).

## Not supported: factored units

The factored form `[0, 25, 50]μm` is **not valid YAML** — a token after the
closing `]` of a flow sequence is a parser error, so `YAML.load` rejects it
before any unit conversion runs. We deliberately do not preprocess this
notation. Write the unit on each element instead (`[0μm, 25μm, 50μm]`). A test
pins this boundary so the behavior is explicit.

## Tests

- "parses unit arrays" — valid per-element form round-trips as `ContextUnits`.
- "Factored unit after a flow sequence is not valid YAML" — asserts the
  factored form raises `YAML.ParserError`.

All 37 tests in the `ParameterSet YAML IO` testitem pass.
