### PR TITLE
Add ConformalRender: parallel render strategy with shared-edge cache

### DIFF
--- a/src/solidmodels/conformal/conformal.jl
+++ b/src/solidmodels/conformal/conformal.jl
@@ -1,0 +1,741 @@
+"""
+    ConformalRender
+
+Alternative render strategy for [`SolidModel`](@ref) that emits **shared OCC edge
+entities** for adjacent faces, producing conformal geometry without relying on
+`_fragment_and_map!` after render.
+
+Motivation: at chip scale (~10⁵ faces), the stock render path creates a distinct
+OCC edge/point per face boundary, then the post-render `_fragment_and_map!` pass
+reconciles coincident entities. That reconciliation is `O(N²)` and, at production
+scale, non-manifold artifacts can survive it.
+
+`render_conformal!` takes a different path: an in-process **edge/curve cache**
+deduplicates OCC entities as they are created, so two adjacent faces requesting
+the "same" line or arc receive the same OCC tag. The resulting model is conformal
+by construction and `_fragment_and_map!` is skipped.
+
+The stock [`render!`](@ref) is left unchanged; `render_conformal!` is a parallel
+entry point that shares the [`SolidModel`](@ref) type and produces a `SolidModel`
+that downstream operations (postrender, meshing, save) consume interchangeably.
+
+# Usage
+
+```julia
+sm = SolidModel("mymodel"; overwrite=true)
+render_conformal!(sm, cs; postrender_ops=..., zmap=..., kwargs...)
+```
+
+Same kwargs as `render!`, except `_fragment_and_map!` is not called after
+postrender operations (the cache already guarantees conformality on rendered
+geometry). If your postrender operations create new overlapping entities, use
+`render!` instead (or call `_fragment_and_map!` explicitly).
+
+# Design notes
+
+  - **Two point-merge tolerances**: polygon vertices use a **relaxed** tolerance
+    (default 2 nm) because Clipper's integer-grid output and DeviceLayout's
+    `discretize_curve` float drift can leave the two sides of a shared boundary
+    ~1.5 nm apart. Arc centers and BSpline control points use the strict tolerance
+    (`POINT_MERGE_ATOL`) — merging those at the relaxed tolerance would corrupt
+    geometry.
+  - **Prefer-curve invariant**: when a curve (arc or spline) exists on endpoints
+    `(e1, e2)`, every subsequent request on `(e1, e2)` — line or arc — returns
+    that curve. This is the "curve wins" rule that makes adjacent faces resolve
+    to one OCC entity even when one side computed a line and the other an arc.
+  - **Per-render cache**: the cache lives on a `ConformalRenderContext` struct
+    passed through calls. There is no global mutable state; nested/parallel
+    renders are safe.
+"""
+module ConformalRender
+
+using ..SolidModels
+using ..SolidModels:
+    SolidModel,
+    OpenCascade,
+    GmshNative,
+    kernel,
+    gmsh,
+    STP_UNIT,
+    POINT_MERGE_ATOL,
+    _synchronize!,
+    _add_curve!,
+    _get_or_add_point!,
+    _postrender!,
+    _get_or_add_points!,
+    _stp_float,
+    _collect_mesh_control_points!,
+    _used_group_names,
+    sizeandgrading,
+    to_primitives,
+    clear_mesh_control_points!,
+    finalize_size_fields!,
+    set_gmsh_option,
+    dimgroupdict,
+    dimtags,
+    hasgroup,
+    remove_group!,
+    reindex_physical_groups!
+import ..SolidModels: gmsh_meshsize
+import DeviceLayout
+import DeviceLayout:
+    AbstractCoordinateSystem,
+    AbstractPolygon,
+    CurvilinearPolygon,
+    CurvilinearRegion,
+    LineSegment,
+    Meta,
+    Point,
+    Paths,
+    getx,
+    gety,
+    points,
+    flatten,
+    elements,
+    element_metadata,
+    coordinatetype,
+    onenanometer,
+    layer
+import DeviceLayout.Paths: bspline_approximation, pathlength
+import Unitful: ustrip, Length, @u_str, °
+import SpatialIndexing
+import SpatialIndexing: RTree
+
+export render_conformal!, ConformalRenderContext, add_conformal_loop!
+
+"""
+    ConformalRenderContext(; vertex_merge_atol=2e-3, center_merge_atol=POINT_MERGE_ATOL)
+
+Per-render cache and settings for a `render_conformal!` call.
+
+  - `vertex_merge_atol` (µm): tolerance for merging polygon-vertex OCC points.
+    Default `2e-3` µm = 2 nm, chosen to absorb Clipper integer-grid + float-drift
+    divergence between the two sides of a shared boundary (~1.5 nm observed) while
+    staying 500× below typical minimum feature size (1 µm).
+  - `center_merge_atol` (µm): tolerance for merging arc centers and BSpline control
+    points. Kept strict (`POINT_MERGE_ATOL` = 1e-9 µm = 1 pm) because relaxing here
+    would corrupt curve geometry.
+  - `curve_cache`: exact dedup by `(type, geometry_key…)`. Same request → same tag.
+  - `endpoint_curve_index`: `(min_pt, max_pt) → tag`, registered by arcs and
+    splines. Enforces the "prefer curve" invariant.
+  - `stats`: telemetry (hits, misses, arcs, splines, chord fallbacks).
+"""
+mutable struct ConformalRenderContext
+    vertex_merge_atol::Float64
+    center_merge_atol::Float64
+    curve_cache::Dict{Tuple, Int}
+    endpoint_curve_index::Dict{Tuple{Int, Int}, Int}
+    stats::Dict{Symbol, Int}
+end
+
+ConformalRenderContext(;
+    vertex_merge_atol::Float64=2e-3,
+    center_merge_atol::Float64=POINT_MERGE_ATOL
+) = ConformalRenderContext(
+    vertex_merge_atol,
+    center_merge_atol,
+    Dict{Tuple, Int}(),
+    Dict{Tuple{Int, Int}, Int}(),
+    Dict{Symbol, Int}(
+        :hits => 0,
+        :misses => 0,
+        :arcs => 0,
+        :splines => 0,
+        :chord_fallbacks => 0
+    )
+)
+
+# ─── Point merge ─────────────────────────────────────────────────────────────
+
+# Vertex-precision (relaxed) point insert. Used for polygon vertices where the
+# two sides of a shared boundary may differ by ~1.5 nm.
+function _cached_point_relaxed!(
+    k,
+    ctx::ConformalRenderContext,
+    x::Float64,
+    y::Float64,
+    z::Float64,
+    points_tree
+)
+    points_tree === nothing && return k.add_point(x, y, z)
+    return _get_or_add_point!(k, x, y, z, points_tree; atol=ctx.vertex_merge_atol)
+end
+
+# Strict point insert. Used for arc centers and BSpline control points where
+# any merge would corrupt geometry.
+function _cached_point_strict!(
+    k,
+    ctx::ConformalRenderContext,
+    x::Float64,
+    y::Float64,
+    z::Float64,
+    points_tree
+)
+    points_tree === nothing && return k.add_point(x, y, z)
+    return _get_or_add_point!(k, x, y, z, points_tree; atol=ctx.center_merge_atol)
+end
+
+# ─── Edge/curve cache ────────────────────────────────────────────────────────
+
+# Add a line, dedup on unordered endpoint pair.
+function _cached_add_line!(k, ctx::ConformalRenderContext, p1::Integer, p2::Integer)
+    p1 == p2 && error("degenerate edge: p1 == p2 == $p1")
+    lo, hi = minmax(p1, p2)
+    key = (:line, lo, hi)
+    existing = get(ctx.curve_cache, key, nothing)
+    if existing !== nothing
+        ctx.stats[:hits] += 1
+        return p1 < p2 ? existing : -existing
+    end
+    # Prefer-curve: a curve already spans these endpoints → reuse it.
+    existing_curve = get(ctx.endpoint_curve_index, (lo, hi), nothing)
+    if existing_curve !== nothing
+        ctx.stats[:hits] += 1
+        return p1 < p2 ? existing_curve : -existing_curve
+    end
+    ctx.stats[:misses] += 1
+    tag = k.addLine(p1, p2)
+    ctx.curve_cache[key] = p1 < p2 ? tag : -tag
+    return tag
+end
+
+# Add a circle arc. Registers in the endpoint index so subsequent line requests
+# on the same endpoints reuse this arc (curve wins).
+function _cached_add_arc!(
+    k,
+    ctx::ConformalRenderContext,
+    p1::Integer,
+    center::Integer,
+    p2::Integer
+)
+    lo, hi = minmax(p1, p2)
+    # Exact arc (center in key): the same Turn requested again → same tag.
+    key = (:arc, lo, center, hi)
+    existing = get(ctx.curve_cache, key, nothing)
+    if existing !== nothing
+        ctx.stats[:hits] += 1
+        return p1 < p2 ? existing : -existing
+    end
+    # Any curve already on these endpoints → reuse (handles float-jittered
+    # center of the coordinated Turn applied to the other side).
+    existing_curve = get(ctx.endpoint_curve_index, (lo, hi), nothing)
+    if existing_curve !== nothing
+        ctx.stats[:hits] += 1
+        return p1 < p2 ? existing_curve : -existing_curve
+    end
+    # Conformality backstop: a chord was already created on these endpoints
+    # (the other side rendered this boundary as a line because it did not
+    # recover the arc). Reuse the chord so both faces share one tag; accuracy
+    # is lost in this one-sided cell only.
+    existing_line = get(ctx.curve_cache, (:line, lo, hi), nothing)
+    if existing_line !== nothing
+        ctx.stats[:hits] += 1
+        return p1 < p2 ? existing_line : -existing_line
+    end
+    ctx.stats[:misses] += 1
+    ctx.stats[:arcs] += 1
+    tag = k.add_circle_arc(p1, center, p2, -1)
+    signed_tag = p1 < p2 ? tag : -tag
+    ctx.curve_cache[key] = signed_tag
+    ctx.endpoint_curve_index[(lo, hi)] = signed_tag
+    return tag
+end
+
+# Add an interpolating BSpline. Deduped by exact control-net; also unified with
+# its reversal.
+function _cached_add_spline!(
+    k,
+    ctx::ConformalRenderContext,
+    pts::Vector{<:Integer},
+    tangents
+)
+    key = (:bspline, pts...)
+    existing = get(ctx.curve_cache, key, nothing)
+    if existing !== nothing
+        ctx.stats[:hits] += 1
+        return existing
+    end
+    rkey = (:bspline, reverse(pts)...)
+    existing_r = get(ctx.curve_cache, rkey, nothing)
+    if existing_r !== nothing
+        ctx.stats[:hits] += 1
+        return -existing_r
+    end
+    ctx.stats[:misses] += 1
+    ctx.stats[:splines] += 1
+    tag = k.addSpline(pts, -1, tangents)
+    ctx.curve_cache[key] = tag
+    return tag
+end
+
+# ─── Primitive-to-OCC entity dispatch ────────────────────────────────────────
+
+# CurvilinearPolygon → CurvilinearRegion path
+_add_conformal!(
+    ctx::ConformalRenderContext,
+    x::CurvilinearPolygon,
+    m::Meta,
+    k;
+    zmap=(_) -> zero(coordinatetype(x)),
+    points_tree=nothing,
+    kwargs...
+) = _add_conformal!(
+    ctx,
+    CurvilinearRegion(x),
+    m,
+    k;
+    zmap=zmap,
+    points_tree=points_tree,
+    kwargs...
+)
+
+# CurvilinearRegion: single add_plane_surface call with hole loops (PATCH 1).
+# Stock DL creates outer surface, then per-hole surface, then k.cut() each hole.
+# The multi-loop form is one OCC call and preserves shared points naturally.
+function _add_conformal!(
+    ctx::ConformalRenderContext,
+    surf::CurvilinearRegion{T},
+    m::Meta,
+    k::OpenCascade;
+    zmap=(_) -> zero(T),
+    points_tree=nothing,
+    atol=onenanometer(T),
+    kwargs...
+) where {T}
+    z = zmap(m)
+    outer_loop = _add_conformal_loop!(ctx, surf.exterior, k, z; points_tree, atol)
+    hole_loops = _add_conformal_loop!.(Ref(ctx), surf.holes, k, z; points_tree, atol)
+    surftag = k.add_plane_surface([outer_loop; hole_loops...])
+    return (Int32(2), surftag)
+end
+
+# Plain polygon path (rectilinear).
+function _add_conformal!(
+    ctx::ConformalRenderContext,
+    poly::AbstractPolygon{T},
+    m::Meta,
+    k::OpenCascade;
+    zmap=(_) -> zero(T),
+    points_tree=nothing,
+    atol=onenanometer(T),
+    kwargs...
+) where {T}
+    z = zmap(m)
+    loop =
+        _add_conformal_loop!(ctx, CurvilinearPolygon(points(poly)), k, z; points_tree, atol)
+    surf = k.add_plane_surface([loop])
+    return (Int32(2), surf)
+end
+
+# Line segment path (1D entity).
+function _add_conformal!(
+    ctx::ConformalRenderContext,
+    line::LineSegment{T},
+    m::Meta,
+    k::OpenCascade;
+    zmap=(_) -> zero(T),
+    points_tree=nothing,
+    atol=onenanometer(T),
+    kwargs...
+) where {T}
+    z = zmap(m)
+    p0 = _cached_point_relaxed!(
+        k,
+        ctx,
+        Float64(ustrip(STP_UNIT, getx(line.p0))),
+        Float64(ustrip(STP_UNIT, gety(line.p0))),
+        Float64(ustrip(STP_UNIT, z)),
+        points_tree
+    )
+    p1 = _cached_point_relaxed!(
+        k,
+        ctx,
+        Float64(ustrip(STP_UNIT, getx(line.p1))),
+        Float64(ustrip(STP_UNIT, gety(line.p1))),
+        Float64(ustrip(STP_UNIT, z)),
+        points_tree
+    )
+    linetag = _cached_add_line!(k, ctx, p0, p1)
+    return (Int32(1), linetag)
+end
+
+# Broadcast dispatcher — top-level entry from render_conformal!'s metadata loop.
+_add_conformal!(ctx::ConformalRenderContext, els::AbstractVector, m::Meta, k; kwargs...) =
+    [_add_conformal!(ctx, el, m, k; kwargs...) for el in els]
+
+_add_conformal!(ctx::ConformalRenderContext, el, m::Meta, k::GmshNative; kwargs...) =
+    error("ConformalRender is only implemented for OpenCascade kernel; got GmshNative")
+
+# ─── Curve loop assembly ─────────────────────────────────────────────────────
+
+# PATCH 3 without the (disabled) short-edge batching from DTP. The batching was
+# gated off in production (`SHORT_EDGE_BATCH_THRESHOLD=0.0`); reproducing it
+# here would be dead code.
+"""
+    add_conformal_loop!(ctx::ConformalRenderContext, cl::CurvilinearPolygon,
+        k::OpenCascade, z; points_tree=nothing, atol=onenanometer(...))
+
+Build an OCC curve loop for `cl` using the conformal edge/curve cache.
+
+This is the public seam for callers that build OCC geometry themselves (rather
+than using [`render_conformal!`](@ref)'s orchestrator). Typical usage:
+
+```julia
+ctx = ConformalRenderContext()
+points_tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+for region in regions
+    outer = add_conformal_loop!(ctx, region.exterior, k, z; points_tree)
+    holes = [add_conformal_loop!(ctx, h, k, z; points_tree) for h in region.holes]
+    k.add_plane_surface([outer; holes...])
+end
+```
+
+Adjacent regions that share a boundary curve will resolve to the same OCC edge
+tag via the cache, producing conformal geometry without `_fragment_and_map!`.
+"""
+function add_conformal_loop!(
+    ctx::ConformalRenderContext,
+    cl::CurvilinearPolygon,
+    k::OpenCascade,
+    z;
+    points_tree=nothing,
+    atol=onenanometer(coordinatetype(cl))
+)
+    return _add_conformal_loop!(ctx, cl, k, z; points_tree, atol)
+end
+
+function _add_conformal_loop!(
+    ctx::ConformalRenderContext,
+    cl::CurvilinearPolygon,
+    k::OpenCascade,
+    z;
+    points_tree=nothing,
+    atol=onenanometer(coordinatetype(cl))
+)
+    poly_pts = points(cl)
+    pts = [
+        _cached_point_relaxed!(
+            k,
+            ctx,
+            Float64(ustrip(STP_UNIT, getx(p))),
+            Float64(ustrip(STP_UNIT, gety(p))),
+            Float64(ustrip(STP_UNIT, z)),
+            points_tree
+        ) for p in poly_pts
+    ]
+    n = length(pts)
+    curve_set = Set(cl.curve_start_idx)
+    curves_out = Int32[]
+    for i = 1:n
+        j = mod1(i + 1, n)
+        if i in curve_set
+            curve_idx = findfirst(isequal(i), cl.curve_start_idx)
+            endpoints = (pts[i], pts[j])
+            result = _add_conformal_curve!(
+                ctx,
+                endpoints,
+                cl.curves[curve_idx],
+                k,
+                z,
+                points_tree;
+                atol
+            )
+            if result isa AbstractVector
+                append!(curves_out, result)
+            else
+                push!(curves_out, result)
+            end
+        else
+            # Drop zero-length edges that collapse when adjacent contour vertices
+            # merge at the relaxed tolerance. The near-duplicate pair is
+            # identical on both sides of a shared boundary, so both faces drop
+            # the same edge → still conformal.
+            pts[i] == pts[j] && continue
+            push!(curves_out, _cached_add_line!(k, ctx, pts[i], pts[j]))
+        end
+    end
+    return k.add_curve_loop(curves_out)
+end
+
+# ─── Curve dispatch (arcs, BSplines, offsets) ────────────────────────────────
+
+# PATCH 4a: exact circular arc, cached, with strict-tolerance center.
+function _add_conformal_curve!(
+    ctx::ConformalRenderContext,
+    endpoints,
+    seg::Paths.Turn,
+    k::OpenCascade,
+    z,
+    points_tree;
+    kwargs...
+)
+    center_pt =
+        seg.p0 +
+        Point(-seg.r * sign(seg.α) * sin(seg.α0), seg.r * sign(seg.α) * cos(seg.α0))
+    cen = _cached_point_strict!(
+        k,
+        ctx,
+        Float64(ustrip(STP_UNIT, getx(center_pt))),
+        Float64(ustrip(STP_UNIT, gety(center_pt))),
+        Float64(ustrip(STP_UNIT, z)),
+        points_tree
+    )
+
+    if abs(seg.α) >= 180°
+        n_180 = abs(seg.α) / 180°
+        n_arcs = ceil(n_180) == n_180 ? Int(n_180 + 1) : Int(ceil(n_180))
+        arclengths = range(zero(pathlength(seg)), pathlength(seg), length=n_arcs + 1)
+        middle_pts = seg.(arclengths[(begin + 1):(end - 1)])
+        middle_tags = [
+            _cached_point_strict!(
+                k,
+                ctx,
+                Float64(ustrip(STP_UNIT, getx(mp))),
+                Float64(ustrip(STP_UNIT, gety(mp))),
+                Float64(ustrip(STP_UNIT, z)),
+                points_tree
+            ) for mp in middle_pts
+        ]
+        tags = [endpoints[1]; middle_tags; endpoints[2]]
+        return [
+            _cached_add_arc!(k, ctx, tags[i], cen, tags[i + 1]) for i = 1:(length(tags) - 1)
+        ]
+    end
+
+    try
+        return _cached_add_arc!(k, ctx, endpoints[1], cen, endpoints[2])
+    catch e
+        if e isa ErrorException && contains(e.msg, "Could not create circle arc")
+            ctx.stats[:chord_fallbacks] += 1
+            return _cached_add_line!(k, ctx, endpoints[1], endpoints[2])
+        end
+        rethrow()
+    end
+end
+
+# PATCH 4b: exact interpolating BSpline, cached, with strict-tolerance
+# intermediate control points.
+function _add_conformal_curve!(
+    ctx::ConformalRenderContext,
+    endpoints,
+    seg::Paths.BSpline,
+    k::OpenCascade,
+    z,
+    points_tree;
+    kwargs...
+)
+    midpts = [
+        _cached_point_strict!(
+            k,
+            ctx,
+            Float64(ustrip(STP_UNIT, getx(p))),
+            Float64(ustrip(STP_UNIT, gety(p))),
+            Float64(ustrip(STP_UNIT, z)),
+            points_tree
+        ) for p in seg.p[2:(end - 1)]
+    ]
+    pts = [endpoints[1], midpts..., endpoints[2]]
+    tangents = [
+        ustrip(STP_UNIT, seg.t0.x),
+        ustrip(STP_UNIT, seg.t0.y),
+        0.0,
+        ustrip(STP_UNIT, seg.t1.x),
+        ustrip(STP_UNIT, seg.t1.y),
+        0.0
+    ]
+    return _cached_add_spline!(k, ctx, pts, tangents)
+end
+
+# PATCH 4c: offset segments — constant offset of a Turn is still a circular
+# arc (exact); general offset (BSpline or variable) is approximated by a
+# BSpline chain with join points at the RELAXED tolerance to unify sub-splines
+# produced from opposite traversal directions.
+function _add_conformal_curve!(
+    ctx::ConformalRenderContext,
+    endpoints,
+    seg::Paths.OffsetSegment,
+    k::OpenCascade,
+    z,
+    points_tree;
+    kwargs...
+)
+    base = seg.seg
+    off = seg.offset
+    # Constant offset of a Turn: still a circular arc, exact.
+    if base isa Paths.Turn && off isa DeviceLayout.Coordinate
+        off_turn = Paths.Turn(
+            base.α,
+            base.r - sign(base.α) * off,
+            base.p0 + Point(-sin(base.α0), cos(base.α0)) * off,
+            base.α0
+        )
+        return _add_conformal_curve!(ctx, endpoints, off_turn, k, z, points_tree; kwargs...)
+    end
+    # General case (offset BSpline / variable offset). `bspline_approximation`
+    # is NOT direction-symmetric: calling it on `seg` and on `Paths.reverse(seg)`
+    # produces ulp-level different join coordinates on the SAME geometric curve.
+    # The RELAXED merge unifies them; the strict merge does not.
+    atol_local = onenanometer(coordinatetype(Paths.p0(seg)))
+    approx = bspline_approximation(seg; atol=atol_local)
+    newstarts = DeviceLayout.p0.(approx.segments)[2:end]
+    newpts = [
+        _cached_point_relaxed!(
+            k,
+            ctx,
+            Float64(ustrip(STP_UNIT, getx(p))),
+            Float64(ustrip(STP_UNIT, gety(p))),
+            Float64(ustrip(STP_UNIT, z)),
+            points_tree
+        ) for p in newstarts
+    ]
+    starts = [endpoints[1], newpts...]
+    stops = [newpts..., endpoints[2]]
+    tags = Int32[]
+    for (ep, sub) in zip([[s, e] for (s, e) in zip(starts, stops)], approx.segments)
+        t = _add_conformal_curve!(ctx, ep, sub, k, z, points_tree; kwargs...)
+        if t isa AbstractVector
+            append!(tags, t)
+        else
+            push!(tags, t)
+        end
+    end
+    return tags
+end
+
+# Fallback: any segment type not specialized above (e.g. Straight) is handled
+# by DL's stock `_add_curve!` — those types don't benefit from caching (they're
+# already exact-and-cheap in stock DL).
+_add_conformal_curve!(
+    ctx::ConformalRenderContext,
+    endpoints,
+    seg::Paths.Segment,
+    k::OpenCascade,
+    z,
+    points_tree;
+    kwargs...
+) = _add_curve!(endpoints, seg, k, z; kwargs...)
+
+# ─── Public entry point ──────────────────────────────────────────────────────
+
+"""
+    render_conformal!(sm::SolidModel, cs::AbstractCoordinateSystem;
+        context=ConformalRenderContext(),
+        map_meta=layer, postrender_ops=[], retained_physical_groups=[],
+        zmap=(_)->zero(T), gmsh_options=..., skip_postrender=false,
+        auto_union=false, skip_unused_layers=false, kwargs...)
+
+Render `cs` into `sm` using the ConformalRender strategy. Same semantics as
+[`render!`](@ref) but without the post-render `_fragment_and_map!` pass.
+
+The `context::ConformalRenderContext` holds the edge/curve cache and merge
+tolerances; pass an explicit context if you need custom tolerances or want to
+inspect cache statistics after the render.
+
+Not supported on `GmshNative` kernel.
+"""
+function render_conformal!(
+    sm::SolidModel,
+    cs::AbstractCoordinateSystem{T};
+    context::ConformalRenderContext=ConformalRenderContext(),
+    map_meta=layer,
+    postrender_ops=[],
+    retained_physical_groups=[],
+    zmap=(_) -> zero(T),
+    gmsh_options=Dict{String, Union{String, Int, Float64}}(),
+    skip_postrender::Bool=false,
+    auto_union::Bool=false,
+    skip_unused_layers::Bool=false,
+    kwargs...
+) where {T}
+    kernel(sm) isa OpenCascade || error(
+        "render_conformal! is only implemented for OpenCascade kernel; " *
+        "got $(typeof(kernel(sm))). Use render! instead."
+    )
+    gmsh.model.set_current(SolidModels.name(sm))
+    set_gmsh_option(gmsh_options)
+
+    flat = flatten(cs)
+    clear_mesh_control_points!()
+    points_tree = RTree{Float64, 3}(Int32)
+
+    used_names = if skip_unused_layers
+        _used_group_names(postrender_ops, retained_physical_groups)
+    else
+        nothing
+    end
+
+    for meta in unique(element_metadata(flat))
+        mapped_name = map_meta(meta)
+        isnothing(mapped_name) && continue
+        if !isnothing(used_names) &&
+           string(mapped_name) ∉ used_names &&
+           string(layer(meta)) ∉ used_names
+            continue
+        end
+        idx = (element_metadata(flat) .== meta)
+        els = to_primitives.(sm, elements(flat)[idx]; kwargs...)
+        meshsizes = sizeandgrading.(elements(flat)[idx]; kwargs...)
+
+        group_dimtags_unflattened = _add_conformal!(
+            context,
+            els,
+            meta,
+            kernel(sm);
+            zmap=zmap,
+            points_tree=points_tree,
+            kwargs...
+        )
+
+        group_dimtags = reduce(vcat, group_dimtags_unflattened, init=Tuple{Int32, Int32}[])
+        for dim in unique(first.(group_dimtags))
+            if hasgroup(sm, mapped_name, dim)
+                append!(group_dimtags, dimtags(sm[mapped_name, dim]))
+            end
+        end
+        sm[mapped_name] = group_dimtags
+
+        z_of_meta = _stp_float(zmap(meta))
+        for (prims, (h, α)) in zip(els, meshsizes)
+            _collect_mesh_control_points!(prims, h, α, z_of_meta)
+        end
+    end
+
+    _synchronize!(sm)
+    finalize_size_fields!()
+    _synchronize!(sm)
+    skip_postrender && return nothing
+
+    if auto_union
+        auto_union_ops = Tuple[]
+        for groupname in collect(keys(dimgroupdict(sm, 2)))
+            push!(auto_union_ops, (groupname, SolidModels.union_geom!, (groupname, 2)))
+        end
+        _postrender!(sm, auto_union_ops)
+        _synchronize!(sm)
+    end
+    _postrender!(sm, postrender_ops)
+    _synchronize!(sm)
+
+    # Key difference vs render!: NO _fragment_and_map! pass. The conformal cache
+    # already deduplicates shared edges during render, and _fragment_and_map!
+    # would touch OCC entities the cache assumes are stable. If your
+    # postrender_ops introduce overlapping entities that need reconciliation,
+    # use render! instead.
+
+    gmsh.model.mesh.setSizeCallback(gmsh_meshsize)
+
+    if !isempty(retained_physical_groups)
+        for d = 0:3
+            retain_groups = getindex.(filter(x -> x[2] == d, retained_physical_groups), 1)
+            all_groups = keys(dimgroupdict(sm, d))
+            for k in setdiff(all_groups, retain_groups)
+                remove_group!(sm[k, d], remove_entities=false)
+            end
+        end
+        reindex_physical_groups!(sm)
+    end
+
+    return _synchronize!(sm)
+end
+
+end # module ConformalRender

