### PR TITLE
Address cleanup issues for #247

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format of this changelog is based on
 ## Unreleased
 
   - `ExamplePDK.ChipTemplates.example_launcher` now styles its simulated-only `PORT` rectangle with `WithDirection`, and the `DemoQPU17` solidmodel example extracts port and junction directions with `ExamplePDK.port_directions` instead of computing them by hand (removing the `lumped_direction` keyword from its config-building functions)
+  - All dimensionless relative rounding is now absolute-by-default: applying
+    `Rounded(::Real)` to a dimensionless polygon or `CurvilinearPolygon` treats the
+    radius as an absolute length (pass `relative=true` to
+    `round_to_curvilinearpolygon` for length-relative fillets). This behavior shipped
+    with the render unification and is now pinned by a regression test.
   - Corner-membership checks in `round_to_curvilinearpolygon` use `Set`/`Dict`
     lookups again, restoring O(n) rounding for polygons with many corners.
   - Converting a path segment/style combination that has no polygon conversion now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format of this changelog is based on
 ## Unreleased
 
   - `ExamplePDK.ChipTemplates.example_launcher` now styles its simulated-only `PORT` rectangle with `WithDirection`, and the `DemoQPU17` solidmodel example extracts port and junction directions with `ExamplePDK.port_directions` instead of computing them by hand (removing the `lumped_direction` keyword from its config-building functions)
+  - Corner-membership checks in `round_to_curvilinearpolygon` use `Set`/`Dict`
+    lookups again, restoring O(n) rounding for polygons with many corners.
   - Converting a path segment/style combination that has no polygon conversion now
     throws a clear `ArgumentError` instead of warning and then failing with a
     `MethodError`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format of this changelog is based on
 ## Unreleased
 
   - `ExamplePDK.ChipTemplates.example_launcher` now styles its simulated-only `PORT` rectangle with `WithDirection`, and the `DemoQPU17` solidmodel example extracts port and junction directions with `ExamplePDK.port_directions` instead of computing them by hand (removing the `lumped_direction` keyword from its config-building functions)
+  - Converting a path segment/style combination that has no polygon conversion now
+    throws a clear `ArgumentError` instead of warning and then failing with a
+    `MethodError`.
   - Rendering an offset segment with a `CompoundStyle` now throws an `ArgumentError`:
     the style grid is in the original segment's arclength frame, which offset
     resolution does not preserve, so the result would place style transitions in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format of this changelog is based on
 ## Unreleased
 
   - `ExamplePDK.ChipTemplates.example_launcher` now styles its simulated-only `PORT` rectangle with `WithDirection`, and the `DemoQPU17` solidmodel example extracts port and junction directions with `ExamplePDK.port_directions` instead of computing them by hand (removing the `lumped_direction` keyword from its config-building functions)
+  - Rendering an offset segment with a `CompoundStyle` now throws an `ArgumentError`:
+    the style grid is in the original segment's arclength frame, which offset
+    resolution does not preserve, so the result would place style transitions in the
+    wrong locations.
   - Added `WithDirection <: GeometryEntityStyle` to annotate geometry entities with a direction (CCW from +x in local frame). The direction transforms with the entity under rotations and reflections, allowing extraction of the final global direction for use in simulation configuration.
   - Added `SolidModels.check_port_connectivity`, using `SolidModels.connected_components` to report ports as `:open`, `:short`, `:floating`, or `:missing`
   - Added `detect_non_boundary_contacts=false` keyword argument to `SolidModels.connected_components`; when `true`, 1d edges embedded in the interior of 2D surfaces (like the feet of staple air bridges) will be treated as connecting

