### PR TITLE
Add fast path for constant curvature discretization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ The format of this changelog is based on
     the style grid is in the original segment's arclength frame, which offset
     resolution does not preserve, so the result would place style transitions in the
     wrong locations.
+  - Added a fast path for constant-curvature discretization: `Turn` and
+    constant-offset `Turn` segments are sampled uniformly at the tolerance-derived
+    angular step instead of marching with the general curvature-controlled kernel,
+    making turn discretization faster and avoiding over-refinment in some cases. Rendered point counts and positions change slightly for every `Turn` within the same `atol`/`rtol` tolerances. Degenerate turns (zero sweep, zero radius, `|offset| == r`) now discretize to exactly two points, and
+    offset turns with `|offset| > r` keep exact endpoints.
   - Added `WithDirection <: GeometryEntityStyle` to annotate geometry entities with a direction (CCW from +x in local frame). The direction transforms with the entity under rotations and reflections, allowing extraction of the final global direction for use in simulation configuration.
   - Added `SolidModels.check_port_connectivity`, using `SolidModels.connected_components` to report ports as `:open`, `:short`, `:floating`, or `:missing`
   - Added `detect_non_boundary_contacts=false` keyword argument to `SolidModels.connected_components`; when `true`, 1d edges embedded in the interior of 2D surfaces (like the feet of staple air bridges) will be treated as connecting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format of this changelog is based on
   - Added a fast path for constant-curvature discretization: `Turn` and
     constant-offset `Turn` segments are sampled uniformly at the tolerance-derived
     angular step instead of marching with the general curvature-controlled kernel,
-    making turn discretization faster and avoiding over-refinment in some cases. Rendered point counts and positions change slightly for every `Turn` within the same `atol`/`rtol` tolerances. Degenerate turns (zero sweep, zero radius, `|offset| == r`) now discretize to exactly two points, and
+    making turn discretization faster and avoiding over-refinement in some cases. Rendered point counts and positions change slightly for every `Turn` within the same `atol`/`rtol` tolerances. Degenerate turns (zero sweep, zero radius, `|offset| == r`) now discretize to exactly two points, and
     offset turns with `|offset| > r` keep exact endpoints.
   - Added `WithDirection <: GeometryEntityStyle` to annotate geometry entities with a direction (CCW from +x in local frame). The direction transforms with the entity under rotations and reflections, allowing extraction of the final global direction for use in simulation configuration.
   - Added `SolidModels.check_port_connectivity`, using `SolidModels.connected_components` to report ports as `:open`, `:short`, `:floating`, or `:missing`

--- a/src/paths/segments/offset.jl
+++ b/src/paths/segments/offset.jl
@@ -175,7 +175,14 @@ offset(seg::GeneralOffset, s) = offset(seg.seg, t -> s(t) + seg.offset(t))
 # Define outer constructors for Turn and Straight from
 Straight(x::ConstantOffset{T, Straight{T}}) where {T} = Straight{T}(x.seg.l, p0(x), α0(x))
 function Turn(x::ConstantOffset{T, Turn{T}}) where {T}
-    return Turn(x.seg.α, x.seg.r - sign(x.seg.α) * x.offset, p0(x), x.seg.α0)
+    seg = x.seg
+    r_eff = seg.r - sign(seg.α) * x.offset
+    # Negative radius means "turn the other way" to Turn, but "flip 180 degrees" to offset Turn
+    if r_eff < zero(r_eff) # Shouldn't happen in normal usage but guard anyway
+        return Turn(seg.α, -r_eff; p0=p0(x), α0=seg.α0 + 180.0°)
+    else
+        return Turn(seg.α, r_eff; p0=p0(x), α0=seg.α0)
+    end
 end
 
 # Resolving an offset changes pathlength, so length-carrying styles (compound, taper) must be