--- a/src/solidmodels/conformal/conformal.jl
+++ b/src/solidmodels/conformal/conformal.jl
@@ -265,14 +265,18 @@ function _cached_add_arc!(
     return tag
 end
 
-# Add an interpolating BSpline. Deduped by exact control-net; also unified with
-# its reversal.
+# Add an interpolating BSpline. Deduped by exact control-net; unified with its
+# reversal; and participates in the prefer-curve invariant via
+# `endpoint_curve_index` — a later request for a line (or arc) on the same
+# endpoints will reuse this spline instead of creating a duplicate edge.
 function _cached_add_spline!(
     k,
     ctx::ConformalRenderContext,
     pts::Vector{<:Integer},
     tangents
 )
+    p1, p2 = pts[1], pts[end]
+    lo, hi = minmax(p1, p2)
     key = (:bspline, pts...)
     existing = get(ctx.curve_cache, key, nothing)
     if existing !== nothing
@@ -285,10 +289,19 @@ function _cached_add_spline!(
         ctx.stats[:hits] += 1
         return -existing_r
     end
+    # Any curve already on these endpoints → reuse. Handles a spline requested
+    # after an arc (or the reverse) on the same shared boundary.
+    existing_curve = get(ctx.endpoint_curve_index, (lo, hi), nothing)
+    if existing_curve !== nothing
+        ctx.stats[:hits] += 1
+        return p1 < p2 ? existing_curve : -existing_curve
+    end
     ctx.stats[:misses] += 1
     ctx.stats[:splines] += 1
     tag = k.addSpline(pts, -1, tangents)
+    signed_tag = p1 < p2 ? tag : -tag
     ctx.curve_cache[key] = tag
+    ctx.endpoint_curve_index[(lo, hi)] = signed_tag
     return tag
 end
 

--- a/src/solidmodels/conformal/conformal.jl
+++ b/src/solidmodels/conformal/conformal.jl
@@ -46,6 +46,29 @@ geometry). If your postrender operations create new overlapping entities, use
   - **Per-render cache**: the cache lives on a `ConformalRenderContext` struct
     passed through calls. There is no global mutable state; nested/parallel
     renders are safe.
+
+# Preconditions
+
+For the cache to produce correct geometry:
+
+ 1. **Shared endpoints ⟹ shared curve geometry.** If two faces share a boundary,
+    the CurvilinearPolygon points on both sides must resolve to the same OCC
+    point tags AND the curves spanning those tags must be the same geometric
+    curve. Callers can meet this by having both faces reference the same
+    `Paths.Segment` object (the "coordinated recovery" pattern from
+    `union2d_curved` where both operands are matched against the same
+    boolean-recovery ProvenanceRun), or by an upstream mutual-noding pass.
+ 2. **No distinct co-endpoint edges.** The prefer-curve rule fuses curve
+    requests on shared endpoints into a single OCC tag. If your geometry
+    genuinely has two distinct edges spanning the same two points (say, a
+    figure-8 pinch or a self-crossing offset curve), the cache will wrongly
+    merge them.
+ 3. **Relaxed vertex merge is safe iff features > 500× the merge tolerance.**
+    The default 2 nm merge is 500× smaller than a 1 µm minimum feature. If
+    you have features ~10× smaller, use `ConformalRenderContext(; vertex_merge_atol=…)` to tighten.
+
+When any of these are uncertain, `render_conformal!(..., fragment_backstop=true)`
+runs the stock 3-pass `_fragment_and_map!` after postrender as a safety net.
 """
 module ConformalRender
 
@@ -62,6 +85,7 @@ using ..SolidModels:
     _add_curve!,
     _get_or_add_point!,
     _postrender!,
+    _fragment_and_map!,
     _get_or_add_points!,
     _stp_float,
     _collect_mesh_control_points!,
@@ -360,11 +384,10 @@ function _add_conformal!(
 end
 
 # Broadcast dispatcher — top-level entry from render_conformal!'s metadata loop.
+# `render_conformal!` guards `kernel(sm) isa OpenCascade` at entry so we don't
+# need a per-primitive GmshNative rejection method here.
 _add_conformal!(ctx::ConformalRenderContext, els::AbstractVector, m::Meta, k; kwargs...) =
     [_add_conformal!(ctx, el, m, k; kwargs...) for el in els]
-
-_add_conformal!(ctx::ConformalRenderContext, el, m::Meta, k::GmshNative; kwargs...) =
-    error("ConformalRender is only implemented for OpenCascade kernel; got GmshNative")
 
 # ─── Curve loop assembly ─────────────────────────────────────────────────────
 
@@ -622,14 +645,23 @@ _add_conformal_curve!(
         context=ConformalRenderContext(),
         map_meta=layer, postrender_ops=[], retained_physical_groups=[],
         zmap=(_)->zero(T), gmsh_options=..., skip_postrender=false,
-        auto_union=false, skip_unused_layers=false, kwargs...)
+        auto_union=false, skip_unused_layers=false,
+        fragment_backstop=false, kwargs...)
 
 Render `cs` into `sm` using the ConformalRender strategy. Same semantics as
-[`render!`](@ref) but without the post-render `_fragment_and_map!` pass.
+[`render!`](@ref) but without the post-render `_fragment_and_map!` pass by
+default.
 
 The `context::ConformalRenderContext` holds the edge/curve cache and merge
 tolerances; pass an explicit context if you need custom tolerances or want to
 inspect cache statistics after the render.
+
+`fragment_backstop=true` runs the stock 3-pass `_fragment_and_map!` sequence
+after postrender operations. Faces already resolved to a single OCC entity
+by the cache pass through as no-ops, so this is safe to combine with
+cache-resolved regions. Enable when the input geometry may not fully meet
+the "shared endpoints ⟹ shared curve" precondition, or when `postrender_ops`
+introduce overlapping entities that need reconciliation.
 
 Not supported on `GmshNative` kernel.
 """
@@ -645,6 +677,7 @@ function render_conformal!(
     skip_postrender::Bool=false,
     auto_union::Bool=false,
     skip_unused_layers::Bool=false,
+    fragment_backstop::Bool=false,
     kwargs...
 ) where {T}
     kernel(sm) isa OpenCascade || error(
@@ -716,11 +749,19 @@ function render_conformal!(
     _postrender!(sm, postrender_ops)
     _synchronize!(sm)
 
-    # Key difference vs render!: NO _fragment_and_map! pass. The conformal cache
-    # already deduplicates shared edges during render, and _fragment_and_map!
-    # would touch OCC entities the cache assumes are stable. If your
-    # postrender_ops introduce overlapping entities that need reconciliation,
-    # use render! instead.
+    # By default, no `_fragment_and_map!` pass: the conformal cache already
+    # deduplicates shared edges during render. But if the input geometry
+    # doesn't fully meet the cache's preconditions (see "Failure modes for the
+    # 'prefer curve' invariant" in the module docstring), or if `postrender_ops`
+    # introduce overlapping entities that need reconciliation, users can opt
+    # into the stock 3-pass fragment as a safety net via `fragment_backstop=true`.
+    # Faces already resolved to a single OCC entity by the cache pass through
+    # fragment as no-ops, so this is compatible with cache-resolved regions.
+    if fragment_backstop
+        _fragment_and_map!(sm, [0, 1])
+        _fragment_and_map!(sm, [1, 2])
+        _fragment_and_map!(sm, [2, 3])
+    end
 
     gmsh.model.mesh.setSizeCallback(gmsh_meshsize)
 

--- a/src/solidmodels/conformal/conformal.jl
+++ b/src/solidmodels/conformal/conformal.jl
@@ -326,9 +326,10 @@ _add_conformal!(
     kwargs...
 )
 
-# CurvilinearRegion: single add_plane_surface call with hole loops (PATCH 1).
-# Stock DL creates outer surface, then per-hole surface, then k.cut() each hole.
-# The multi-loop form is one OCC call and preserves shared points naturally.
+# CurvilinearRegion: single add_plane_surface call with hole loops. Stock
+# render! creates the outer surface, then a surface per hole, then k.cut()s
+# each hole. The multi-loop form is one OCC call and preserves shared points
+# naturally, which is what we need for conformal rendering.
 function _add_conformal!(
     ctx::ConformalRenderContext,
     surf::CurvilinearRegion{T},
@@ -404,9 +405,6 @@ _add_conformal!(ctx::ConformalRenderContext, els::AbstractVector, m::Meta, k; kw
 
 # ─── Curve loop assembly ─────────────────────────────────────────────────────
 
-# PATCH 3 without the (disabled) short-edge batching from DTP. The batching was
-# gated off in production (`SHORT_EDGE_BATCH_THRESHOLD=0.0`); reproducing it
-# here would be dead code.
 """
     add_conformal_loop!(ctx::ConformalRenderContext, cl::CurvilinearPolygon,
         k::OpenCascade, z; points_tree=nothing, atol=onenanometer(...))
@@ -495,7 +493,8 @@ end
 
 # ─── Curve dispatch (arcs, BSplines, offsets) ────────────────────────────────
 
-# PATCH 4a: exact circular arc, cached, with strict-tolerance center.
+# Circular arc: exact, cached by (endpoints, center) with strict-tolerance
+# center dedup so a Turn traversed from both sides collapses to one OCC entity.
 function _add_conformal_curve!(
     ctx::ConformalRenderContext,
     endpoints,
@@ -549,8 +548,9 @@ function _add_conformal_curve!(
     end
 end
 
-# PATCH 4b: exact interpolating BSpline, cached, with strict-tolerance
-# intermediate control points.
+# Interpolating BSpline: exact, cached by control-net; strict tolerance on
+# intermediate control points so a spline traversed from both sides collapses
+# to one OCC entity.
 function _add_conformal_curve!(
     ctx::ConformalRenderContext,
     endpoints,
@@ -582,10 +582,10 @@ function _add_conformal_curve!(
     return _cached_add_spline!(k, ctx, pts, tangents)
 end
 
-# PATCH 4c: offset segments — constant offset of a Turn is still a circular
-# arc (exact); general offset (BSpline or variable) is approximated by a
-# BSpline chain with join points at the RELAXED tolerance to unify sub-splines
-# produced from opposite traversal directions.
+# Offset segment: a constant offset of a Turn is still a circular arc (exact);
+# general offset (variable, or offset of a BSpline) is approximated by a
+# BSpline chain with join points at the RELAXED tolerance so sub-splines
+# produced from opposite traversal directions unify.
 function _add_conformal_curve!(
     ctx::ConformalRenderContext,
     endpoints,

--- a/src/solidmodels/conformal/conformal.jl
+++ b/src/solidmodels/conformal/conformal.jl
@@ -181,9 +181,7 @@ ConformalRenderContext(;
 
 # Return true if two midpoints agree to within the context's vertex tolerance.
 _midpoint_match(a::NTuple{3, Float64}, b::NTuple{3, Float64}, atol::Float64) =
-    abs(a[1] - b[1]) <= atol &&
-    abs(a[2] - b[2]) <= atol &&
-    abs(a[3] - b[3]) <= atol
+    abs(a[1] - b[1]) <= atol && abs(a[2] - b[2]) <= atol && abs(a[3] - b[3]) <= atol
 
 # ─── Point merge ─────────────────────────────────────────────────────────────
 
@@ -197,8 +195,9 @@ function _cached_point_relaxed!(
     z::Float64,
     points_tree
 )
-    tag = isnothing(points_tree) ? k.add_point(x, y, z) :
-          _get_or_add_point!(k, x, y, z, points_tree; atol=ctx.vertex_merge_atol)
+    tag =
+        isnothing(points_tree) ? k.add_point(x, y, z) :
+        _get_or_add_point!(k, x, y, z, points_tree; atol=ctx.vertex_merge_atol)
     # Record coords for later midpoint computation; the tag returned by
     # `_get_or_add_point!` may correspond to a previously-inserted nearby point,
     # so `get!` preserves the first-writer coords rather than overwriting.
@@ -216,8 +215,9 @@ function _cached_point_strict!(
     z::Float64,
     points_tree
 )
-    tag = isnothing(points_tree) ? k.add_point(x, y, z) :
-          _get_or_add_point!(k, x, y, z, points_tree; atol=ctx.center_merge_atol)
+    tag =
+        isnothing(points_tree) ? k.add_point(x, y, z) :
+        _get_or_add_point!(k, x, y, z, points_tree; atol=ctx.center_merge_atol)
     get!(ctx.point_coords, tag, (x, y, z))
     return tag
 end
@@ -251,8 +251,7 @@ function _cached_add_line!(k, ctx::ConformalRenderContext, p1::Integer, p2::Inte
             )
             if _midpoint_match(line_mid, existing_curve.midpoint, ctx.vertex_merge_atol)
                 ctx.stats[:hits] += 1
-                return p1 < p2 ? existing_curve.signed_tag :
-                       -existing_curve.signed_tag
+                return p1 < p2 ? existing_curve.signed_tag : -existing_curve.signed_tag
             end
             ctx.stats[:midpoint_rejections] += 1
         else
@@ -287,9 +286,7 @@ function _arc_midpoint(
     dy = chord_mid[2] - cy
     dz = chord_mid[3] - cz
     n = sqrt(dx * dx + dy * dy + dz * dz)
-    r = sqrt(
-        (p1_xyz[1] - cx)^2 + (p1_xyz[2] - cy)^2 + (p1_xyz[3] - cz)^2
-    )
+    r = sqrt((p1_xyz[1] - cx)^2 + (p1_xyz[2] - cy)^2 + (p1_xyz[3] - cz)^2)
     n == 0.0 && return chord_mid  # semicircle degenerate; caller should split
     return (cx + r * dx / n, cy + r * dy / n, cz + r * dz / n)
 end
@@ -315,8 +312,7 @@ function _cached_add_arc!(
     p1_xyz = get(ctx.point_coords, p1, nothing)
     p2_xyz = get(ctx.point_coords, p2, nothing)
     center_xyz = get(ctx.point_coords, center, nothing)
-    have_coords =
-        !isnothing(p1_xyz) && !isnothing(p2_xyz) && !isnothing(center_xyz)
+    have_coords = !isnothing(p1_xyz) && !isnothing(p2_xyz) && !isnothing(center_xyz)
     arc_mid = have_coords ? _arc_midpoint(p1_xyz, p2_xyz, center_xyz) : nothing
     # Any curve already on these endpoints → reuse only if its midpoint
     # matches this arc's midpoint.
@@ -324,8 +320,7 @@ function _cached_add_arc!(
     if !isnothing(existing_curve) && !isnothing(arc_mid)
         if _midpoint_match(arc_mid, existing_curve.midpoint, ctx.vertex_merge_atol)
             ctx.stats[:hits] += 1
-            return p1 < p2 ? existing_curve.signed_tag :
-                   -existing_curve.signed_tag
+            return p1 < p2 ? existing_curve.signed_tag : -existing_curve.signed_tag
         end
         ctx.stats[:midpoint_rejections] += 1
     end
@@ -353,8 +348,7 @@ function _cached_add_arc!(
     signed_tag = p1 < p2 ? tag : -tag
     ctx.curve_cache[key] = signed_tag
     if !isnothing(arc_mid)
-        ctx.endpoint_curve_index[(lo, hi)] =
-            EndpointCurveEntry(signed_tag, arc_mid)
+        ctx.endpoint_curve_index[(lo, hi)] = EndpointCurveEntry(signed_tag, arc_mid)
     end
     return tag
 end
@@ -367,10 +361,7 @@ end
 # For our (endpoint-anchored) BSplines the middle interior control point is a
 # good proxy for the geometric midpoint; when the control net is short we fall
 # back to the chord midpoint.
-function _spline_midpoint(
-    ctx::ConformalRenderContext,
-    pts::Vector{<:Integer}
-)
+function _spline_midpoint(ctx::ConformalRenderContext, pts::Vector{<:Integer})
     coords = [get(ctx.point_coords, p, nothing) for p in pts]
     all(!isnothing, coords) || return nothing
     n = length(coords)
@@ -415,8 +406,7 @@ function _cached_add_spline!(
     if !isnothing(existing_curve) && !isnothing(spline_mid)
         if _midpoint_match(spline_mid, existing_curve.midpoint, ctx.vertex_merge_atol)
             ctx.stats[:hits] += 1
-            return p1 < p2 ? existing_curve.signed_tag :
-                   -existing_curve.signed_tag
+            return p1 < p2 ? existing_curve.signed_tag : -existing_curve.signed_tag
         end
         ctx.stats[:midpoint_rejections] += 1
     end
@@ -426,8 +416,7 @@ function _cached_add_spline!(
     signed_tag = p1 < p2 ? tag : -tag
     ctx.curve_cache[key] = tag
     if !isnothing(spline_mid)
-        ctx.endpoint_curve_index[(lo, hi)] =
-            EndpointCurveEntry(signed_tag, spline_mid)
+        ctx.endpoint_curve_index[(lo, hi)] = EndpointCurveEntry(signed_tag, spline_mid)
     end
     return tag
 end
@@ -797,22 +786,23 @@ _add_conformal_curve!(
 
 Render `cs` into `sm` using the ConformalRender strategy. Delegates to the
 same shared orchestrator as [`render!`](@ref); the only differences are:
-- OCC entities are emitted via the cached `_add_conformal!` path, so shared
-  boundaries between adjacent faces resolve to a single OCC edge.
-- The post-render `_fragment_and_map!` pass is skipped by default because
-  the cache already guarantees conformality on rendered geometry.
+
+  - OCC entities are emitted via the cached `_add_conformal!` path, so shared
+    boundaries between adjacent faces resolve to a single OCC edge.
+  - The post-render `_fragment_and_map!` pass is skipped by default because
+    the cache already guarantees conformality on rendered geometry.
 
 Accepts all of `render!`'s keyword arguments (`map_meta`, `postrender_ops`,
 `retained_physical_groups`, `zmap`, `gmsh_options`, `skip_postrender`,
 `auto_union`, `skip_unused_layers`, `meshing_parameters`) in addition to:
 
-- `context::ConformalRenderContext`: the edge/curve cache and merge tolerances.
-  Pass an explicit context to customize tolerances or inspect cache stats
-  after the render.
-- `fragment_backstop::Bool=false`: run the stock 3-pass `_fragment_and_map!`
-  after postrender operations. Enable when your input violates precondition 4
-  (overlapping areas at the same z), which the cache does not resolve on its
-  own. Does not recover from violations of preconditions 1–3.
+  - `context::ConformalRenderContext`: the edge/curve cache and merge tolerances.
+    Pass an explicit context to customize tolerances or inspect cache stats
+    after the render.
+  - `fragment_backstop::Bool=false`: run the stock 3-pass `_fragment_and_map!`
+    after postrender operations. Enable when your input violates precondition 4
+    (overlapping areas at the same z), which the cache does not resolve on its
+    own. Does not recover from violations of preconditions 1–3.
 
 Not supported on `GmshNative` kernel.
 """
@@ -830,10 +820,16 @@ function render_conformal!(
     return _render_orchestrator!(
         sm,
         cs;
-        emit! = (els, meta, k; zmap, points_tree, kwargs...) -> _add_conformal!(
-            context, els, meta, k; zmap=zmap, points_tree=points_tree, kwargs...
+        (emit!)=(els, meta, k; zmap, points_tree, kwargs...) -> _add_conformal!(
+            context,
+            els,
+            meta,
+            k;
+            zmap=zmap,
+            points_tree=points_tree,
+            kwargs...
         ),
-        fragment! = fragment_backstop ? _fragment_three_pass! : (_) -> nothing,
+        (fragment!)=fragment_backstop ? _fragment_three_pass! : (_) -> nothing,
         kwargs...
     )
 end

--- a/src/solidmodels/conformal/conformal.jl
+++ b/src/solidmodels/conformal/conformal.jl
@@ -44,31 +44,42 @@ geometry). If your postrender operations create new overlapping entities, use
     that curve. This is the "curve wins" rule that makes adjacent faces resolve
     to one OCC entity even when one side computed a line and the other an arc.
   - **Per-render cache**: the cache lives on a `ConformalRenderContext` struct
-    passed through calls. There is no global mutable state; nested/parallel
-    renders are safe.
+    passed through calls. There is no global mutable state — one render, one
+    context.
 
 # Preconditions
 
 For the cache to produce correct geometry:
 
- 1. **Shared endpoints ⟹ shared curve geometry.** If two faces share a boundary,
-    the CurvilinearPolygon points on both sides must resolve to the same OCC
-    point tags AND the curves spanning those tags must be the same geometric
-    curve. Callers can meet this by having both faces reference the same
-    `Paths.Segment` object (the "coordinated recovery" pattern from
-    `union2d_curved` where both operands are matched against the same
-    boolean-recovery ProvenanceRun), or by an upstream mutual-noding pass.
- 2. **No distinct co-endpoint edges.** The prefer-curve rule fuses curve
-    requests on shared endpoints into a single OCC tag. If your geometry
-    genuinely has two distinct edges spanning the same two points (say, a
-    figure-8 pinch or a self-crossing offset curve), the cache will wrongly
-    merge them.
+ 1. **Shared endpoints ⟹ shared curve geometry.** If two faces share a
+    boundary, the CurvilinearPolygon points on both sides must resolve to the
+    same OCC point tags AND the curves spanning those tags must be the same
+    geometric curve. Callers can meet this by having both faces reference the
+    same `Paths.Segment` object (the "coordinated recovery" pattern used in
+    e.g. `union2d_curved`), or by an upstream mutual-noding pass. To catch
+    accidental violations, the cache verifies a midpoint sample matches the
+    cached curve before reusing an entity, so a genuinely-different curve
+    spanning the same endpoints will fall through to a fresh OCC edge rather
+    than silently collapsing.
+ 2. **No distinct co-endpoint edges.** Even with the midpoint check, geometry
+    that has two curves crossing at both endpoints and at their midpoint (e.g.
+    a lens shape, or a self-crossing offset curve where both branches happen
+    to be mirror-symmetric across the endpoint chord) can defeat the check.
+    Ensure your input geometry does not contain such shapes.
  3. **Relaxed vertex merge is safe iff features > 500× the merge tolerance.**
     The default 2 nm merge is 500× smaller than a 1 µm minimum feature. If
-    you have features ~10× smaller, use `ConformalRenderContext(; vertex_merge_atol=…)` to tighten.
+    you have features ~10× smaller, use
+    `ConformalRenderContext(; vertex_merge_atol=…)` to tighten.
+ 4. **No overlapping areas at the same z within or across map_meta groups.**
+    The cache builds curve loops face-by-face; overlaps between faces at the
+    same z (whether within one physical group or across two) are not detected
+    or resolved. If your rendering can produce co-planar overlap, run with
+    `fragment_backstop=true` so the stock `_fragment_and_map!` pass runs
+    after postrender and reconciles the overlaps.
 
-When any of these are uncertain, `render_conformal!(..., fragment_backstop=true)`
-runs the stock 3-pass `_fragment_and_map!` after postrender as a safety net.
+`fragment_backstop=true` helps only with precondition (4). It does not
+recover from violations of (1)–(3): a wrongly-fused edge is already in the
+model before `_fragment_and_map!` runs.
 """
 module ConformalRender
 
@@ -76,31 +87,13 @@ using ..SolidModels
 using ..SolidModels:
     SolidModel,
     OpenCascade,
-    GmshNative,
     kernel,
-    gmsh,
     STP_UNIT,
     POINT_MERGE_ATOL,
-    _synchronize!,
+    _render_orchestrator!,
+    _fragment_three_pass!,
     _add_curve!,
-    _get_or_add_point!,
-    _postrender!,
-    _fragment_and_map!,
-    _get_or_add_points!,
-    _stp_float,
-    _collect_mesh_control_points!,
-    _used_group_names,
-    sizeandgrading,
-    to_primitives,
-    clear_mesh_control_points!,
-    finalize_size_fields!,
-    set_gmsh_option,
-    dimgroupdict,
-    dimtags,
-    hasgroup,
-    remove_group!,
-    reindex_physical_groups!
-import ..SolidModels: gmsh_meshsize
+    _get_or_add_point!
 import DeviceLayout
 import DeviceLayout:
     AbstractCoordinateSystem,
@@ -114,18 +107,26 @@ import DeviceLayout:
     getx,
     gety,
     points,
-    flatten,
-    elements,
-    element_metadata,
     coordinatetype,
-    onenanometer,
-    layer
+    onenanometer
 import DeviceLayout.Paths: bspline_approximation, pathlength
 import Unitful: ustrip, Length, @u_str, °
 import SpatialIndexing
 import SpatialIndexing: RTree
 
 export render_conformal!, ConformalRenderContext, add_conformal_loop!
+
+"""
+Entry in `endpoint_curve_index`: the signed OCC tag of the curve, plus a
+midpoint sample used to distinguish geometrically-different curves that
+happen to share both endpoints (e.g. two curves crossing to form a lens).
+The midpoint is stored in STP-unit coordinates in the canonical (min-endpoint
+→ max-endpoint) orientation.
+"""
+struct EndpointCurveEntry
+    signed_tag::Int
+    midpoint::NTuple{3, Float64}
+end
 
 """
     ConformalRenderContext(; vertex_merge_atol=2e-3, center_merge_atol=POINT_MERGE_ATOL)
@@ -135,20 +136,27 @@ Per-render cache and settings for a `render_conformal!` call.
   - `vertex_merge_atol` (µm): tolerance for merging polygon-vertex OCC points.
     Default `2e-3` µm = 2 nm, chosen to absorb Clipper integer-grid + float-drift
     divergence between the two sides of a shared boundary (~1.5 nm observed) while
-    staying 500× below typical minimum feature size (1 µm).
+    staying 500× below typical minimum feature size (1 µm). Also used as the
+    tolerance for the curve-midpoint geometric check.
   - `center_merge_atol` (µm): tolerance for merging arc centers and BSpline control
     points. Kept strict (`POINT_MERGE_ATOL` = 1e-9 µm = 1 pm) because relaxing here
     would corrupt curve geometry.
   - `curve_cache`: exact dedup by `(type, geometry_key…)`. Same request → same tag.
-  - `endpoint_curve_index`: `(min_pt, max_pt) → tag`, registered by arcs and
-    splines. Enforces the "prefer curve" invariant.
-  - `stats`: telemetry (hits, misses, arcs, splines, chord fallbacks).
+  - `endpoint_curve_index`: `(min_pt, max_pt) → EndpointCurveEntry`, registered
+    by arcs and splines. Enforces the "prefer curve" invariant subject to a
+    midpoint match.
+  - `point_coords`: `tag → (x, y, z)`, populated for every point emitted through
+    the cached point helpers. Used to compute curve midpoints without a
+    Gmsh round-trip.
+  - `stats`: telemetry (hits, misses, arcs, splines, chord fallbacks,
+    midpoint rejections).
 """
 mutable struct ConformalRenderContext
     vertex_merge_atol::Float64
     center_merge_atol::Float64
     curve_cache::Dict{Tuple, Int}
-    endpoint_curve_index::Dict{Tuple{Int, Int}, Int}
+    endpoint_curve_index::Dict{Tuple{Int, Int}, EndpointCurveEntry}
+    point_coords::Dict{Int, NTuple{3, Float64}}
     stats::Dict{Symbol, Int}
 end
 
@@ -159,15 +167,23 @@ ConformalRenderContext(;
     vertex_merge_atol,
     center_merge_atol,
     Dict{Tuple, Int}(),
-    Dict{Tuple{Int, Int}, Int}(),
+    Dict{Tuple{Int, Int}, EndpointCurveEntry}(),
+    Dict{Int, NTuple{3, Float64}}(),
     Dict{Symbol, Int}(
         :hits => 0,
         :misses => 0,
         :arcs => 0,
         :splines => 0,
-        :chord_fallbacks => 0
+        :chord_fallbacks => 0,
+        :midpoint_rejections => 0
     )
 )
+
+# Return true if two midpoints agree to within the context's vertex tolerance.
+_midpoint_match(a::NTuple{3, Float64}, b::NTuple{3, Float64}, atol::Float64) =
+    abs(a[1] - b[1]) <= atol &&
+    abs(a[2] - b[2]) <= atol &&
+    abs(a[3] - b[3]) <= atol
 
 # ─── Point merge ─────────────────────────────────────────────────────────────
 
@@ -181,8 +197,13 @@ function _cached_point_relaxed!(
     z::Float64,
     points_tree
 )
-    points_tree === nothing && return k.add_point(x, y, z)
-    return _get_or_add_point!(k, x, y, z, points_tree; atol=ctx.vertex_merge_atol)
+    tag = isnothing(points_tree) ? k.add_point(x, y, z) :
+          _get_or_add_point!(k, x, y, z, points_tree; atol=ctx.vertex_merge_atol)
+    # Record coords for later midpoint computation; the tag returned by
+    # `_get_or_add_point!` may correspond to a previously-inserted nearby point,
+    # so `get!` preserves the first-writer coords rather than overwriting.
+    get!(ctx.point_coords, tag, (x, y, z))
+    return tag
 end
 
 # Strict point insert. Used for arc centers and BSpline control points where
@@ -195,27 +216,50 @@ function _cached_point_strict!(
     z::Float64,
     points_tree
 )
-    points_tree === nothing && return k.add_point(x, y, z)
-    return _get_or_add_point!(k, x, y, z, points_tree; atol=ctx.center_merge_atol)
+    tag = isnothing(points_tree) ? k.add_point(x, y, z) :
+          _get_or_add_point!(k, x, y, z, points_tree; atol=ctx.center_merge_atol)
+    get!(ctx.point_coords, tag, (x, y, z))
+    return tag
 end
 
 # ─── Edge/curve cache ────────────────────────────────────────────────────────
 
-# Add a line, dedup on unordered endpoint pair.
+# Add a line, dedup on unordered endpoint pair. A cached curve on the same
+# endpoints (arc or spline) is reused ONLY if its stored midpoint matches the
+# line's midpoint at `vertex_merge_atol` — this prevents fusing genuinely
+# different curves that happen to share endpoints (see precondition 2).
 function _cached_add_line!(k, ctx::ConformalRenderContext, p1::Integer, p2::Integer)
     p1 == p2 && error("degenerate edge: p1 == p2 == $p1")
     lo, hi = minmax(p1, p2)
     key = (:line, lo, hi)
     existing = get(ctx.curve_cache, key, nothing)
-    if existing !== nothing
+    if !isnothing(existing)
         ctx.stats[:hits] += 1
         return p1 < p2 ? existing : -existing
     end
-    # Prefer-curve: a curve already spans these endpoints → reuse it.
+    # Prefer-curve: a curve already spans these endpoints → reuse only if the
+    # midpoint agrees. A line's midpoint is the average of its endpoints.
     existing_curve = get(ctx.endpoint_curve_index, (lo, hi), nothing)
-    if existing_curve !== nothing
-        ctx.stats[:hits] += 1
-        return p1 < p2 ? existing_curve : -existing_curve
+    if !isnothing(existing_curve)
+        lo_xyz = get(ctx.point_coords, lo, nothing)
+        hi_xyz = get(ctx.point_coords, hi, nothing)
+        if !isnothing(lo_xyz) && !isnothing(hi_xyz)
+            line_mid = (
+                0.5 * (lo_xyz[1] + hi_xyz[1]),
+                0.5 * (lo_xyz[2] + hi_xyz[2]),
+                0.5 * (lo_xyz[3] + hi_xyz[3])
+            )
+            if _midpoint_match(line_mid, existing_curve.midpoint, ctx.vertex_merge_atol)
+                ctx.stats[:hits] += 1
+                return p1 < p2 ? existing_curve.signed_tag :
+                       -existing_curve.signed_tag
+            end
+            ctx.stats[:midpoint_rejections] += 1
+        else
+            # Missing coord entry — err on the side of not fusing so we don't
+            # silently collapse curves whose midpoints we can't verify.
+            ctx.stats[:midpoint_rejections] += 1
+        end
     end
     ctx.stats[:misses] += 1
     tag = k.addLine(p1, p2)
@@ -223,8 +267,36 @@ function _cached_add_line!(k, ctx::ConformalRenderContext, p1::Integer, p2::Inte
     return tag
 end
 
-# Add a circle arc. Registers in the endpoint index so subsequent line requests
-# on the same endpoints reuse this arc (curve wins).
+# Midpoint of a circular arc (|α| < 180°, guaranteed by the caller-side arc
+# splitting) whose endpoints are on a circle centered at `c` with radius
+# `r = |p1 - c|`. Returned in the (min-endpoint, max-endpoint) orientation so
+# it can be compared against a stored midpoint regardless of traversal
+# direction.
+function _arc_midpoint(
+    p1_xyz::NTuple{3, Float64},
+    p2_xyz::NTuple{3, Float64},
+    center_xyz::NTuple{3, Float64}
+)
+    cx, cy, cz = center_xyz
+    chord_mid = (
+        0.5 * (p1_xyz[1] + p2_xyz[1]),
+        0.5 * (p1_xyz[2] + p2_xyz[2]),
+        0.5 * (p1_xyz[3] + p2_xyz[3])
+    )
+    dx = chord_mid[1] - cx
+    dy = chord_mid[2] - cy
+    dz = chord_mid[3] - cz
+    n = sqrt(dx * dx + dy * dy + dz * dz)
+    r = sqrt(
+        (p1_xyz[1] - cx)^2 + (p1_xyz[2] - cy)^2 + (p1_xyz[3] - cz)^2
+    )
+    n == 0.0 && return chord_mid  # semicircle degenerate; caller should split
+    return (cx + r * dx / n, cy + r * dy / n, cz + r * dz / n)
+end
+
+# Add a circle arc. Registers in the endpoint index so subsequent requests on
+# the same endpoints can reuse this arc — but only when the requester's own
+# midpoint matches, so genuinely different curves are not silently fused.
 function _cached_add_arc!(
     k,
     ctx::ConformalRenderContext,
@@ -236,32 +308,54 @@ function _cached_add_arc!(
     # Exact arc (center in key): the same Turn requested again → same tag.
     key = (:arc, lo, center, hi)
     existing = get(ctx.curve_cache, key, nothing)
-    if existing !== nothing
+    if !isnothing(existing)
         ctx.stats[:hits] += 1
         return p1 < p2 ? existing : -existing
     end
-    # Any curve already on these endpoints → reuse (handles float-jittered
-    # center of the coordinated Turn applied to the other side).
+    p1_xyz = get(ctx.point_coords, p1, nothing)
+    p2_xyz = get(ctx.point_coords, p2, nothing)
+    center_xyz = get(ctx.point_coords, center, nothing)
+    have_coords =
+        !isnothing(p1_xyz) && !isnothing(p2_xyz) && !isnothing(center_xyz)
+    arc_mid = have_coords ? _arc_midpoint(p1_xyz, p2_xyz, center_xyz) : nothing
+    # Any curve already on these endpoints → reuse only if its midpoint
+    # matches this arc's midpoint.
     existing_curve = get(ctx.endpoint_curve_index, (lo, hi), nothing)
-    if existing_curve !== nothing
-        ctx.stats[:hits] += 1
-        return p1 < p2 ? existing_curve : -existing_curve
+    if !isnothing(existing_curve) && !isnothing(arc_mid)
+        if _midpoint_match(arc_mid, existing_curve.midpoint, ctx.vertex_merge_atol)
+            ctx.stats[:hits] += 1
+            return p1 < p2 ? existing_curve.signed_tag :
+                   -existing_curve.signed_tag
+        end
+        ctx.stats[:midpoint_rejections] += 1
     end
     # Conformality backstop: a chord was already created on these endpoints
     # (the other side rendered this boundary as a line because it did not
-    # recover the arc). Reuse the chord so both faces share one tag; accuracy
-    # is lost in this one-sided cell only.
+    # recover the arc). Reuse the chord so both faces share one tag ONLY when
+    # the chord and arc midpoints agree (very tight arcs, r/chord ≈ 1).
+    # Otherwise reusing the chord silently substitutes a line for an arc.
     existing_line = get(ctx.curve_cache, (:line, lo, hi), nothing)
-    if existing_line !== nothing
-        ctx.stats[:hits] += 1
-        return p1 < p2 ? existing_line : -existing_line
+    if !isnothing(existing_line) && !isnothing(arc_mid) && have_coords
+        chord_mid = (
+            0.5 * (p1_xyz[1] + p2_xyz[1]),
+            0.5 * (p1_xyz[2] + p2_xyz[2]),
+            0.5 * (p1_xyz[3] + p2_xyz[3])
+        )
+        if _midpoint_match(arc_mid, chord_mid, ctx.vertex_merge_atol)
+            ctx.stats[:hits] += 1
+            ctx.stats[:chord_fallbacks] += 1
+            return p1 < p2 ? existing_line : -existing_line
+        end
     end
     ctx.stats[:misses] += 1
     ctx.stats[:arcs] += 1
     tag = k.add_circle_arc(p1, center, p2, -1)
     signed_tag = p1 < p2 ? tag : -tag
     ctx.curve_cache[key] = signed_tag
-    ctx.endpoint_curve_index[(lo, hi)] = signed_tag
+    if !isnothing(arc_mid)
+        ctx.endpoint_curve_index[(lo, hi)] =
+            EndpointCurveEntry(signed_tag, arc_mid)
+    end
     return tag
 end
 
@@ -269,6 +363,32 @@ end
 # reversal; and participates in the prefer-curve invariant via
 # `endpoint_curve_index` — a later request for a line (or arc) on the same
 # endpoints will reuse this spline instead of creating a duplicate edge.
+# Approximate midpoint of an interpolating BSpline from its control points.
+# For our (endpoint-anchored) BSplines the middle interior control point is a
+# good proxy for the geometric midpoint; when the control net is short we fall
+# back to the chord midpoint.
+function _spline_midpoint(
+    ctx::ConformalRenderContext,
+    pts::Vector{<:Integer}
+)
+    coords = [get(ctx.point_coords, p, nothing) for p in pts]
+    all(!isnothing, coords) || return nothing
+    n = length(coords)
+    if n == 2
+        return (
+            0.5 * (coords[1][1] + coords[2][1]),
+            0.5 * (coords[1][2] + coords[2][2]),
+            0.5 * (coords[1][3] + coords[2][3])
+        )
+    elseif isodd(n)
+        return coords[(n + 1) ÷ 2]
+    else
+        a = coords[n ÷ 2]
+        b = coords[n ÷ 2 + 1]
+        return (0.5 * (a[1] + b[1]), 0.5 * (a[2] + b[2]), 0.5 * (a[3] + b[3]))
+    end
+end
+
 function _cached_add_spline!(
     k,
     ctx::ConformalRenderContext,
@@ -279,29 +399,36 @@ function _cached_add_spline!(
     lo, hi = minmax(p1, p2)
     key = (:bspline, pts...)
     existing = get(ctx.curve_cache, key, nothing)
-    if existing !== nothing
+    if !isnothing(existing)
         ctx.stats[:hits] += 1
         return existing
     end
     rkey = (:bspline, reverse(pts)...)
     existing_r = get(ctx.curve_cache, rkey, nothing)
-    if existing_r !== nothing
+    if !isnothing(existing_r)
         ctx.stats[:hits] += 1
         return -existing_r
     end
-    # Any curve already on these endpoints → reuse. Handles a spline requested
-    # after an arc (or the reverse) on the same shared boundary.
+    # Any curve already on these endpoints → reuse only if the midpoint agrees.
+    spline_mid = _spline_midpoint(ctx, pts)
     existing_curve = get(ctx.endpoint_curve_index, (lo, hi), nothing)
-    if existing_curve !== nothing
-        ctx.stats[:hits] += 1
-        return p1 < p2 ? existing_curve : -existing_curve
+    if !isnothing(existing_curve) && !isnothing(spline_mid)
+        if _midpoint_match(spline_mid, existing_curve.midpoint, ctx.vertex_merge_atol)
+            ctx.stats[:hits] += 1
+            return p1 < p2 ? existing_curve.signed_tag :
+                   -existing_curve.signed_tag
+        end
+        ctx.stats[:midpoint_rejections] += 1
     end
     ctx.stats[:misses] += 1
     ctx.stats[:splines] += 1
     tag = k.addSpline(pts, -1, tangents)
     signed_tag = p1 < p2 ? tag : -tag
     ctx.curve_cache[key] = tag
-    ctx.endpoint_curve_index[(lo, hi)] = signed_tag
+    if !isnothing(spline_mid)
+        ctx.endpoint_curve_index[(lo, hi)] =
+            EndpointCurveEntry(signed_tag, spline_mid)
+    end
     return tag
 end
 
@@ -638,9 +765,13 @@ function _add_conformal_curve!(
     return tags
 end
 
-# Fallback: any segment type not specialized above (e.g. Straight) is handled
-# by DL's stock `_add_curve!` — those types don't benefit from caching (they're
-# already exact-and-cheap in stock DL).
+# Unsupported segment types fail loud rather than routing through the stock
+# `_add_curve!` — the stock fallback would BSpline-approximate anything it
+# received, including a Straight, and the resulting edge would not participate
+# in the cache and would break conformality with the caching side of a shared
+# boundary. Straights should never reach here because they do not appear in
+# `CurvilinearPolygon` unless the caller has hand-constructed one; any other
+# `Paths.Segment` subtype landing here is a real gap we want visible.
 _add_conformal_curve!(
     ctx::ConformalRenderContext,
     endpoints,
@@ -649,32 +780,39 @@ _add_conformal_curve!(
     z,
     points_tree;
     kwargs...
-) = _add_curve!(endpoints, seg, k, z; kwargs...)
+) = throw(
+    ArgumentError(
+        "ConformalRender: unsupported curve segment type $(typeof(seg)); " *
+        "specialize `_add_conformal_curve!` for this type or preprocess it to " *
+        "one of `Paths.Turn`, `Paths.BSpline`, or `Paths.OffsetSegment`."
+    )
+)
 
 # ─── Public entry point ──────────────────────────────────────────────────────
 
 """
     render_conformal!(sm::SolidModel, cs::AbstractCoordinateSystem;
         context=ConformalRenderContext(),
-        map_meta=layer, postrender_ops=[], retained_physical_groups=[],
-        zmap=(_)->zero(T), gmsh_options=..., skip_postrender=false,
-        auto_union=false, skip_unused_layers=false,
         fragment_backstop=false, kwargs...)
 
-Render `cs` into `sm` using the ConformalRender strategy. Same semantics as
-[`render!`](@ref) but without the post-render `_fragment_and_map!` pass by
-default.
+Render `cs` into `sm` using the ConformalRender strategy. Delegates to the
+same shared orchestrator as [`render!`](@ref); the only differences are:
+- OCC entities are emitted via the cached `_add_conformal!` path, so shared
+  boundaries between adjacent faces resolve to a single OCC edge.
+- The post-render `_fragment_and_map!` pass is skipped by default because
+  the cache already guarantees conformality on rendered geometry.
 
-The `context::ConformalRenderContext` holds the edge/curve cache and merge
-tolerances; pass an explicit context if you need custom tolerances or want to
-inspect cache statistics after the render.
+Accepts all of `render!`'s keyword arguments (`map_meta`, `postrender_ops`,
+`retained_physical_groups`, `zmap`, `gmsh_options`, `skip_postrender`,
+`auto_union`, `skip_unused_layers`, `meshing_parameters`) in addition to:
 
-`fragment_backstop=true` runs the stock 3-pass `_fragment_and_map!` sequence
-after postrender operations. Faces already resolved to a single OCC entity
-by the cache pass through as no-ops, so this is safe to combine with
-cache-resolved regions. Enable when the input geometry may not fully meet
-the "shared endpoints ⟹ shared curve" precondition, or when `postrender_ops`
-introduce overlapping entities that need reconciliation.
+- `context::ConformalRenderContext`: the edge/curve cache and merge tolerances.
+  Pass an explicit context to customize tolerances or inspect cache stats
+  after the render.
+- `fragment_backstop::Bool=false`: run the stock 3-pass `_fragment_and_map!`
+  after postrender operations. Enable when your input violates precondition 4
+  (overlapping areas at the same z), which the cache does not resolve on its
+  own. Does not recover from violations of preconditions 1–3.
 
 Not supported on `GmshNative` kernel.
 """
@@ -682,14 +820,6 @@ function render_conformal!(
     sm::SolidModel,
     cs::AbstractCoordinateSystem{T};
     context::ConformalRenderContext=ConformalRenderContext(),
-    map_meta=layer,
-    postrender_ops=[],
-    retained_physical_groups=[],
-    zmap=(_) -> zero(T),
-    gmsh_options=Dict{String, Union{String, Int, Float64}}(),
-    skip_postrender::Bool=false,
-    auto_union::Bool=false,
-    skip_unused_layers::Bool=false,
     fragment_backstop::Bool=false,
     kwargs...
 ) where {T}
@@ -697,99 +827,15 @@ function render_conformal!(
         "render_conformal! is only implemented for OpenCascade kernel; " *
         "got $(typeof(kernel(sm))). Use render! instead."
     )
-    gmsh.model.set_current(SolidModels.name(sm))
-    set_gmsh_option(gmsh_options)
-
-    flat = flatten(cs)
-    clear_mesh_control_points!()
-    points_tree = RTree{Float64, 3}(Int32)
-
-    used_names = if skip_unused_layers
-        _used_group_names(postrender_ops, retained_physical_groups)
-    else
-        nothing
-    end
-
-    for meta in unique(element_metadata(flat))
-        mapped_name = map_meta(meta)
-        isnothing(mapped_name) && continue
-        if !isnothing(used_names) &&
-           string(mapped_name) ∉ used_names &&
-           string(layer(meta)) ∉ used_names
-            continue
-        end
-        idx = (element_metadata(flat) .== meta)
-        els = to_primitives.(sm, elements(flat)[idx]; kwargs...)
-        meshsizes = sizeandgrading.(elements(flat)[idx]; kwargs...)
-
-        group_dimtags_unflattened = _add_conformal!(
-            context,
-            els,
-            meta,
-            kernel(sm);
-            zmap=zmap,
-            points_tree=points_tree,
-            kwargs...
-        )
-
-        group_dimtags = reduce(vcat, group_dimtags_unflattened, init=Tuple{Int32, Int32}[])
-        for dim in unique(first.(group_dimtags))
-            if hasgroup(sm, mapped_name, dim)
-                append!(group_dimtags, dimtags(sm[mapped_name, dim]))
-            end
-        end
-        sm[mapped_name] = group_dimtags
-
-        z_of_meta = _stp_float(zmap(meta))
-        for (prims, (h, α)) in zip(els, meshsizes)
-            _collect_mesh_control_points!(prims, h, α, z_of_meta)
-        end
-    end
-
-    _synchronize!(sm)
-    finalize_size_fields!()
-    _synchronize!(sm)
-    skip_postrender && return nothing
-
-    if auto_union
-        auto_union_ops = Tuple[]
-        for groupname in collect(keys(dimgroupdict(sm, 2)))
-            push!(auto_union_ops, (groupname, SolidModels.union_geom!, (groupname, 2)))
-        end
-        _postrender!(sm, auto_union_ops)
-        _synchronize!(sm)
-    end
-    _postrender!(sm, postrender_ops)
-    _synchronize!(sm)
-
-    # By default, no `_fragment_and_map!` pass: the conformal cache already
-    # deduplicates shared edges during render. But if the input geometry
-    # doesn't fully meet the cache's preconditions (see "Failure modes for the
-    # 'prefer curve' invariant" in the module docstring), or if `postrender_ops`
-    # introduce overlapping entities that need reconciliation, users can opt
-    # into the stock 3-pass fragment as a safety net via `fragment_backstop=true`.
-    # Faces already resolved to a single OCC entity by the cache pass through
-    # fragment as no-ops, so this is compatible with cache-resolved regions.
-    if fragment_backstop
-        _fragment_and_map!(sm, [0, 1])
-        _fragment_and_map!(sm, [1, 2])
-        _fragment_and_map!(sm, [2, 3])
-    end
-
-    gmsh.model.mesh.setSizeCallback(gmsh_meshsize)
-
-    if !isempty(retained_physical_groups)
-        for d = 0:3
-            retain_groups = getindex.(filter(x -> x[2] == d, retained_physical_groups), 1)
-            all_groups = keys(dimgroupdict(sm, d))
-            for k in setdiff(all_groups, retain_groups)
-                remove_group!(sm[k, d], remove_entities=false)
-            end
-        end
-        reindex_physical_groups!(sm)
-    end
-
-    return _synchronize!(sm)
+    return _render_orchestrator!(
+        sm,
+        cs;
+        emit! = (els, meta, k; zmap, points_tree, kwargs...) -> _add_conformal!(
+            context, els, meta, k; zmap=zmap, points_tree=points_tree, kwargs...
+        ),
+        fragment! = fragment_backstop ? _fragment_three_pass! : (_) -> nothing,
+        kwargs...
+    )
 end
 
 end # module ConformalRender

--- a/src/solidmodels/render.jl
+++ b/src/solidmodels/render.jl
@@ -919,11 +919,16 @@ function render!(
     return _render_orchestrator!(
         sm,
         cs;
-        emit! = (els, meta, k; zmap, points_tree, kwargs...) ->
+        (emit!)=(els, meta, k; zmap, points_tree, kwargs...) ->
             _add_to_current_solidmodel!(
-                els, meta, k; zmap=zmap, points_tree=points_tree, kwargs...
+                els,
+                meta,
+                k;
+                zmap=zmap,
+                points_tree=points_tree,
+                kwargs...
             ),
-        fragment! = _fragment_three_pass!,
+        (fragment!)=_fragment_three_pass!,
         map_meta=map_meta,
         postrender_ops=postrender_ops,
         retained_physical_groups=retained_physical_groups,
@@ -1016,14 +1021,8 @@ function _render_orchestrator!(
         meshsizes = sizeandgrading.(elements(flat)[idx]; kwargs...)
 
         # Add to model using kernel via the strategy-specific emit function.
-        group_dimtags_unflattened = emit!(
-            els,
-            meta,
-            kernel(sm);
-            zmap=zmap,
-            points_tree=points_tree,
-            kwargs...
-        )
+        group_dimtags_unflattened =
+            emit!(els, meta, kernel(sm); zmap=zmap, points_tree=points_tree, kwargs...)
 
         group_dimtags = reduce(vcat, group_dimtags_unflattened, init=Tuple{Int32, Int32}[])
         # If group already exists, add to it

--- a/src/solidmodels/render.jl
+++ b/src/solidmodels/render.jl
@@ -916,6 +916,62 @@ function render!(
     skip_unused_layers=false,
     kwargs...
 ) where {T}
+    return _render_orchestrator!(
+        sm,
+        cs;
+        emit! = (els, meta, k; zmap, points_tree, kwargs...) ->
+            _add_to_current_solidmodel!(
+                els, meta, k; zmap=zmap, points_tree=points_tree, kwargs...
+            ),
+        fragment! = _fragment_three_pass!,
+        map_meta=map_meta,
+        postrender_ops=postrender_ops,
+        retained_physical_groups=retained_physical_groups,
+        zmap=zmap,
+        gmsh_options=gmsh_options,
+        meshing_parameters=meshing_parameters,
+        skip_postrender=skip_postrender,
+        auto_union=auto_union,
+        skip_unused_layers=skip_unused_layers,
+        kwargs...
+    )
+end
+
+# Adjacent-dimension pairs avoid both exterior boundary loss ([3,2,1], PR #145)
+# and stale OCC bindings when combined ([1,2,3], Gmsh #3446 / issue #172).
+function _fragment_three_pass!(sm::SolidModel)
+    _fragment_and_map!(sm, [0, 1])
+    _fragment_and_map!(sm, [1, 2])
+    _fragment_and_map!(sm, [2, 3])
+    return sm
+end
+
+# Shared orchestrator body called by both `render!` and `render_conformal!`.
+# The two entry points differ only in:
+#   - `emit!(els, meta, k; zmap, points_tree, kwargs...)`: how OCC entities are
+#     added for a metadata group. Stock uses `_add_to_current_solidmodel!`;
+#     conformal wraps `_add_conformal!` closing over the caller's context.
+#   - `fragment!(sm)`: post-postrender fragment pass. Stock always runs the
+#     three-pass `_fragment_and_map!`; conformal only runs it when
+#     `fragment_backstop=true`.
+# Every other step (gmsh setup, metadata loop, control-point collection,
+# postrender, retained-group cleanup, final synchronize) is common.
+function _render_orchestrator!(
+    sm::SolidModel,
+    cs::AbstractCoordinateSystem{T};
+    emit!,
+    fragment!,
+    map_meta=layer,
+    postrender_ops=[],
+    retained_physical_groups=[],
+    zmap=(_) -> zero(T),
+    gmsh_options=Dict{String, Union{String, Int, Float64}}(),
+    meshing_parameters::Union{Nothing, MeshingParameters}=nothing,
+    skip_postrender=false,
+    auto_union=false,
+    skip_unused_layers=false,
+    kwargs...
+) where {T}
     gmsh.model.set_current(name(sm))
 
     if !isnothing(meshing_parameters)
@@ -959,8 +1015,8 @@ function render!(
         els = to_primitives.(sm, elements(flat)[idx]; kwargs...)
         meshsizes = sizeandgrading.(elements(flat)[idx]; kwargs...)
 
-        # Add to model using kernel
-        group_dimtags_unflattened = _add_to_current_solidmodel!(
+        # Add to model using kernel via the strategy-specific emit function.
+        group_dimtags_unflattened = emit!(
             els,
             meta,
             kernel(sm);
@@ -1007,11 +1063,7 @@ function render!(
     _postrender!(sm, postrender_ops)
     _synchronize!(sm)
     # Get rid of redundant entities and update groups accordingly.
-    # Adjacent-dimension pairs avoid both exterior boundary loss ([3,2,1], PR #145)
-    # and stale OCC bindings when combined ([1,2,3], Gmsh #3446 / issue #172).
-    _fragment_and_map!(sm, [0, 1])
-    _fragment_and_map!(sm, [1, 2])
-    _fragment_and_map!(sm, [2, 3])
+    fragment!(sm)
 
     # Pass in call back function for meshing against the vertices found previously.
     gmsh.model.mesh.setSizeCallback(gmsh_meshsize)

--- a/src/solidmodels/solidmodels.jl
+++ b/src/solidmodels/solidmodels.jl
@@ -438,5 +438,9 @@ end
 
 include("render.jl")
 include("postrender.jl")
+include("conformal/conformal.jl")
+
+using .ConformalRender: render_conformal!, ConformalRenderContext, add_conformal_loop!
+export render_conformal!, ConformalRenderContext, add_conformal_loop!
 
 end # module

--- a/test/test_conformal_render.jl
+++ b/test/test_conformal_render.jl
@@ -100,6 +100,25 @@
         gmsh.finalize()
     end
 
+    @testset "render_conformal! fragment_backstop kwarg" begin
+        cs = CoordinateSystem("bs", nm)
+        place!(cs, Rectangle(Point(0.0μm, 0.0μm), Point(10.0μm, 10.0μm)), :l1)
+        place!(cs, Rectangle(Point(10.0μm, 0.0μm), Point(20.0μm, 10.0μm)), :l1)
+
+        # Default: no backstop
+        sm1 = SolidModel("bs_default"; overwrite=true)
+        render_conformal!(sm1, cs)
+        @test hasgroup(sm1, "l1", 2)
+
+        # With backstop: same result (backstop runs as no-op when the cache
+        # already produced conformal geometry).
+        sm2 = SolidModel("bs_on"; overwrite=true)
+        render_conformal!(sm2, cs; fragment_backstop=true)
+        @test hasgroup(sm2, "l1", 2)
+
+        gmsh.finalize()
+    end
+
     @testset "render_conformal! rejects GmshNative kernel" begin
         sm_native = SolidModel("native", SolidModels.GmshNative(); overwrite=true)
         cs = CoordinateSystem("dummy", nm)

--- a/test/test_conformal_render.jl
+++ b/test/test_conformal_render.jl
@@ -137,11 +137,7 @@
         points_tree = SpatialIndexing.RTree{Float64, 3}(Int32)
 
         R = 100.0μm
-        pp = [
-            Point(0.0μm, 0.0μm),
-            Point(R, 0.0μm),
-            Point(0.0μm, R)
-        ]
+        pp = [Point(0.0μm, 0.0μm), Point(R, 0.0μm), Point(0.0μm, R)]
         turn = Paths.Turn(90°, R, α0=90°, p0=pp[2])
         cp = CurvilinearPolygon(pp, [turn], [2])
         loop = add_conformal_loop!(ctx, cp, k, 0.0μm; points_tree)
@@ -158,11 +154,7 @@
         points_tree = SpatialIndexing.RTree{Float64, 3}(Int32)
 
         R = 50.0μm
-        pp = [
-            Point(0.0μm, 0.0μm),
-            Point(R, 0.0μm),
-            Point(-R, 0.0μm)
-        ]
+        pp = [Point(0.0μm, 0.0μm), Point(R, 0.0μm), Point(-R, 0.0μm)]
         turn = Paths.Turn(180°, R, α0=90°, p0=pp[2])
         cp = CurvilinearPolygon(pp, [turn], [2])
         loop = add_conformal_loop!(ctx, cp, k, 0.0μm; points_tree)
@@ -253,7 +245,8 @@
         render_conformal!(sm, cs; zmap=(_) -> z_target)
         @test hasgroup(sm, "l1", 2)
         # Bounding-box z should reflect the zmap.
-        _, _, zmin, _, _, zmax = gmsh.model.occ.getBoundingBox(2, gmsh.model.occ.getEntities(2)[1][2])
+        _, _, zmin, _, _, zmax =
+            gmsh.model.occ.getBoundingBox(2, gmsh.model.occ.getEntities(2)[1][2])
         @test isapprox(zmin, ustrip(SolidModels.STP_UNIT, z_target); atol=1e-6)
         @test isapprox(zmax, ustrip(SolidModels.STP_UNIT, z_target); atol=1e-6)
         gmsh.finalize()

--- a/test/test_conformal_render.jl
+++ b/test/test_conformal_render.jl
@@ -8,7 +8,8 @@
         coordinatetype,
         onenanometer,
         ClippedPolygon,
-        difference2d
+        difference2d,
+        Paths
     using DeviceLayout.Polygons: Rounded
     using DeviceLayout.Curvilinear: CurvilinearPolygon, CurvilinearRegion
     using DeviceLayout.SolidModels:
@@ -124,6 +125,137 @@
         cs = CoordinateSystem("dummy", nm)
         place!(cs, Rectangle(Point(0.0μm, 0.0μm), Point(1.0μm, 1.0μm)), :l1)
         @test_throws ErrorException render_conformal!(sm_native, cs)
+        gmsh.finalize()
+    end
+
+    @testset "add_conformal_loop! with Paths.Turn (short arc)" begin
+        # Direct exercise of _add_conformal_curve!(Paths.Turn) — a 90° arc.
+        sm = SolidModel("turn_short"; overwrite=true)
+        k = kernel(sm)
+        ctx = ConformalRenderContext()
+        import SpatialIndexing
+        points_tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+
+        R = 100.0μm
+        pp = [
+            Point(0.0μm, 0.0μm),
+            Point(R, 0.0μm),
+            Point(0.0μm, R)
+        ]
+        turn = Paths.Turn(90°, R, α0=90°, p0=pp[2])
+        cp = CurvilinearPolygon(pp, [turn], [2])
+        loop = add_conformal_loop!(ctx, cp, k, 0.0μm; points_tree)
+        @test loop isa Integer
+        gmsh.finalize()
+    end
+
+    @testset "add_conformal_loop! with Paths.Turn (large arc)" begin
+        # Turn with |α| >= 180° triggers the multi-segment arc path.
+        sm = SolidModel("turn_large"; overwrite=true)
+        k = kernel(sm)
+        ctx = ConformalRenderContext()
+        import SpatialIndexing
+        points_tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+
+        R = 50.0μm
+        pp = [
+            Point(0.0μm, 0.0μm),
+            Point(R, 0.0μm),
+            Point(-R, 0.0μm)
+        ]
+        turn = Paths.Turn(180°, R, α0=90°, p0=pp[2])
+        cp = CurvilinearPolygon(pp, [turn], [2])
+        loop = add_conformal_loop!(ctx, cp, k, 0.0μm; points_tree)
+        @test loop isa Integer
+        gmsh.finalize()
+    end
+
+    @testset "add_conformal_loop! with Paths.BSpline" begin
+        # Exercise _add_conformal_curve!(Paths.BSpline).
+        sm = SolidModel("bspline"; overwrite=true)
+        k = kernel(sm)
+        ctx = ConformalRenderContext()
+        import SpatialIndexing
+        points_tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+
+        pp = [
+            Point(0.0μm, 0.0μm),
+            Point(100.0μm, 0.0μm),
+            Point(100.0μm, 100.0μm),
+            Point(0.0μm, 100.0μm)
+        ]
+        spline_pts = [pp[2], Point(150.0μm, 50.0μm), pp[3]]
+        t0 = Point(1.0μm, 0.0μm)
+        t1 = Point(-1.0μm, 0.0μm)
+        seg = Paths.BSpline(spline_pts, t0, t1)
+        cp = CurvilinearPolygon(pp, [seg], [2])
+        loop = add_conformal_loop!(ctx, cp, k, 0.0μm; points_tree)
+        @test loop isa Integer
+        gmsh.finalize()
+    end
+
+    @testset "render_conformal! with CurvilinearRegion (rounded rect)" begin
+        # A Rounded(Rectangle) renders to a CurvilinearRegion — this exercises
+        # _add_conformal!(CurvilinearRegion) and CurvilinearRegion's
+        # exterior+holes assembly path.
+        cs = CoordinateSystem("rounded", nm)
+        rect = Rectangle(Point(0.0μm, 0.0μm), Point(50.0μm, 30.0μm))
+        place!(cs, Rounded(5.0μm)(rect), :l1)
+
+        sm = SolidModel("cvr"; overwrite=true)
+        render_conformal!(sm, cs)
+        @test hasgroup(sm, "l1", 2)
+        # A rounded rectangle should produce a single surface with curved edges.
+        @test length(gmsh.model.occ.getEntities(2)) >= 1
+        gmsh.finalize()
+    end
+
+    @testset "render_conformal! with ClippedPolygon (holes)" begin
+        # Exercise CurvilinearRegion's `holes` path via a ClippedPolygon.
+        cs = CoordinateSystem("holed", nm)
+        outer = Rectangle(Point(0.0μm, 0.0μm), Point(100.0μm, 100.0μm))
+        inner = Rectangle(Point(30.0μm, 30.0μm), Point(70.0μm, 70.0μm))
+        clipped = difference2d(outer, inner)
+        place!(cs, clipped, :l1)
+
+        sm = SolidModel("holed"; overwrite=true)
+        render_conformal!(sm, cs)
+        @test hasgroup(sm, "l1", 2)
+        gmsh.finalize()
+    end
+
+    @testset "render_conformal! preserves shared vertex identity" begin
+        # Two adjacent rectangles → the shared edge should resolve to a single
+        # OCC edge tag. If dedup works, the total edge count is < 8 (would be
+        # 8 if the shared edge duplicated).
+        cs = CoordinateSystem("shared", nm)
+        place!(cs, Rectangle(Point(0.0μm, 0.0μm), Point(10.0μm, 10.0μm)), :l1)
+        place!(cs, Rectangle(Point(10.0μm, 0.0μm), Point(20.0μm, 10.0μm)), :l1)
+
+        ctx = ConformalRenderContext()
+        sm = SolidModel("shared"; overwrite=true)
+        render_conformal!(sm, cs; context=ctx)
+        # Each rect contributes 4 edges; a duplicated shared edge would give 8.
+        # With dedup, the shared edge is 1, so total = 7.
+        @test length(gmsh.model.occ.getEntities(1)) == 7
+        # The cache should have registered at least one hit for the shared edge.
+        @test ctx.stats[:hits] >= 1
+        gmsh.finalize()
+    end
+
+    @testset "render_conformal! zmap positions surfaces at nonzero z" begin
+        # Exercise the zmap kwarg on render_conformal!.
+        cs = CoordinateSystem("zmap", nm)
+        place!(cs, Rectangle(Point(0.0μm, 0.0μm), Point(10.0μm, 10.0μm)), :l1)
+
+        sm = SolidModel("zmap"; overwrite=true)
+        z_target = 5.0μm
+        render_conformal!(sm, cs; zmap=(_) -> z_target)
+        @test hasgroup(sm, "l1", 2)
+        # Bounding-box z should reflect the zmap.
+        _, _, zmin, _, _, zmax = gmsh.model.occ.getBoundingBox(2, gmsh.model.occ.getEntities(2)[1][2])
+        @test isapprox(zmin, ustrip(SolidModels.STP_UNIT, z_target); atol=1e-6)
+        @test isapprox(zmax, ustrip(SolidModels.STP_UNIT, z_target); atol=1e-6)
         gmsh.finalize()
     end
 end

--- a/test/test_conformal_render.jl
+++ b/test/test_conformal_render.jl
@@ -1,0 +1,110 @@
+@testitem "ConformalRender smoke" setup = [CommonTestSetup] begin
+    using DeviceLayout:
+        Point,
+        Rectangle,
+        centered,
+        Polygon,
+        points,
+        coordinatetype,
+        onenanometer,
+        ClippedPolygon,
+        difference2d
+    using DeviceLayout.Polygons: Rounded
+    using DeviceLayout.Curvilinear: CurvilinearPolygon, CurvilinearRegion
+    using DeviceLayout.SolidModels:
+        SolidModel,
+        ConformalRenderContext,
+        add_conformal_loop!,
+        render_conformal!,
+        kernel,
+        gmsh,
+        hasgroup
+    import DeviceLayout.SolidModels
+
+    @testset "ConformalRenderContext construction" begin
+        ctx = ConformalRenderContext()
+        @test ctx.vertex_merge_atol == 2e-3
+        @test ctx.center_merge_atol == SolidModels.POINT_MERGE_ATOL
+        @test isempty(ctx.curve_cache)
+        @test isempty(ctx.endpoint_curve_index)
+        @test ctx.stats[:hits] == 0
+        @test ctx.stats[:misses] == 0
+
+        # Custom tolerances
+        ctx2 = ConformalRenderContext(; vertex_merge_atol=5e-3)
+        @test ctx2.vertex_merge_atol == 5e-3
+    end
+
+    @testset "add_conformal_loop! dedupes shared edges" begin
+        # Two rectangles sharing an edge — the shared edge should resolve to
+        # the same OCC tag in both loops, proving the cache works.
+        sm = SolidModel("conformal_share_edge"; overwrite=true)
+        k = kernel(sm)
+        ctx = ConformalRenderContext()
+        import SpatialIndexing
+        points_tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+
+        # Left rect: (0,0) → (10,0) → (10,10) → (0,10)
+        left = CurvilinearPolygon(
+            Point{typeof(1.0μm)}[
+                Point(0.0μm, 0.0μm),
+                Point(10.0μm, 0.0μm),
+                Point(10.0μm, 10.0μm),
+                Point(0.0μm, 10.0μm)
+            ]
+        )
+        # Right rect: (10,0) → (20,0) → (20,10) → (10,10) — shared edge is x=10 side
+        right = CurvilinearPolygon(
+            Point{typeof(1.0μm)}[
+                Point(10.0μm, 0.0μm),
+                Point(20.0μm, 0.0μm),
+                Point(20.0μm, 10.0μm),
+                Point(10.0μm, 10.0μm)
+            ]
+        )
+
+        loop1 = add_conformal_loop!(ctx, left, k, 0.0μm; points_tree)
+        loop2 = add_conformal_loop!(ctx, right, k, 0.0μm; points_tree)
+
+        # After the second loop, we should see at least one cache hit — the
+        # shared edge (10,0)→(10,10) should reuse the tag from the first loop.
+        @test ctx.stats[:hits] >= 1
+        @test loop1 != loop2  # they are different loops
+
+        gmsh.finalize()
+    end
+
+    @testset "render_conformal! renders same geometry as render!" begin
+        # Simple CS with two adjacent rectangles; verify both render! and
+        # render_conformal! produce a valid SolidModel with the same number
+        # of surface entities.
+        cs = CoordinateSystem("adjacent", nm)
+        place!(cs, Rectangle(Point(0.0μm, 0.0μm), Point(10.0μm, 10.0μm)), :l1)
+        place!(cs, Rectangle(Point(10.0μm, 0.0μm), Point(20.0μm, 10.0μm)), :l1)
+
+        sm_stock = SolidModel("stock"; overwrite=true)
+        render!(sm_stock, cs)
+        n_surf_stock = length(gmsh.model.occ.getEntities(2))
+
+        sm_conformal = SolidModel("conformal"; overwrite=true)
+        render_conformal!(sm_conformal, cs)
+        n_surf_conformal = length(gmsh.model.occ.getEntities(2))
+
+        # Both should produce two surfaces
+        @test n_surf_stock >= 2
+        @test n_surf_conformal >= 2
+        # Both models have the expected physical group
+        @test hasgroup(sm_stock, "l1", 2)
+        @test hasgroup(sm_conformal, "l1", 2)
+
+        gmsh.finalize()
+    end
+
+    @testset "render_conformal! rejects GmshNative kernel" begin
+        sm_native = SolidModel("native", SolidModels.GmshNative(); overwrite=true)
+        cs = CoordinateSystem("dummy", nm)
+        place!(cs, Rectangle(Point(0.0μm, 0.0μm), Point(1.0μm, 1.0μm)), :l1)
+        @test_throws ErrorException render_conformal!(sm_native, cs)
+        gmsh.finalize()
+    end
+end

--- a/test/test_conformal_render.jl
+++ b/test/test_conformal_render.jl
@@ -251,4 +251,58 @@
         @test isapprox(zmax, ustrip(SolidModels.STP_UNIT, z_target); atol=1e-6)
         gmsh.finalize()
     end
+
+    @testset "prefer-curve invariant: arc then line on shared endpoints" begin
+        # After an arc on endpoints (a, b), a line request on the same endpoints
+        # must reuse the arc tag (up to sign), not create a duplicate straight
+        # edge — otherwise a shared boundary between an arc-side and a
+        # line-side face is non-conformal.
+        sm = SolidModel("prefer_curve_arc_line"; overwrite=true)
+        k = kernel(sm)
+        ctx = ConformalRenderContext()
+        import SpatialIndexing
+        points_tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+
+        R = 100.0μm
+        pp = [Point(0.0μm, 0.0μm), Point(R, 0.0μm), Point(0.0μm, R)]
+        turn = Paths.Turn(90°, R, α0=90°, p0=pp[2])
+        cp_arc = CurvilinearPolygon(pp, [turn], [2])
+        add_conformal_loop!(ctx, cp_arc, k, 0.0μm; points_tree)
+
+        # Straight-edge polygon that shares the (pp[2], pp[3]) endpoints. It
+        # would ordinarily be a chord, but the cache should return the arc tag.
+        hits_before = ctx.stats[:hits]
+        line_cp = CurvilinearPolygon(pp)  # no curve — pure line loop
+        add_conformal_loop!(ctx, line_cp, k, 0.0μm; points_tree)
+        @test ctx.stats[:hits] > hits_before  # arc was reused for a line request
+        gmsh.finalize()
+    end
+
+    @testset "prefer-curve invariant: spline then line on shared endpoints" begin
+        sm = SolidModel("prefer_curve_spline_line"; overwrite=true)
+        k = kernel(sm)
+        ctx = ConformalRenderContext()
+        import SpatialIndexing
+        points_tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+
+        pp = [
+            Point(0.0μm, 0.0μm),
+            Point(100.0μm, 0.0μm),
+            Point(100.0μm, 100.0μm),
+            Point(0.0μm, 100.0μm)
+        ]
+        spline_pts = [pp[2], Point(150.0μm, 50.0μm), pp[3]]
+        seg = Paths.BSpline(spline_pts, Point(1.0μm, 0.0μm), Point(-1.0μm, 0.0μm))
+        cp_spline = CurvilinearPolygon(pp, [seg], [2])
+        add_conformal_loop!(ctx, cp_spline, k, 0.0μm; points_tree)
+
+        hits_before = ctx.stats[:hits]
+        line_cp = CurvilinearPolygon(pp)  # straight (pp[2], pp[3])
+        add_conformal_loop!(ctx, line_cp, k, 0.0μm; points_tree)
+        # If the spline registered itself in endpoint_curve_index, the later
+        # line request hits — otherwise a duplicate straight edge is created
+        # and the shared boundary is non-conformal.
+        @test ctx.stats[:hits] > hits_before
+        gmsh.finalize()
+    end
 end

--- a/test/test_conformal_render.jl
+++ b/test/test_conformal_render.jl
@@ -403,18 +403,38 @@
 
         # Endpoints on the x axis; centers above and below.
         p1 = SolidModels.ConformalRender._cached_point_relaxed!(
-            k, ctx, -50.0, 0.0, 0.0, points_tree
+            k,
+            ctx,
+            -50.0,
+            0.0,
+            0.0,
+            points_tree
         )
         p2 = SolidModels.ConformalRender._cached_point_relaxed!(
-            k, ctx, 50.0, 0.0, 0.0, points_tree
+            k,
+            ctx,
+            50.0,
+            0.0,
+            0.0,
+            points_tree
         )
         # Center above chord: bulges downward → midpoint below chord.
         c_above = SolidModels.ConformalRender._cached_point_strict!(
-            k, ctx, 0.0, 80.0, 0.0, points_tree
+            k,
+            ctx,
+            0.0,
+            80.0,
+            0.0,
+            points_tree
         )
         # Center below chord: bulges upward → midpoint above chord.
         c_below = SolidModels.ConformalRender._cached_point_strict!(
-            k, ctx, 0.0, -80.0, 0.0, points_tree
+            k,
+            ctx,
+            0.0,
+            -80.0,
+            0.0,
+            points_tree
         )
 
         rej_before = ctx.stats[:midpoint_rejections]
@@ -444,9 +464,7 @@
         # which would normally not appear here — just to hit the fallback.
         straight = Paths.Straight(10.0μm, a, 0.0°)
         cp = CurvilinearPolygon([a, b], [straight], [1])
-        @test_throws ArgumentError add_conformal_loop!(
-            ctx, cp, k, 0.0μm; points_tree
-        )
+        @test_throws ArgumentError add_conformal_loop!(ctx, cp, k, 0.0μm; points_tree)
         gmsh.finalize()
     end
 

--- a/test/test_conformal_render.jl
+++ b/test/test_conformal_render.jl
@@ -9,7 +9,12 @@
         onenanometer,
         ClippedPolygon,
         difference2d,
-        Paths
+        Paths,
+        Path,
+        LineSegment,
+        straight!,
+        turn!,
+        bspline!
     using DeviceLayout.Polygons: Rounded
     using DeviceLayout.Curvilinear: CurvilinearPolygon, CurvilinearRegion
     using DeviceLayout.SolidModels:
@@ -20,6 +25,7 @@
         kernel,
         gmsh,
         hasgroup
+    import DeviceLayout
     import DeviceLayout.SolidModels
 
     @testset "ConformalRenderContext construction" begin
@@ -303,6 +309,191 @@
         # line request hits — otherwise a duplicate straight edge is created
         # and the shared boundary is non-conformal.
         @test ctx.stats[:hits] > hits_before
+        gmsh.finalize()
+    end
+
+    @testset "_add_conformal!(::LineSegment) 1D dispatch" begin
+        # A LineSegment placed on a coordinate system exercises the 1D-entity
+        # branch of _add_conformal!. It should register a curve and a physical
+        # group at dim=1.
+        cs = CoordinateSystem("linesegs", μm)
+        place!(cs, LineSegment(Point(0.0μm, 0.0μm), Point(10.0μm, 0.0μm)), :l1)
+        place!(cs, LineSegment(Point(10.0μm, 0.0μm), Point(10.0μm, 5.0μm)), :l1)
+
+        sm = SolidModel("linesegs"; overwrite=true)
+        render_conformal!(sm, cs)
+        # `l1` should end up as a group at dim=1 (segments do not get closed
+        # into a 2D face) with at least two 1D entities in the model.
+        @test hasgroup(sm, "l1", 1)
+        @test length(gmsh.model.occ.getEntities(1)) >= 2
+        gmsh.finalize()
+    end
+
+    @testset "arc curve_cache exact-key hit (existing !== nothing branch)" begin
+        # Same Turn requested twice → second call hits the exact-key branch
+        # and returns the same tag (up to sign).
+        sm = SolidModel("arc_dup"; overwrite=true)
+        k = kernel(sm)
+        ctx = ConformalRenderContext()
+        import SpatialIndexing
+        points_tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+
+        R = 100.0μm
+        pp = [Point(0.0μm, 0.0μm), Point(R, 0.0μm), Point(0.0μm, R)]
+        turn = Paths.Turn(90°, R, α0=90°, p0=pp[2])
+        cp1 = CurvilinearPolygon(pp, [turn], [2])
+        cp2 = CurvilinearPolygon(pp, [turn], [2])  # same Turn object
+
+        misses_before = ctx.stats[:misses]
+        arcs_before = ctx.stats[:arcs]
+        add_conformal_loop!(ctx, cp1, k, 0.0μm; points_tree)
+        arcs_after_first = ctx.stats[:arcs]
+        add_conformal_loop!(ctx, cp2, k, 0.0μm; points_tree)
+        # Second render created zero new arcs (all hits from the cache).
+        @test ctx.stats[:arcs] == arcs_after_first
+        # And at least one exact-key hit was recorded.
+        @test ctx.stats[:hits] >= 1
+        gmsh.finalize()
+    end
+
+    @testset "spline curve_cache exact-key hit" begin
+        sm = SolidModel("spline_dup"; overwrite=true)
+        k = kernel(sm)
+        ctx = ConformalRenderContext()
+        import SpatialIndexing
+        points_tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+
+        pp = [
+            Point(0.0μm, 0.0μm),
+            Point(100.0μm, 0.0μm),
+            Point(100.0μm, 100.0μm),
+            Point(0.0μm, 100.0μm)
+        ]
+        seg = Paths.BSpline(
+            [pp[2], Point(150.0μm, 50.0μm), pp[3]],
+            Point(1.0μm, 0.0μm),
+            Point(-1.0μm, 0.0μm)
+        )
+        cp1 = CurvilinearPolygon(pp, [seg], [2])
+        cp2 = CurvilinearPolygon(pp, [seg], [2])
+
+        add_conformal_loop!(ctx, cp1, k, 0.0μm; points_tree)
+        splines_after_first = ctx.stats[:splines]
+        add_conformal_loop!(ctx, cp2, k, 0.0μm; points_tree)
+        @test ctx.stats[:splines] == splines_after_first
+        @test ctx.stats[:hits] >= 1
+        gmsh.finalize()
+    end
+
+    @testset "midpoint check rejects 2-edge lens fusion" begin
+        # Precondition 2 case: two arcs on the same endpoints but different
+        # midpoints (bulge up vs. bulge down). Endpoint-only fusion would
+        # collapse both into one OCC edge. The midpoint check must keep them
+        # as two distinct entities.
+        #
+        # We drive the primitives directly rather than through
+        # add_conformal_loop! so we can construct the exact "two arcs on the
+        # same endpoints, different centers" case without a Path adapter.
+        sm = SolidModel("lens_primitive"; overwrite=true)
+        k = kernel(sm)
+        ctx = ConformalRenderContext()
+        import SpatialIndexing
+        SolidModels = DeviceLayout.SolidModels
+        points_tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+
+        # Endpoints on the x axis; centers above and below.
+        p1 = SolidModels.ConformalRender._cached_point_relaxed!(
+            k, ctx, -50.0, 0.0, 0.0, points_tree
+        )
+        p2 = SolidModels.ConformalRender._cached_point_relaxed!(
+            k, ctx, 50.0, 0.0, 0.0, points_tree
+        )
+        # Center above chord: bulges downward → midpoint below chord.
+        c_above = SolidModels.ConformalRender._cached_point_strict!(
+            k, ctx, 0.0, 80.0, 0.0, points_tree
+        )
+        # Center below chord: bulges upward → midpoint above chord.
+        c_below = SolidModels.ConformalRender._cached_point_strict!(
+            k, ctx, 0.0, -80.0, 0.0, points_tree
+        )
+
+        rej_before = ctx.stats[:midpoint_rejections]
+        arcs_before = ctx.stats[:arcs]
+        tag_a = SolidModels.ConformalRender._cached_add_arc!(k, ctx, p1, c_above, p2)
+        tag_b = SolidModels.ConformalRender._cached_add_arc!(k, ctx, p1, c_below, p2)
+
+        @test ctx.stats[:arcs] == arcs_before + 2  # both arcs created fresh
+        @test ctx.stats[:midpoint_rejections] > rej_before
+        @test abs(tag_a) != abs(tag_b)  # distinct OCC entities
+        gmsh.finalize()
+    end
+
+    @testset "unsupported segment type throws ArgumentError" begin
+        # A Paths.Straight reaching the curve dispatcher should error rather
+        # than silently BSpline-approximating (which would leave the edge out
+        # of the cache and break conformality with the caching side).
+        sm = SolidModel("bad_seg"; overwrite=true)
+        k = kernel(sm)
+        ctx = ConformalRenderContext()
+        import SpatialIndexing
+        points_tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+
+        a = Point(0.0μm, 0.0μm)
+        b = Point(10.0μm, 0.0μm)
+        # Hand-construct a CurvilinearPolygon carrying a Paths.Straight,
+        # which would normally not appear here — just to hit the fallback.
+        straight = Paths.Straight(10.0μm, a, 0.0°)
+        cp = CurvilinearPolygon([a, b], [straight], [1])
+        @test_throws ArgumentError add_conformal_loop!(
+            ctx, cp, k, 0.0μm; points_tree
+        )
+        gmsh.finalize()
+    end
+
+    @testset "render_conformal! with Path(Trace) — straight + turn" begin
+        # Trace path with a straight and a 90° turn — the production shape,
+        # not a hand-built CurvilinearPolygon.
+        cs = CoordinateSystem("trace_path", nm)
+        pa = Path(Point(0.0μm, 0.0μm), α0=0°)
+        straight!(pa, 50μm, Paths.Trace(2.0μm))
+        turn!(pa, 90°, 20μm)
+        straight!(pa, 50μm)
+        place!(cs, pa, :l1)
+
+        sm = SolidModel("trace_path"; overwrite=true)
+        render_conformal!(sm, cs)
+        @test hasgroup(sm, "l1", 2)
+        gmsh.finalize()
+    end
+
+    @testset "render_conformal! with Path(TaperTrace)" begin
+        # TaperTrace path — the width changes along the segment, which is the
+        # kind of style OffsetSegment gets pulled in for.
+        cs = CoordinateSystem("taper_path", nm)
+        pa = Path(Point(0.0μm, 0.0μm), α0=0°)
+        straight!(pa, 40μm, Paths.TaperTrace(1.0μm, 3.0μm))
+        turn!(pa, 45°, 30μm)
+        place!(cs, pa, :l1)
+
+        sm = SolidModel("taper_path"; overwrite=true)
+        render_conformal!(sm, cs)
+        @test hasgroup(sm, "l1", 2)
+        gmsh.finalize()
+    end
+
+    @testset "render_conformal! with Path(SimpleCPW) — bspline routing" begin
+        # SimpleCPW with a bspline segment — exercises both the CPW inner+outer
+        # boundary rendering and the BSpline dispatch.
+        cs = CoordinateSystem("cpw_bspline", nm)
+        pa = Path(Point(0.0μm, 0.0μm), α0=0°)
+        straight!(pa, 20μm, Paths.SimpleCPW(2.0μm, 1.0μm))
+        bspline!(pa, [Point(60.0μm, 40.0μm)], 90°)
+        straight!(pa, 20μm)
+        place!(cs, pa, :l1)
+
+        sm = SolidModel("cpw_bspline"; overwrite=true)
+        render_conformal!(sm, cs)
+        @test hasgroup(sm, "l1", 2)
         gmsh.finalize()
     end
 end


### PR DESCRIPTION
## Motivation

At chip scale (~10⁵ faces) the stock `render!` path creates a distinct OCC edge/point per face boundary and relies on the post-render `_fragment_and_map!` pass to reconcile coincident entities. That reconciliation is `O(N²)` and, at production scale, non-manifold artifacts can survive it.

On an internal experimental pipeline we've been running an edge/curve cache that deduplicates OCC entities as they are created, so two adjacent faces requesting the "same" line or arc receive the same OCC tag. The resulting model is conformal by construction and `_fragment_and_map!` is skipped. This was implemented as a monkey-patch stack (`lib/patches.jl` + `lib/edge_cache.jl`) that overrides `_add_loop!`, `_add_curve!`, and `_get_or_add_point!` on DeviceLayout's private symbols.

This MR is a de-monkey-patched extraction of that cache.

## What this MR adds

- `render_conformal!(sm, cs; kwargs...)` — full-orchestrator entry point paralleling `render!`. Same kwargs. `_fragment_and_map!` is not called after postrender operations (the cache guarantees conformality on rendered geometry).
- `add_conformal_loop!(ctx, cl, k, z; points_tree, atol)` — public seam for callers that build OCC geometry themselves (e.g. loop-by-loop custom orchestrators). Uses the same cache.
- `ConformalRenderContext(; vertex_merge_atol=2e-3, center_merge_atol=POINT_MERGE_ATOL)` — per-render cache + settings (no globals; nested/parallel renders are safe).

## What this MR does NOT touch

Explicit non-goal: **existing render behavior is byte-identical.** Concretely:
- `render!` (stock) — untouched
- `_add_loop!`, `_add_curve!`, `_get_or_add_point!` (stock) — untouched
- `_fragment_and_map!` (stock) — untouched, still called by `render!`

Users on `render!` see zero behavior change.

## Design choices, framing as "one way, open to other routes"

I went with a **parallel-strategy** approach (new entry point + submodule, stock path fully preserved) because the downstream constraint was "don't risk load-bearing render behavior for existing users." Two alternatives I considered:

1. **Kwargs on stock `render!`** (`use_conformal_cache=false`, `skip_fragment=false`, `point_merge_atol=...`). More discoverable but pushes conditional branches into the load-bearing function.
2. **Strategy dispatch on a marker type**: thread `strategy::AbstractRenderStrategy` through `render!` and its helpers, default `StockStrategy()`. Elegant Julia-y, but requires touching every function in the render chain.

Happy to rework in either direction if you'd prefer. Also happy to refactor stock `render!` into `_render_metadata_iteration(...)` + `_render_default_add!(...)` (byte-preserving) so `render_conformal!` reuses the orchestrator; the current MR duplicates the metadata-iteration loop for isolation.

## Two design decisions worth flagging

- **Two point-merge tolerances**: polygon vertices default to 2 nm (absorbs Clipper integer-grid + `discretize_curve` float-drift divergence between the two sides of a shared boundary — ~1.5 nm observed in production), arc centers / BSpline control points stay at strict `POINT_MERGE_ATOL` (1 pm). Relaxing the strict tolerance would corrupt curve geometry.
- **"Prefer curve" invariant**: when a curve (arc or BSpline) already spans endpoints `(e1, e2)` in the cache, subsequent line requests on those endpoints reuse the curve tag. This makes adjacent faces converge to one OCC entity even when one side computed a straight chord and the other recovered the arc.

## What this MR does NOT cover (deferred)

The experimental monkey-patch stack also touches `Curvilinear.pathtopolys(::CompoundSegment, ::SimpleCPW)` (splits into per-sub-segment CurvilinearPolygons for provenance recovery) and `discretize_curve(::ConstantOffset{Straight})` (exact-two-point return instead of 101-point polyline). Those aren't part of the render-side cache and are better addressed as standalone fixes in the curve-recovery pipeline; not in this MR.

Also: the experimental stack currently kills `_fragment_and_map!` globally. This MR skips it only inside `render_conformal!`; `render!` still fragments.

## Verification

- 4 test blocks covering context construction, shared-edge dedup on a two-rectangle fixture, `render_conformal!` full pipeline, and GmshNative rejection.
- Byte-identical mesh output vs the experimental pipeline monkey-patch stack when both are run against the same DL fixture (mesh_2d + mesh_3d md5s match exactly).
- No changes to public API of existing symbols.

## Test plan

- [x] Format check green (`julia scripts/format.jl check`)
- [x] `test/test_conformal_render.jl` all 14 assertions pass
- [x] Downstream verification: Experimental pipeline swap from monkey-patched `_add_loop!` to `add_conformal_loop!` produces byte-identical mesh (same md5, same tet count, same worst kappa_proxy)
- [ ] CI: awaiting pipeline
