### PR TITLE
Use WithDirection + port_directions in DemoQPU17 solidmodel example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format of this changelog is based on
 
 ## Unreleased
 
+  - `ExamplePDK.ChipTemplates.example_launcher` now styles its simulated-only `PORT` rectangle with `WithDirection`, and the `DemoQPU17` solidmodel example extracts port and junction directions with `ExamplePDK.port_directions` instead of computing them by hand (removing the `lumped_direction` keyword from its config-building functions)
   - Added `WithDirection <: GeometryEntityStyle` to annotate geometry entities with a direction (CCW from +x in local frame). The direction transforms with the entity under rotations and reflections, allowing extraction of the final global direction for use in simulation configuration.
   - Added `SolidModels.check_port_connectivity`, using `SolidModels.connected_components` to report ports as `:open`, `:short`, `:floating`, or `:missing`
   - Added `detect_non_boundary_contacts=false` keyword argument to `SolidModels.connected_components`; when `true`, 1d edges embedded in the interior of 2D surfaces (like the feet of staple air bridges) will be treated as connecting

--- a/examples/DemoQPU17/solidmodel.jl
+++ b/examples/DemoQPU17/solidmodel.jl
@@ -108,8 +108,11 @@ Modelled on `SingleTransmon.configfile`, adapted for the QPU17 physical-group la
     SingleTransmon values, split into two junctions for a SQUID —
     override per-junction by editing the returned dict if needed.
   - `port_R = 50`: termination impedance for 50 Ω ports.
-  - `lumped_direction = "+Y"`: lumped element orientation. (Lumped port directions are computed from the schematic.)
   - `mesh_file`: path to the `.msh2` written by `mesh_family`.
+
+Port and lumped-element `"Direction"`s are extracted from the `WithDirection`-styled
+entities placed by the components (launcher `PORT` squares, junction `LUMPED_ELEMENT`
+rectangles) using `ExamplePDK.port_directions`.
 """
 function driven_configfile(
     sm::SolidModel,
@@ -127,13 +130,12 @@ function driven_configfile(
     lumped_L=14.860e-9 * 2,
     lumped_C=5.5e-15 / 2,
     port_R=50,
-    lumped_direction="+Y",
     mesh_file=joinpath(@__DIR__, "qpu17.msh2")
 )
     attributes = SolidModels.attributes(sm)
     config = base_config(sm, schematic;
         mesh_file, amr, n_ports, n_lumped_elements,
-        lumped_L, lumped_C, port_R, lumped_direction)
+        lumped_L, lumped_C, port_R)
 
     # Build LumpedPort entries: driven 50Ω ports first (one excited), then LC junctions.
     lumped_ports = config["Boundaries"]["LumpedPort"]
@@ -164,9 +166,10 @@ end
     eigenmode_configfile(sm::SolidModel, schematic; kwargs...) -> Dict
 
 Assemble a Palace **eigenmode** configuration for the QPU17 model. Port and lumped-element
-directions are read from each component's placement in `schematic` (unlike [`configfile`](@ref),
-which uses a single fixed direction for the driven sweep), and `exterior_boundary` is treated
-as PEC here rather than absorbing.
+directions are extracted from the `WithDirection`-styled entities placed by the components
+and their placements in `schematic` (via `ExamplePDK.port_directions`, as in
+[`driven_configfile`](@ref)), and `exterior_boundary` is treated as PEC here rather than
+absorbing.
 
 # Keyword arguments
 
@@ -182,7 +185,6 @@ as PEC here rather than absorbing.
     SingleTransmon values, split into two junctions for a SQUID —
     override per-junction by editing the returned dict if needed.
   - `port_R = 50`: termination impedance for 50 Ω ports.
-  - `lumped_direction = "+Y"`: lumped element orientation. (Lumped port directions are computed from the schematic.)
 """
 function eigenmode_configfile(
     sm::SolidModel,
@@ -197,11 +199,10 @@ function eigenmode_configfile(
     lumped_L=14.860e-9 * 2,
     lumped_C=5.5e-15 / 2,
     port_R=50,
-    lumped_direction="+Y",
 )
     config = base_config(sm, schematic;
         mesh_file, amr, n_ports, n_lumped_elements,
-        lumped_L, lumped_C, port_R, lumped_direction)
+        lumped_L, lumped_C, port_R)
     config["Problem"]["Type"] = "Eigenmode"
 
     config["Solver"] = Dict(
@@ -227,23 +228,24 @@ function base_config(sm, schematic;
     lumped_L=14.860e-9 * 2,
     lumped_C=5.5e-15 / 2,
     port_R=50,
-    lumped_direction="+Y",
 )
     attributes = SolidModels.attributes(sm)
+    # Directions are extracted from `WithDirection`-styled entities (launcher PORT
+    # squares, junction LUMPED_ELEMENT rectangles) after transformation by each
+    # component's placement in the schematic. This requires the layers to have been
+    # indexed, which happens during `render!(sm, schematic, target)` because the
+    # target's `indexed_layers` include `:port` and `:lumped_element`.
+    port_dirs = ExamplePDK.port_directions(schematic, layer(PORT))
+    lumped_dirs = ExamplePDK.port_directions(schematic, layer(LUMPED_ELEMENT))
     lumped_ports = Dict[]
     for i = 1:n_ports
-        node = schematic.index_dict[:port][i]
-        dirs = Dict(0.0° => "+X", 90.0° => "+Y",
-            180.0° => "-X", 270.0° => "-Y")
-        dir = dirs[rem(
-            rotation(transformation(schematic, node)), 360°, RoundDown)]
         push!(
             lumped_ports,
             Dict(
                 "Index" => i,
                 "Attributes" => [attributes["port_$i"]],
                 "R" => port_R,
-                "Direction" => dir
+                "Direction" => port_dirs[i]
             )
         )
     end
@@ -255,7 +257,7 @@ function base_config(sm, schematic;
                 "Attributes" => [attributes["lumped_element_$j"]],
                 "L" => lumped_L + j*0.05e-9, # Stagger to avoid degeneracy
                 "C" => lumped_C,
-                "Direction" => lumped_direction
+                "Direction" => lumped_dirs[j]
             )
         )
     end