--- a/src/curvilinear.jl
+++ b/src/curvilinear.jl
@@ -1077,9 +1077,19 @@ function round_to_curvilinearpolygon(
         line_arc_cornerindices(pol)
     end
 
+    # Per-vertex membership checks below run once per polygon point; Vector `in` and
+    # `findfirst` made the loop O(n²) in the corner count. Set/Dict restore O(n).
+    # The reverse iteration keeps findfirst's first-match semantics for the curve lookup.
+    la_set = Set(la_indices)
+    corner_set = Set(corner_indices)
+    curve_index_at_vertex = Dict{Int, Int}()
+    for (k, v) in Iterators.reverse(collect(pairs(pol.curve_start_idx)))
+        curve_index_at_vertex[v] = k
+    end
+
     for i in eachindex(poly)
         edge = edge_type_at_vertex(pol, i)
-        is_line_arc = i in la_indices
+        is_line_arc = i in la_set
 
         if is_line_arc
             # A line-arc corner has a straight edge on one side and an arc on the other.
@@ -1111,7 +1121,7 @@ function round_to_curvilinearpolygon(
                 # the arc is trimmed depends on orientation: a line→arc corner (outgoing)
                 # cuts the arc's START, an arc→line corner cuts its END.
                 arc_start_vtx = arc_is_outgoing ? i : mod1(i - 1, len)
-                curve_k = findfirst(isequal(arc_start_vtx), pol.curve_start_idx)
+                curve_k = get(curve_index_at_vertex, arc_start_vtx, nothing)
                 if !isnothing(curve_k)
                     if arc_is_outgoing
                         trim_start_pts[curve_k] = result.T_arc
@@ -1122,7 +1132,7 @@ function round_to_curvilinearpolygon(
             else
                 push!(new_points, poly[i])
             end
-        elseif !(i in corner_indices)
+        elseif !(i in corner_set)
             push!(new_points, poly[i])
         else
             p0 = poly[mod1(i - 1, len)]

--- a/src/curvilinear.jl
+++ b/src/curvilinear.jl
@@ -322,8 +322,7 @@ rather than as part of the SchematicGraph.
 """
 function pathtopolys(f::Paths.Segment{T}, s::Paths.Style; kwargs...) where {T}
     # All supported segment/style combinations have specific methods; landing here means
-    # nothing can render this pair (the old fallback warned and then called a since-removed
-    # three-argument to_polygons method, producing a confusing MethodError).
+    # nothing can render this pair
     throw(ArgumentError("no method converting path segment $f with style $s to polygons"))
 end
 pathtopolys(f::Paths.Corner{T}, s::Paths.SimpleTraceCorner; kwargs...) where {T} =
@@ -1066,13 +1065,11 @@ function round_to_curvilinearpolygon(
         line_arc_cornerindices(pol)
     end
 
-    # Per-vertex membership checks below run once per polygon point; Vector `in` and
-    # `findfirst` made the loop O(n²) in the corner count. Set/Dict restore O(n).
-    # The reverse iteration keeps findfirst's first-match semantics for the curve lookup.
+    # Per-vertex membership checks below run once per polygon point; use Set/Dict to keep this O(n).
     la_set = Set(la_indices)
     corner_set = Set(corner_indices)
     curve_index_at_vertex = Dict{Int, Int}()
-    for (k, v) in Iterators.reverse(collect(pairs(pol.curve_start_idx)))
+    for (k, v) in pairs(pol.curve_start_idx)
         curve_index_at_vertex[v] = k
     end
 

--- a/src/curvilinear.jl
+++ b/src/curvilinear.jl
@@ -347,6 +347,15 @@ pathtopolys(f::Paths.OffsetSegment{T}, s::Paths.Style; kwargs...) where {T} =
     _pathtopolys_resolved_offset(f, s; kwargs...)
 pathtopolys(f::Paths.OffsetSegment{T}, s::Paths.PeriodicStyle; kwargs...) where {T} =
     _pathtopolys_resolved_offset(f, s; kwargs...)
+# CompoundStyle grids are expressed in the original segment's arclength frame, which
+# offset resolution does not preserve — style transitions would land in the wrong
+# places. Fail loudly rather than render subtly wrong geometry.
+pathtopolys(f::Paths.OffsetSegment{T}, s::Paths.CompoundStyle; kwargs...) where {T} = throw(
+    ArgumentError(
+        "cannot render offset segment $f with a CompoundStyle: the style grid is in " *
+        "the original segment's arclength frame, which offset resolution does not preserve"
+    )
+)
 pathtopolys(::Paths.OffsetSegment{T}, ::Paths.NoRenderContinuous; kwargs...) where {T} =
     Polygon{T}[]
 pathtopolys(::Paths.OffsetSegment{T}, ::Paths.NoRenderDiscrete; kwargs...) where {T} =

--- a/src/curvilinear.jl
+++ b/src/curvilinear.jl
@@ -365,14 +365,19 @@ pathtopolys(::Paths.OffsetSegment{T}, ::Paths.NoRenderDiscrete; kwargs...) where
 pathtopolys(::Paths.OffsetSegment{T}, ::Paths.SimpleNoRender; kwargs...) where {T} =
     Polygon{T}[]
 pathtopolys(::Paths.OffsetSegment{T}, ::Paths.NoRender; kwargs...) where {T} = Polygon{T}[]
-function pathtopolys(
+# DecoratedStyles: strip the decoration and delegate to the underlying style.
+# Attachments are handled by render!(Cell, Path), not here. (The per-wrapper methods
+# below exist for dispatch specificity; they share this body.)
+function _pathtopolys_ignoring_attachments(seg, sty; kwargs...)
+    @warn "Ignoring attachments on path segment $seg with style $sty when converting to polygons. Did you write `render!.(cell, path, ...)` instead of `render!(cell, path, ...)`?"
+    return pathtopolys(seg, Paths.undecorated(sty); kwargs...)
+end
+
+pathtopolys(
     f::Paths.OffsetSegment{T},
     sty::Paths.AbstractDecoratedStyle;
     kwargs...
-) where {T}
-    @warn "Ignoring attachments on path segment $f with style $sty when converting to polygons. Did you write `render!.(cell, path, ...)` instead of `render!(cell, path, ...)`?"
-    return pathtopolys(f, Paths.undecorated(sty); kwargs...)
-end
+) where {T} = _pathtopolys_ignoring_attachments(f, sty; kwargs...)
 
 # NoRender and friends — effectively the same as above but without the warning
 pathtopolys(seg::Paths.Segment{T}, s::Paths.NoRenderContinuous; kwargs...) where {T} =
@@ -390,19 +395,10 @@ function pathtopolys(p::Paths.Path{T}; kwargs...) where {T}
     return reduce(vcat, vcat.(pathtopolys.(nodes; kwargs...)))
 end
 
-function pathtopolys(seg::Paths.Segment{T}, sty::Paths.PeriodicStyle; kwargs...) where {T}
-    subsegs, substys = Paths.resolve_periodic(seg, sty)
-    return reduce(
-        vcat,
-        (
-            vcat(pathtopolys(Paths.Node(se, st); kwargs...)) for
-            (se, st) in zip(subsegs, substys)
-        ),
-        init=GeometryEntity{T}[]
-    )
-end
-function pathtopolys(
-    seg::Paths.CompoundSegment{T},
+# The two PeriodicStyle methods below exist for dispatch specificity (CompoundSegment
+# has its own generic-Style method); they share this body.
+function _pathtopolys_periodic(
+    seg::Paths.Segment{T},
     sty::Paths.PeriodicStyle;
     kwargs...
 ) where {T}
@@ -416,6 +412,10 @@ function pathtopolys(
         init=GeometryEntity{T}[]
     )
 end
+pathtopolys(seg::Paths.Segment{T}, sty::Paths.PeriodicStyle; kwargs...) where {T} =
+    _pathtopolys_periodic(seg, sty; kwargs...)
+pathtopolys(seg::Paths.CompoundSegment{T}, sty::Paths.PeriodicStyle; kwargs...) where {T} =
+    _pathtopolys_periodic(seg, sty; kwargs...)
 
 function _compound_segment_slice(f::Paths.Segment{T}, start, stop) where {T}
     len = pathlength(f)
@@ -488,14 +488,11 @@ end
 pathtopolys(f::Paths.CompoundSegment{T}, s::Paths.Style; kwargs...) where {T} =
     _compound_pin_render(f, s, (se, sty) -> pathtopolys(se, sty; kwargs...))
 # Wrapper segments route here; concrete-style methods only accept BaseContinuousSegment.
-function pathtopolys(
+pathtopolys(
     f::Paths.CompoundSegment{T},
     sty::Paths.AbstractDecoratedStyle;
     kwargs...
-) where {T}
-    @warn "Ignoring attachments on path segment $f with style $sty when converting to polygons. Did you write `render!.(cell, path, ...)` instead of `render!(cell, path, ...)`?"
-    return pathtopolys(f, Paths.undecorated(sty); kwargs...)
-end
+) where {T} = _pathtopolys_ignoring_attachments(f, sty; kwargs...)
 pathtopolys(::Paths.CompoundSegment{T}, ::Paths.NoRender; kwargs...) where {T} =
     Polygon{T}[]
 pathtopolys(::Paths.CompoundSegment{T}, ::Paths.NoRenderContinuous; kwargs...) where {T} =
@@ -823,16 +820,8 @@ to_polygons(
     kwargs...
 ) where {T} = to_polygons(Paths.resolve_offset(seg), sty; kwargs...)
 
-# DecoratedStyles: strip the decoration and delegate to the underlying style.
-# Attachments are handled by render!(Cell, Path), not here.
-function pathtopolys(
-    seg::Paths.Segment{T},
-    sty::Paths.AbstractDecoratedStyle;
-    kwargs...
-) where {T}
-    @warn "Ignoring attachments on path segment $seg with style $sty when converting to polygons. Did you write `render!.(cell, path, ...)` instead of `render!(cell, path, ...)`?"
-    return pathtopolys(seg, Paths.undecorated(sty); kwargs...)
-end
+pathtopolys(seg::Paths.Segment{T}, sty::Paths.AbstractDecoratedStyle; kwargs...) where {T} =
+    _pathtopolys_ignoring_attachments(seg, sty; kwargs...)
 
 # Segment-level calls bypass the Node linearity gate, so straight linear cases need explicit
 # polygon-producing methods. Dispatch on Paths.Straight keeps these methods below the wrapper

--- a/src/curvilinear.jl
+++ b/src/curvilinear.jl
@@ -321,8 +321,10 @@ This is particularly helpful if a Path is being used within the construction of 
 rather than as part of the SchematicGraph.
 """
 function pathtopolys(f::Paths.Segment{T}, s::Paths.Style; kwargs...) where {T}
-    @warn "Discretizing path segment ($f, $s) for CurvilinearRegion construction"
-    return to_polygons(f, pathlength(f), s; kwargs...)
+    # All supported segment/style combinations have specific methods; landing here means
+    # nothing can render this pair (the old fallback warned and then called a since-removed
+    # three-argument to_polygons method, producing a confusing MethodError).
+    throw(ArgumentError("no method converting path segment $f with style $s to polygons"))
 end
 pathtopolys(f::Paths.Corner{T}, s::Paths.SimpleTraceCorner; kwargs...) where {T} =
     to_polygons(f, s; kwargs...)

--- a/test/test_render.jl
+++ b/test/test_render.jl
@@ -1254,3 +1254,17 @@ end
     @test res_poly ≈ res_rect + Point(5mm, 0mm)
     @test isempty(to_polygons(xor2d(res_clipped_poly, [res_rect, res_poly])))
 end
+
+@testitem "Unrenderable segment/style combinations fail loudly (#247)" setup =
+    [CommonTestSetup] begin
+    # Offset segment + CompoundStyle: the style grid is in the original segment's
+    # arclength frame, which offset resolution does not preserve
+    seg = Paths.Straight(20.0μm, p0=Point(0.0μm, 0.0μm), α0=0°)
+    off = Paths.offset(seg, 1.0μm)
+    csty = Paths.CompoundStyle(
+        Paths.Style[Paths.Trace(1.0μm), Paths.Trace(2.0μm)],
+        [0.0μm, 10.0μm, 20.0μm],
+        gensym()
+    )
+    @test_throws ArgumentError pathtopolys(off, csty)
+end

--- a/test/test_render.jl
+++ b/test/test_render.jl
@@ -1267,4 +1267,10 @@ end
         gensym()
     )
     @test_throws ArgumentError pathtopolys(off, csty)
+
+    # A segment/style pair with no conversion method errors clearly instead of
+    # warning and then throwing a MethodError (the old fallback called a removed
+    # three-argument to_polygons)
+    corner_seg = Paths.Corner{typeof(1.0μm)}(90°)
+    @test_throws ArgumentError pathtopolys(corner_seg, Paths.Trace(1.0μm))
 end

--- a/test/test_shapes.jl
+++ b/test/test_shapes.jl
@@ -915,3 +915,20 @@ end
         end
     end
 end
+
+@testitem "Dimensionless rounding is absolute-by-default (#247)" setup = [CommonTestSetup] begin
+    # Behavior shipped with the render unification: Rounded(::Real) on dimensionless
+    # geometry uses the radius as an absolute length. This pins it so a silent return
+    # to the length-relative interpretation fails.
+    cp = CurvilinearPolygon(Point.([0.0, 10.0, 10.0, 0.0], [0.0, 0.0, 10.0, 10.0]))
+    r_default = Curvilinear.round_to_curvilinearpolygon(cp, 0.05)
+    r_abs = Curvilinear.round_to_curvilinearpolygon(cp, 0.05; relative=false)
+    r_rel = Curvilinear.round_to_curvilinearpolygon(cp, 0.05; relative=true)
+
+    @test points(r_default) == points(r_abs)
+    # Absolute: every fillet arc has radius 0.05. The relative interpretation would
+    # give 0.05 * min(side) = 0.5.
+    @test all(c -> isapprox(c.r, 0.05), r_default.curves)
+    @test all(c -> isapprox(c.r, 0.5), r_rel.curves)
+    @test points(r_default) != points(r_rel)
+end


### PR DESCRIPTION
This addresses the mechanical cleanup items in #247:

- Offset segment on CompoundStyle is a hard error
- Unrenderable segment fallback shows a clear error
- Use Set/Dict for corner index lookups in `round_to_curvilinearpolygon`
- Deduplicate some pathtopolys code
- Test for default absolute rounding for dimensionless geometry