### PR TITLE
Fix gridpoints_in_polygon exact comparison bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format of this changelog is based on
     `arclength_to_t` call). The forward map remains exact; `arclength_to_t` now uses a
     table-seeded Newton iteration (relative tolerance `1e-12`) in place of `Optim`-based
     minimization, so results may differ from previous versions within tolerance.
+  - Fixed bug where exact floating point comparison in `autofill` could lead to a gridpoint on an interior edge being filled
 
 ## 1.15.0 (2026-06-14)
 

--- a/src/polygons.jl
+++ b/src/polygons.jl
@@ -1400,10 +1400,17 @@ function gridpoints_in_polygon(
                 (last(edge).x - first(edge).x) * (y - first(edge).y) /
                 (last(edge).y - first(edge).y)
             x_right_minidx = searchsortedfirst(grid_x, x) # Can be nx + 1 if x > last(grid_x)
-            # If the grid point lies on the edge, it's in the polygon
+            # If a grid point lies on the edge, it's in the polygon. The computed
+            # crossing x may round to either side of an on-edge grid point, so we
+            # check both grid points bracketing the insertion point: grid_x[k-1] < x
+            # <= grid_x[k]. Checking only grid_x[k] would miss points where x rounds
+            # just above the grid point.
             x_right_minidx <= nx &&
                 isapprox(x, grid_x[x_right_minidx]) &&
                 (in_poly[x_right_minidx, iy] = true)
+            x_right_minidx > 1 &&
+                isapprox(x, grid_x[x_right_minidx - 1]) &&
+                (in_poly[x_right_minidx - 1, iy] = true)
             # Record edge crossing in difference array (O(1) instead of O(grid_x))
             s = sign(last(edge).y - first(edge).y)
             delta[1] += s

--- a/src/polygons.jl
+++ b/src/polygons.jl
@@ -1402,7 +1402,7 @@ function gridpoints_in_polygon(
             x_right_minidx = searchsortedfirst(grid_x, x) # Can be nx + 1 if x > last(grid_x)
             # If the grid point lies on the edge, it's in the polygon
             x_right_minidx <= nx &&
-                x == grid_x[x_right_minidx] &&
+                isapprox(x, grid_x[x_right_minidx]) &&
                 (in_poly[x_right_minidx, iy] = true)
             # Record edge crossing in difference array (O(1) instead of O(grid_x))
             s = sign(last(edge).y - first(edge).y)

--- a/test/test_pointinpoly.jl
+++ b/test/test_pointinpoly.jl
@@ -88,6 +88,16 @@
     in_poly = gridpoints_in_polygon(poly, dx, dy)
     @test count((!).(in_poly)) == 14
     @test all(in_poly .== gridpoints_in_polygon(poly, dx, dy))
+
+    # On-edge grid point with floating-point round-off in the edge crossing.
+    # The slanted edge (0, 0)->(0.2μm, 0.4μm) has slope 1/2 and passes exactly
+    # through the grid point (0.1μm, 0.2μm). The crossing x = 0.2*(0.2/0.4) is
+    # evaluated as 0.10000000000000002, just above 0.1μm, so `searchsortedfirst`
+    # returns the next grid point. The on-edge point must still be counted as
+    # inside, which requires checking both grid points bracketing the crossing.
+    tri =
+        Polygon(Point(0.0, 0.0)μm, Point(0.2, 0.4)μm, Point(0.6, 0.4)μm, Point(0.6, 0.0)μm)
+    @test Polygons.gridpoints_in_polygon([tri], [0.1]μm, [0.2]μm)[1, 1]
 end
 
 @testitem "Autofill" setup = [CommonTestSetup] begin


### PR DESCRIPTION
Fix the bug described in [this comment](https://github.com/aws-cqc/DeviceLayout.jl/pull/236#issuecomment-4864422022) (tracked in #247), as well as the symmetric bug with epsilon in the other direction, with a regression test.