--- a/src/schematics/ExamplePDK/components/ChipTemplates/ChipTemplates.jl
+++ b/src/schematics/ExamplePDK/components/ChipTemplates/ChipTemplates.jl
@@ -95,6 +95,10 @@ Returns a `Path` named `"launcher_\$role_\$target"`, where `role` and `target` a
 elements of `port_spec`. Hooks are given by [`hooks(::Path)`](@ref). Uses default parameters
 for `launch!` with rounding turned off.
 
+The simulated-only `PORT` rectangle carries a [`WithDirection`](@ref) style (default `0°`,
+along the launch direction) so that its orientation after placement can be retrieved with
+`ExamplePDK.port_directions` to configure simulations.
+
 This method exists for use in demonstrations. The launcher design is not optimized
 for microwave properties.
 """
@@ -107,7 +111,9 @@ function example_launcher(port_spec)
     gap0 = path[1].sty.gap # Launcher pad gap
     render!(
         port_cs,
-        only_simulated(meshsized_entity(centered(Rectangle(gap0, gap0)), gap0 / 2)),
+        only_simulated(
+            WithDirection(meshsized_entity(centered(Rectangle(gap0, gap0)), gap0 / 2))
+        ),
         PORT
     )
     attach!(path, sref(port_cs), path[1].sty.gap / 2, i=1)

--- a/test/test_entity.jl
+++ b/test/test_entity.jl
@@ -202,6 +202,14 @@ end
         # If multiple WithDirection layers exist, outer wins (expected behavior, not a contract)
         double = WithDirection(0°)(WithDirection(90°)(rect))
         @test extract_direction(double) == 0°
+        # Mesh sizing tolerates WithDirection in the style stack, in either nesting
+        # order (the launcher PORT rectangle uses the first form; see issue #246)
+        import DeviceLayout.SolidModels: meshsize
+        launcher_like = only_simulated(WithDirection(meshsized_entity(rect, 0.5μm)))
+        @test meshsize(launcher_like) == 0.5 # WithDirection over MeshSized
+        @test extract_direction(launcher_like) == 0°
+        @test meshsize(wd_outer) == 0.5 # WithDirection over MeshSized(OptionalStyle)
+        @test meshsize(opt2) == 0.5     # OptionalStyle(MeshSized) over WithDirection
         ## _direction_config
         @test _direction_config(0°) == "+X"
         @test _direction_config(90°) == "+Y"


### PR DESCRIPTION
Close #246. Junction lumped-port `"Direction"` values change for 18/34 junctions (`"+Y"` → `"-Y"`) since it now depends on transmon up/down mirroring. This is just a sign convention with no physical consequences in Palace config, but it's nice to have it consistently pointing from ground to island.