--- a/src/render/discretization.jl
+++ b/src/render/discretization.jl
@@ -36,6 +36,26 @@ function discretize_curve(
     return _offset_bspline_point.(Ref(s), discretization_grid(s, tolerance; rtol=rtol))
 end
 
+function discretize_curve(s::Paths.Turn, tolerance; rtol=nothing)
+    if !isnothing(rtol)
+        tolerance = max(tolerance, rtol * s.r)
+    end
+    θ_0 = s.α0 - sign(s.α) * 90.0°
+    ps = circular_arc(θ_0 + s.α, s.r, tolerance; θ_0=θ_0, center=Paths.curvaturecenter(s))
+    # Avoid floating point disagreement about endpoints compared to evaluating s(x)
+    ps[1] = p0(s)
+    ps[end] = p1(s)
+    return ps
+end
+
+function discretize_curve(
+    s::Paths.ConstantOffset{T, Paths.Turn{T}},
+    tolerance;
+    rtol=nothing
+) where {T}
+    return discretize_curve(Paths.resolve_offset(s), tolerance; rtol)
+end
+
 function discretization_grid(s::Paths.Segment, tolerance; rtol=nothing)
     l = pathlength(s)
     return discretization_grid(
@@ -72,10 +92,10 @@ end
 # True curvature κ(t) = |r'×r''|/|r'|³ for a 2D BSpline interpolation r.
 # Returns a scalar with units 1/length, matching the marching kernel's
 # `cc` contract.
+# Bypasses arclength-to-t conversion we'd get using `Paths.curvatureradius`/`Paths.signed_curvature`
+# Doesn't use pre-allocated G, H as with `Paths._curvature!` -- only minor speedup in some cases anyway
 function _bspline_curvature(r, t)
-    g = Paths.Interpolations.gradient(r, t)[1]
-    h = Paths.Interpolations.hessian(r, t)[1]
-    return abs(g.x * h.y - g.y * h.x) / (g.x^2 + g.y^2)^(3 // 2)
+    return abs(_bspline_signed_curvature(r, t))
 end
 
 function discretization_grid(s::Paths.BSpline, tolerance; rtol=nothing)
@@ -156,8 +176,8 @@ end
 # Offset-BSpline curvature in base spline `t` space, avoiding an arclength-to-`t`
 # root-find at every discretization step.
 function _offset_bspline_curvature(s::Paths.ConstantOffset, t)
-    return _bspline_curvature(s.seg.r, t) /
-           abs(1 - s.offset * _bspline_signed_curvature(s.seg.r, t))
+    κ = _bspline_signed_curvature(s.seg.r, t)
+    return abs(κ) / abs(1 - s.offset * κ)
 end
 
 # Mirrors curvatureradius(::GeneralOffset, s), including its ignored offset*dκ/ds term.

--- a/src/render/discretization.jl
+++ b/src/render/discretization.jl
@@ -42,6 +42,7 @@ function discretize_curve(s::Paths.Turn, tolerance; rtol=nothing)
     end
     θ_0 = s.α0 - sign(s.α) * 90.0°
     ps = circular_arc(θ_0 + s.α, s.r, tolerance; θ_0=θ_0, center=Paths.curvaturecenter(s))
+    length(ps) < 2 && return [p0(s), p1(s)]
     # Avoid floating point disagreement about endpoints compared to evaluating s(x)
     ps[1] = p0(s)
     ps[end] = p1(s)
@@ -53,7 +54,11 @@ function discretize_curve(
     tolerance;
     rtol=nothing
 ) where {T}
-    return discretize_curve(Paths.resolve_offset(s), tolerance; rtol)
+    ps = discretize_curve(Paths.resolve_offset(s), tolerance; rtol)
+    # Avoid floating point disagreement about endpoints compared to evaluating s(x)
+    ps[1] = p0(s)
+    ps[end] = p1(s)
+    return ps
 end
 
 function discretization_grid(s::Paths.Segment, tolerance; rtol=nothing)

--- a/src/render/discretization.jl
+++ b/src/render/discretization.jl
@@ -40,8 +40,14 @@ function discretize_curve(s::Paths.Turn, tolerance; rtol=nothing)
     if !isnothing(rtol)
         tolerance = max(tolerance, rtol * abs(s.r))
     end
-    θ_0 = s.α0 - sign(s.α) * 90.0°
-    ps = circular_arc(θ_0 + s.α, s.r, tolerance; θ_0=θ_0, center=Paths.curvaturecenter(s))
+    θ_0 = s.α0 - sign(s.r) * sign(s.α) * 90.0°
+    ps = circular_arc(
+        θ_0 + sign(s.r) * s.α,
+        abs(s.r),
+        tolerance;
+        θ_0=θ_0,
+        center=Paths.curvaturecenter(s)
+    )
     length(ps) < 2 && return [p0(s), p1(s)]
     # Avoid floating point disagreement about endpoints compared to evaluating s(x)
     ps[1] = p0(s)

--- a/src/render/discretization.jl
+++ b/src/render/discretization.jl
@@ -38,7 +38,7 @@ end
 
 function discretize_curve(s::Paths.Turn, tolerance; rtol=nothing)
     if !isnothing(rtol)
-        tolerance = max(tolerance, rtol * s.r)
+        tolerance = max(tolerance, rtol * abs(s.r))
     end
     θ_0 = s.α0 - sign(s.α) * 90.0°
     ps = circular_arc(θ_0 + s.α, s.r, tolerance; θ_0=θ_0, center=Paths.curvaturecenter(s))

--- a/src/simple_shapes.jl
+++ b/src/simple_shapes.jl
@@ -60,9 +60,9 @@ If `θ_1 > θ_0`, the arc is drawn counterclockwise.
 function circular_arc(θ_0::Float64, θ_1::Float64, dθ_max::Float64, r, center)
     iszero(r) && return [center]
     θs = range(θ_0, stop=θ_1, length=1 + Int(ceil(abs(θ_1 - θ_0) / dθ_max)))
-    return map(θs) do θ 
+    return map(θs) do θ
         s, c = sincos(θ)
-        return Point(r*c, r*s) + center
+        return Point(r * c, r * s) + center
     end
 end
 circular_arc(θ_0, θ_1, dθ_max, r, center) = circular_arc(

--- a/src/simple_shapes.jl
+++ b/src/simple_shapes.jl
@@ -60,7 +60,10 @@ If `θ_1 > θ_0`, the arc is drawn counterclockwise.
 function circular_arc(θ_0::Float64, θ_1::Float64, dθ_max::Float64, r, center)
     iszero(r) && return [center]
     θs = range(θ_0, stop=θ_1, length=1 + Int(ceil(abs(θ_1 - θ_0) / dθ_max)))
-    return Translation(center).(Point.(r * cos.(θs), r * sin.(θs)))
+    return map(θs) do θ 
+        s, c = sincos(θ)
+        return Point(r*c, r*s) + center
+    end
 end
 circular_arc(θ_0, θ_1, dθ_max, r, center) = circular_arc(
     convert(Float64, θ_0),

--- a/src/simple_shapes.jl
+++ b/src/simple_shapes.jl
@@ -57,11 +57,18 @@ Discretizes a circular arc from `θ_0` to `θ_1` with a maximum angular step `d�
 
 If `θ_1 > θ_0`, the arc is drawn counterclockwise.
 """
-function circular_arc(θ_0, θ_1, dθ_max, r, center)
+function circular_arc(θ_0::Float64, θ_1::Float64, dθ_max::Float64, r, center)
     iszero(r) && return [center]
     θs = range(θ_0, stop=θ_1, length=1 + Int(ceil(abs(θ_1 - θ_0) / dθ_max)))
     return Translation(center).(Point.(r * cos.(θs), r * sin.(θs)))
 end
+circular_arc(θ_0, θ_1, dθ_max, r, center) = circular_arc(
+    convert(Float64, θ_0),
+    convert(Float64, θ_1),
+    convert(Float64, dθ_max),
+    r,
+    center
+)
 
 # modifying circular_arc so that it draws the shorter arc from θ1 to θ2, which may be clockwise. Inputting θ as a
 # vector [θ1, θ2] because I think that's less likely to get accidentally used in a way that intends to call the

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -6,7 +6,7 @@
         # Julia v1.10 and v1.11 give different fingerprints
         # Mainly for flagging unintentional changes, so doesn't need to run on every version
         fingerprint = Cells.geometry_fingerprint(artwork)
-        expected = "962424e17cceab86e2f90cb95302080d8acd08ad210116951ccc71eb81708c58"
+        expected = "5349dc07d9ceabb83a3dd8ac7b100fa0fd41b251424a077112fb3a4c09473af5"
         @test fingerprint == expected
         fingerprint != expected && println("""
             Expected QPU17 artwork fingerprint: $expected

--- a/test/test_shapes.jl
+++ b/test/test_shapes.jl
@@ -984,4 +984,17 @@ end
         rad = circular_arc(convert(Float64, 90.0°), 5.0μm, 1.0nm)
         @test deg == rad
     end
+
+    @testset "Negative radius semantics" begin
+        # Offset with negative radius is flipped; turn with negative radius is just turn in other direction
+        # Make sure resolution accounts for the difference
+        # In practice shouldn't come up since `pathtopolys` clips off negative-radius part;
+        # user has to explicity create and style OffsetSegment (DL internals)
+        t = Paths.Turn(90.0°, 5.0μm)
+        off = Paths.ConstantOffset(t, 8.0μm)
+        # Runs without error, endpoints consistent, rtol triggers correctly
+        poly = to_polygons(pathtopolys(Paths.Node(off, Paths.Trace(0.1μm))))
+        poly_rtol = to_polygons(pathtopolys(Paths.Node(off, Paths.Trace(0.1μm))), rtol=0.1)
+        @test length(points(poly)) > length(points(poly_rtol))
+    end
 end

--- a/test/test_shapes.jl
+++ b/test/test_shapes.jl
@@ -939,3 +939,49 @@ end
     @test all(c -> isapprox(c.r, 0.5), r_rel.curves)
     @test points(r_default) != points(r_rel)
 end
+
+@testitem "Constant-curvature discretization endpoints (#250)" setup = [CommonTestSetup] begin
+    import DeviceLayout: discretize_curve
+
+    # Offset turns with |offset| > r resolve to a flipped (negative-radius) arc;
+    # endpoints must come from the original offset segment, not the resolved turn's
+    # call operator (regression: the end point was off by exactly 2|r′|).
+    t_ccw = Paths.Turn(90.0°, 5.0μm; p0=Point(0.0μm, 0.0μm), α0=0.0°)
+    t_cw = Paths.Turn(-90.0°, 5.0μm; p0=Point(0.0μm, 0.0μm), α0=0.0°)
+    t_big = Paths.Turn(90.0°, 10.0μm; p0=Point(0.0μm, 0.0μm), α0=0.0°)
+
+    @testset "Endpoint exactness for |offset| > r (all quadrants)" begin
+        for seg in (
+            Paths.ConstantOffset(t_ccw, 8.0μm),   # resolved r′ = −3 μm (inner, flipped)
+            Paths.ConstantOffset(t_cw, -8.0μm),   # mirror
+            Paths.ConstantOffset(t_ccw, -8.0μm),  # outer side, r′ = +13 μm
+            Paths.ConstantOffset(t_cw, 8.0μm),
+            Paths.ConstantOffset(t_big, 15.0μm)
+        )
+            ps = discretize_curve(seg, 1.0nm)
+            @test ps[1] == Paths.p0(seg)
+            @test ps[end] == Paths.p1(seg)
+        end
+        ps = discretize_curve(Paths.ConstantOffset(t_ccw, 8.0μm), 1.0nm)
+        @test isapprox(ps[end], Point(-3.0μm, 5.0μm); atol=1.0nm)
+    end
+
+    @testset "Degenerate turns produce two finite points" begin
+        for seg in (
+            Paths.Turn(0.0°, 5.0μm; p0=Point(0.0μm, 0.0μm), α0=0.0°),
+            Paths.Turn(90.0°, 0.0μm; p0=Point(0.0μm, 0.0μm), α0=0.0°),
+            Paths.ConstantOffset(t_ccw, 5.0μm),   # offset == r → zero effective radius
+            Paths.ConstantOffset(t_cw, -5.0μm)
+        )
+            ps = discretize_curve(seg, 1.0nm)
+            @test length(ps) == 2
+            @test all(p -> isfinite(getx(p)) && isfinite(gety(p)), ps)
+        end
+    end
+
+    @testset "Degree-Quantity θ matches Float64 radians in circular_arc" begin
+        deg = circular_arc(90.0°, 5.0μm, 1.0nm)
+        rad = circular_arc(convert(Float64, 90.0°), 5.0μm, 1.0nm)
+        @test deg == rad
+    end
+end

--- a/test/test_shapes.jl
+++ b/test/test_shapes.jl
@@ -997,4 +997,19 @@ end
         poly_rtol = to_polygons(pathtopolys(Paths.Node(off, Paths.Trace(0.1μm))), rtol=0.1)
         @test length(points(poly)) > length(points(poly_rtol))
     end
+
+    @testset "Negative-radius Turn matches Turn(t)" begin
+        # Turn(α, -r) is the same curve as Turn(-α, r); the fast path must not
+        # mirror the arc (regression: interior samples up to ~2|r| off-curve).
+        for (α, r) in ((90.0°, -5.0μm), (-90.0°, -5.0μm), (270.0°, -5.0μm))
+            t = Paths.Turn(α, r; p0=Point(0.0μm, 0.0μm), α0=10.0°)
+            ps = discretize_curve(t, 1.0nm)
+            L = pathlength(t)
+            truth = t.(range(zero(L), L, length=length(ps)))
+            @test maximum(norm.(ps .- truth)) < 1.0nm
+            @test ps[1] == Paths.p0(t)
+            @test ps[end] == Paths.p1(t)
+            @test ps == discretize_curve(Paths.Turn(-α, -r; p0=t.p0, α0=t.α0), 1.0nm)
+        end
+    end
 end

--- a/test/test_shapes.jl
+++ b/test/test_shapes.jl
@@ -474,6 +474,13 @@ end
     coarse = to_polygons(cp; atol=2.0nm)
     fine = to_polygons(cp; atol=0.1nm)
     @test length(points(coarse)) < length(points(fine))
+
+    # Rounding through CurvilinearPolygon doesn't over-refine tight corners
+    @test length(
+        to_polygons(
+            Curvilinear.round_to_curvilinearpolygon(Rectangle(1.0μm, 1.0μm), 0.1μm)
+        ).p
+    ) < 60
 end
 
 @testitem "CurvilinearRegion holes (#241)" setup = [CommonTestSetup] begin


### PR DESCRIPTION
Address part of the over-refinement problem mentioned in #247 -- now we get the same number of points as through `circular_arc` when we are discretizing circular arcs. This seems to be about 3x faster than marching. DemoQPU17 gets a fingerprint update, but all changes are <1nm slivers.

Also fix some duplication in BSpline discretization (another item in the same issue), including removing a redundant calculation of the curvature which saves about 30% of render time. I looked at using `Paths._curvature!` with pre-allocated G, H for B-spline curvature calls but benchmarks were ambiguous.