### PR TITLE
Fix rendering of full 360°-multiple turns (issue #252)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ The format of this changelog is based on
     angular step instead of marching with the general curvature-controlled kernel,
     making turn discretization faster and avoiding over-refinement in some cases. Rendered point counts and positions change slightly for every `Turn` within the same `atol`/`rtol` tolerances. Degenerate turns (zero sweep, zero radius, `|offset| == r`) now discretize to exactly two points, and
     offset turns with `|offset| > r` keep exact endpoints.
+  - Fixed turns sweeping a full multiple of 360° rendering as degenerate polygons in GDS
+    and as silent zero-area surfaces in SolidModel (issue #252): full turns are now split
+    into two half turns during path polygonization, so a 360° turn renders as two
+    half-annulus polygons per surface. In curve-recovery/provenance terms this means a
+    full turn is represented by two 180° curves rather than one 360° curve. Closed
+    segments reaching the degenerate corner-point checks now throw an `ArgumentError`
+    instead of silently dropping a curve.
   - Added `WithDirection <: GeometryEntityStyle` to annotate geometry entities with a direction (CCW from +x in local frame). The direction transforms with the entity under rotations and reflections, allowing extraction of the final global direction for use in simulation configuration.
   - Added `SolidModels.check_port_connectivity`, using `SolidModels.connected_components` to report ports as `:open`, `:short`, `:floating`, or `:missing`
   - Added `detect_non_boundary_contacts=false` keyword argument to `SolidModels.connected_components`; when `true`, 1d edges embedded in the interior of 2D surfaces (like the feet of staple air bridges) will be treated as connecting

--- a/docs/src/concepts/polygons.md
+++ b/docs/src/concepts/polygons.md
@@ -125,6 +125,30 @@ This works for both the Cell and SolidModel rendering paths. The inner `Rounded`
 a `CurvilinearPolygon` with exact fillet arcs, and the outer `Rounded` applies line-arc
 rounding at the transitions.
 
+#### Circles and rings
+
+`RelativeRounded(0.5)` on a square places all four fillet arc centers at the square's
+center, so the result is an exact circle built from four 90° arcs:
+
+```julia
+mycircle(r) = RelativeRounded(0.5)(centered(Rectangle(2r, 2r)))
+```
+
+An idiomatic ring (annulus) is then the same rounding applied to the difference of
+two such squares, which is exact for both the Cell and SolidModel rendering paths:
+
+```julia
+myring(r_outer, r_inner) = RelativeRounded(0.5)(
+    difference2d(
+        centered(Rectangle(2r_outer, 2r_outer)),
+        centered(Rectangle(2r_inner, 2r_inner))
+    )
+)
+```
+
+(A ring can also be drawn as a `Path` with a full 360° turn, which renders as two
+half-annulus polygons.)
+
 #### Selecting line-arc corners
 
 [`Curvilinear.line_arc_cornerindices`](@ref) identifies vertices where a straight edge meets a curve.

--- a/src/curvilinear.jl
+++ b/src/curvilinear.jl
@@ -606,24 +606,16 @@ const BaseContinuousSegment{T} = Union{Paths.Straight{T}, Paths.Turn{T}, Paths.B
 pathtopolys(f::BaseContinuousSegment{T}, s::Paths.CompoundStyle; kwargs...) where {T} =
     _compound_style_grid_render(f, s; kwargs...)
 
-# A Turn sweeping a full multiple of 360° has coincident endpoints, which the
-# degenerate-point checks and the CurvilinearPolygon constructor's duplicate-point
-# elimination would otherwise silently collapse to empty geometry (issue #252).
-# Detection uses endpoint coincidence (robust to floating-point angle storage) at the
-# constructor's deduplication tolerance; the sweep threshold keeps the recursion in
-# `_split_full_turn` finite (halves of a split full turn sweep at most 180° and small
-# radii cannot re-fire the check).
+# A Turn sweeping a full multiple of 360° has coincident endpoints, which CurvilinearPolygon
+# and the `pathtopolys` degenerate-point clipping logic would not handle correctly (issue #252)
 _is_full_turn(seg::Paths.Segment) = false
 function _is_full_turn(seg::Paths.Turn{T}) where {T}
+    # Check endpoint coincidence with same tolerance as CurvilinearPolygon constructor deduplication
     return abs(seg.α) > 270° &&
            isapprox(Paths.p0(seg), Paths.p1(seg); atol=1e-3 * DeviceLayout.onenanometer(T))
 end
 
-# Full turns render as two half-turn polygons (per surface). A single polygon whose
-# boundary is a closed loop is not representable (constructor dedup), and the
-# zero-width-slit "keyhole" alternative is rejected by the OpenCASCADE kernel
-# ("Curve loop is not closed") even though GDS accepts it — so the split must
-# produce separate polygons.
+# Full turns split into two nodes (avoid closed-loop segments and OCC-unfriendly keyhole geometry)
 function _split_full_turn(seg::Paths.Turn{T}, sty::Paths.Style; kwargs...) where {T}
     seg1, seg2, sty1, sty2 = split(seg, sty, pathlength(seg) / 2)
     return vcat(
@@ -632,9 +624,7 @@ function _split_full_turn(seg::Paths.Turn{T}, sty::Paths.Style; kwargs...) where
     )
 end
 
-# Closed segments other than full turns (e.g. a closed BSpline) cannot be represented
-# as a single curvilinear polygon either; fail loudly instead of letting the
-# constructor silently delete the coincident endpoints and their curves.
+# Closed segments other than full turns (e.g. a closed BSpline) are not split but fail loudly
 function _assert_open_segment(seg::Paths.Segment{T}) where {T}
     if isapprox(Paths.p0(seg), Paths.p1(seg); atol=1e-3 * DeviceLayout.onenanometer(T))
         throw(
@@ -657,8 +647,7 @@ function pathtopolys(
     pts = corner_points(seg, sty, true)
     # Check if the points are degenerate (inner edge clipped to the curve origin when
     # radius ≤ extent). Coincident segment endpoints also make these checks fire — for
-    # the wrong reason — so closed segments fail loudly here instead of silently losing
-    # a curve (issue #252; full turns are split above and never reach this point).
+    # the wrong reason — so closed segments that are not split above fail loudly.
     if isapprox(pts[1], pts[2])
         _assert_open_segment(seg)
         return CurvilinearPolygon(pts[2:end], [Paths.offset(seg, Paths.extent(sty))], [-2])
@@ -704,7 +693,7 @@ function pathtopolys(
     _is_full_turn(seg) && return _split_full_turn(seg, sty; kwargs...)
     pts = corner_points(seg, sty, true)
     # As for SimpleTrace above: the degenerate-point checks below are for the
-    # radius ≤ extent clip, not for closed segments (issue #252).
+    # radius ≤ extent clip, not for closed segments.
     (isapprox(pts[1], pts[2]) || isapprox(pts[7], pts[8])) && _assert_open_segment(seg)
     return [
         isapprox(pts[1], pts[2]) ?

--- a/src/curvilinear.jl
+++ b/src/curvilinear.jl
@@ -606,6 +606,46 @@ const BaseContinuousSegment{T} = Union{Paths.Straight{T}, Paths.Turn{T}, Paths.B
 pathtopolys(f::BaseContinuousSegment{T}, s::Paths.CompoundStyle; kwargs...) where {T} =
     _compound_style_grid_render(f, s; kwargs...)
 
+# A Turn sweeping a full multiple of 360° has coincident endpoints, which the
+# degenerate-point checks and the CurvilinearPolygon constructor's duplicate-point
+# elimination would otherwise silently collapse to empty geometry (issue #252).
+# Detection uses endpoint coincidence (robust to floating-point angle storage) at the
+# constructor's deduplication tolerance; the sweep threshold keeps the recursion in
+# `_split_full_turn` finite (halves of a split full turn sweep at most 180° and small
+# radii cannot re-fire the check).
+_is_full_turn(seg::Paths.Segment) = false
+function _is_full_turn(seg::Paths.Turn{T}) where {T}
+    return abs(seg.α) > 270° &&
+           isapprox(Paths.p0(seg), Paths.p1(seg); atol=1e-3 * DeviceLayout.onenanometer(T))
+end
+
+# Full turns render as two half-turn polygons (per surface). A single polygon whose
+# boundary is a closed loop is not representable (constructor dedup), and the
+# zero-width-slit "keyhole" alternative is rejected by the OpenCASCADE kernel
+# ("Curve loop is not closed") even though GDS accepts it — so the split must
+# produce separate polygons.
+function _split_full_turn(seg::Paths.Turn{T}, sty::Paths.Style; kwargs...) where {T}
+    seg1, seg2, sty1, sty2 = split(seg, sty, pathlength(seg) / 2)
+    return vcat(
+        vcat(pathtopolys(Paths.Node(seg1, sty1); kwargs...)),
+        vcat(pathtopolys(Paths.Node(seg2, sty2); kwargs...))
+    )
+end
+
+# Closed segments other than full turns (e.g. a closed BSpline) cannot be represented
+# as a single curvilinear polygon either; fail loudly instead of letting the
+# constructor silently delete the coincident endpoints and their curves.
+function _assert_open_segment(seg::Paths.Segment{T}) where {T}
+    if isapprox(Paths.p0(seg), Paths.p1(seg); atol=1e-3 * DeviceLayout.onenanometer(T))
+        throw(
+            ArgumentError(
+                "cannot represent closed segment $seg as a single curvilinear polygon; " *
+                "split it (e.g. with `Paths.split`) so each piece has distinct endpoints"
+            )
+        )
+    end
+end
+
 # Traces generate one surface
 # SimpleTrace can use constant offset
 function pathtopolys(
@@ -613,11 +653,17 @@ function pathtopolys(
     sty::Paths.SimpleTrace;
     kwargs...
 ) where {T}
+    _is_full_turn(seg) && return _split_full_turn(seg, sty; kwargs...)
     pts = corner_points(seg, sty, true)
-    # Check if the points are degenerate
+    # Check if the points are degenerate (inner edge clipped to the curve origin when
+    # radius ≤ extent). Coincident segment endpoints also make these checks fire — for
+    # the wrong reason — so closed segments fail loudly here instead of silently losing
+    # a curve (issue #252; full turns are split above and never reach this point).
     if isapprox(pts[1], pts[2])
+        _assert_open_segment(seg)
         return CurvilinearPolygon(pts[2:end], [Paths.offset(seg, Paths.extent(sty))], [-2])
     elseif isapprox(pts[3], pts[4])
+        _assert_open_segment(seg)
         return CurvilinearPolygon(pts[1:3], [Paths.offset(seg, -Paths.extent(sty))], [1])
     end
     return CurvilinearPolygon(
@@ -637,6 +683,7 @@ function pathtopolys(seg::Paths.BSpline{T}, sty::Paths.SimpleTrace; kwargs...) w
 end
 
 function pathtopolys(seg::BaseContinuousSegment{T}, sty::Paths.Trace; kwargs...) where {T}
+    _is_full_turn(seg) && return _split_full_turn(seg, sty; kwargs...)
     pts = corner_points(seg, sty, false)
     return CurvilinearPolygon(
         pts,
@@ -654,7 +701,11 @@ function pathtopolys(
     sty::Paths.SimpleCPW;
     kwargs...
 ) where {T}
+    _is_full_turn(seg) && return _split_full_turn(seg, sty; kwargs...)
     pts = corner_points(seg, sty, true)
+    # As for SimpleTrace above: the degenerate-point checks below are for the
+    # radius ≤ extent clip, not for closed segments (issue #252).
+    (isapprox(pts[1], pts[2]) || isapprox(pts[7], pts[8])) && _assert_open_segment(seg)
     return [
         isapprox(pts[1], pts[2]) ?
         CurvilinearPolygon(pts[2:4], [Paths.offset(seg, -Paths.trace(sty) / 2)], [-2]) :
@@ -696,6 +747,7 @@ function pathtopolys(seg::Paths.BSpline{T}, sty::Paths.SimpleCPW; kwargs...) whe
 end
 
 function pathtopolys(seg::BaseContinuousSegment{T}, sty::Paths.CPW; kwargs...) where {T}
+    _is_full_turn(seg) && return _split_full_turn(seg, sty; kwargs...)
     pts = corner_points(seg, sty, false)
     return [
         CurvilinearPolygon(
@@ -720,6 +772,7 @@ end
 # Strands generate 2*num polygons (plus and minus side for each strand).
 # Each strand is a trace-like shape at a computed offset from center.
 function pathtopolys(seg::BaseContinuousSegment{T}, sty::Paths.Strands; kwargs...) where {T}
+    _is_full_turn(seg) && return _split_full_turn(seg, sty; kwargs...)
     polys = Union{CurvilinearPolygon{T}, Polygon{T}}[]
     for i = 0:(Paths.num(sty) - 1)
         # Offset to center of strand i, plus half-width for edges

--- a/test/test_render.jl
+++ b/test/test_render.jl
@@ -1274,3 +1274,98 @@ end
     corner_seg = Paths.Corner{typeof(1.0μm)}(90°)
     @test_throws ArgumentError pathtopolys(corner_seg, Paths.Trace(1.0μm))
 end
+
+@testitem "Full turns render non-degenerate (#252)" setup = [CommonTestSetup] begin
+    # Turns sweeping an exact multiple of 360° have coincident endpoints; they are
+    # split into two half turns at pathtopolys so neither the degenerate-point checks
+    # nor the CurvilinearPolygon constructor dedup can silently collapse them.
+    annulus_area(r, w) = 2π * r * w
+    function ring_polys(α, sty; r=100μm)
+        pa = Path(0μm, 0μm)
+        turn!(pa, α, r, sty)
+        return reduce(vcat, vcat.(to_polygons.(pathtopolys(pa))))
+    end
+    total_area(polys) = sum(Polygons.area.(polys))
+
+    @testset "Trace/CPW/Strands full turns" begin
+        polys = ring_polys(360°, Paths.Trace(10μm))
+        @test length(polys) == 2
+        @test all(pp -> length(points(pp)) >= 3, polys)
+        @test total_area(polys) ≈ annulus_area(100μm, 10μm) rtol = 1e-4
+
+        # Docs example direction (concepts/paths.md ring)
+        polys = ring_polys(-360°, Paths.CPW(10μm, 6μm))
+        @test length(polys) == 4
+        @test total_area(polys) ≈ 2 * annulus_area(100μm, 6μm) rtol = 1e-4
+
+        # SimpleTrace/SimpleCPW take the clipped corner-point branch
+        polys = ring_polys(360°, Paths.SimpleTrace(10μm))
+        @test total_area(polys) ≈ annulus_area(100μm, 10μm) rtol = 1e-4
+        polys = ring_polys(360°, Paths.SimpleCPW(10μm, 6μm))
+        @test total_area(polys) ≈ 2 * annulus_area(100μm, 6μm) rtol = 1e-4
+
+        # Strands: two strands, two sides, two halves
+        polys = ring_polys(360°, Paths.Strands(2μm, 2μm, 2μm, 2))
+        @test length(polys) == 8
+        @test all(pp -> length(points(pp)) >= 3, polys)
+    end
+
+    @testset "Exact multiples and radians input" begin
+        # 720° recurses into four half turns
+        polys = ring_polys(720°, Paths.Trace(10μm))
+        @test length(polys) == 4
+        @test total_area(polys) ≈ 2 * annulus_area(100μm, 10μm) rtol = 1e-4
+
+        # Radian (plain-number) input must be caught too: detection is by endpoint
+        # coincidence, not by exact angle arithmetic
+        polys = ring_polys(2π, Paths.Trace(10μm))
+        @test length(polys) == 2
+        @test total_area(polys) ≈ annulus_area(100μm, 10μm) rtol = 1e-4
+    end
+
+    @testset "Non-multiples unchanged" begin
+        # Over-full but non-multiple turns render as a single (self-overlapping) polygon
+        for α in (370°, 450°, 540°)
+            polys = ring_polys(α, Paths.Trace(10μm))
+            @test length(polys) == 1
+            @test length(points(only(polys))) > 3
+        end
+        polys = ring_polys(359.9°, Paths.Trace(10μm))
+        @test length(polys) == 1
+        @test total_area(polys) ≈ (359.9 / 360) * annulus_area(100μm, 10μm) rtol = 1e-4
+    end
+
+    @testset "Booleans and rendering see the ring" begin
+        pa = Path(0μm, 0μm)
+        turn!(pa, 360°, 100μm, Paths.Trace(10μm))
+        u = union2d(pathtopolys(pa))
+        upolys = to_polygons(u)
+        @test !isempty(upolys)
+        @test total_area(upolys) ≈ annulus_area(100μm, 10μm) rtol = 1e-4
+
+        c = Cell("ring", nm)
+        render!(c, pa, GDSMeta(0))
+        @test all(pp -> length(points(pp)) >= 3, elements(c))
+        @test total_area(elements(c)) ≈ annulus_area(100μm, 10μm) rtol = 1e-4
+    end
+
+    @testset "Pinched inner edge still uses the degenerate branch" begin
+        # radius ≤ extent: inner edge clips to the curve origin (pie slice), no error
+        cp = pathtopolys(
+            Paths.Turn(90°, 10.0μm; p0=Point(0.0μm, 0.0μm)),
+            Paths.SimpleTrace(30.0μm)
+        )
+        @test cp isa CurvilinearPolygon
+        @test length(points(cp)) == 3
+    end
+
+    @testset "Closed segments fail loudly" begin
+        # The degenerate-point branches are guarded against closed segments (coincident
+        # endpoints), which would otherwise silently lose the inner offset curve. Full
+        # turns never reach the guard (split above), so exercise the backstop directly.
+        closed = Paths.Turn(360°, 100.0μm; p0=Point(0.0μm, 0.0μm))
+        @test_throws ArgumentError DeviceLayout.Curvilinear._assert_open_segment(closed)
+        open_seg = Paths.Turn(90°, 100.0μm; p0=Point(0.0μm, 0.0μm))
+        @test DeviceLayout.Curvilinear._assert_open_segment(open_seg) === nothing
+    end
+end

--- a/test/test_solidmodel.jl
+++ b/test/test_solidmodel.jl
@@ -1685,3 +1685,23 @@
         @test "small2" ∈ names2
     end
 end
+
+@testitem "Full turns render in SolidModel (#252)" setup = [CommonTestSetup] begin
+    # A 360° turn previously reached OpenCASCADE as a collapsed 2-point polygon and
+    # produced a silent zero-area surface; it now renders as two half-annulus surfaces.
+    for (sty, nsurf, expected) in [
+        (Paths.Trace(10.0μm), 2, 2π * 100 * 10),
+        (Paths.CPW(10.0μm, 6.0μm), 4, 2 * 2π * 100 * 6)
+    ]
+        cs = CoordinateSystem("ring", nm)
+        pa = Path(Point(0.0μm, 0.0μm))
+        turn!(pa, 360°, 100.0μm, sty)
+        place!(cs, pa, SemanticMeta(:ring))
+        sm = SolidModel("ring"; overwrite=true)
+        render!(sm, cs, zmap=(_) -> 0.0μm)
+        tags = SolidModels.entitytags(sm["ring", 2])
+        area = sum(SolidModels.gmsh.model.occ.getMass(2, t) for t in tags; init=0.0)
+        @test length(tags) == nsurf
+        @test area ≈ expected rtol = 1e-6
+    end
+end


### PR DESCRIPTION
Close #252. Turns sweeping an exact multiple of 360° have coincident endpoints, which the pathtopolys degenerate-point checks and the CurvilinearPolygon constructor's duplicate-point elimination silently collapsed to empty geometry (degenerate 2-point polygons in GDS, zero-area surfaces in SolidModel). Full turns are now split into two half turns during path polygonization, rendering as two polygons per surface — exact in both backends. Closed segments reaching the degenerate corner-point checks now fail loudly with an ArgumentError instead of silently dropping a curve.

Also documents the difference2d + RelativeRounded(0.5) ring recipe.