### PR TITLE
Add layerwise rounding post-render pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,12 @@ The format of this changelog is based on
   - Loops removed by styling (`NoRender`, including via `OptionalStyle`/`optional_entity` or a
     `StyleDict` entry, nested inside `Rounded`) expand to no polygons instead of zero-point
     `Polygon`s, which reached `Cell`s and could not be written to GDS. (#269)
+  - `round_layer` and `round_layer!` apply corner rounding to the rendered geometry of a
+    layer as a post-render pass. The layer's elements (including those inside references)
+    are flattened and unioned before rounding, so corners are rounded correctly where
+    separately-drawn shapes meet, and holes are preserved. Rounding is symbolic
+    (`CurvilinearRegion` with true arcs); for `CoordinateSystem` input, curves already
+    present in the layer survive the union exactly.
 
 ## 1.16.0 (2026-07-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ The format of this changelog is based on
     raised a `MethodError` part-way through the traversal. References to `Path`s are handled by
     replacing the `Path` with an equivalent `CoordinateSystem` containing its references and its undecorated
     nodes separately.
+  - `round_layer` and `round_layer!` apply corner rounding to the rendered geometry of a
+    layer as a post-render pass. The layer's elements (including those inside references)
+    are flattened and unioned before rounding, so corners are rounded correctly where
+    separately-drawn shapes meet, and holes are preserved. Rounding is symbolic
+    (`CurvilinearRegion` with true arcs); for `CoordinateSystem` input, curves already
+    present in the layer survive the union exactly when their full discretized footprint
+    remains on the result boundary.
 
 ### Changed
 
@@ -55,13 +62,6 @@ The format of this changelog is based on
   - Loops removed by styling (`NoRender`, including via `OptionalStyle`/`optional_entity` or a
     `StyleDict` entry, nested inside `Rounded`) expand to no polygons instead of zero-point
     `Polygon`s, which reached `Cell`s and could not be written to GDS. (#269)
-  - `round_layer` and `round_layer!` apply corner rounding to the rendered geometry of a
-    layer as a post-render pass. The layer's elements (including those inside references)
-    are flattened and unioned before rounding, so corners are rounded correctly where
-    separately-drawn shapes meet, and holes are preserved. Rounding is symbolic
-    (`CurvilinearRegion` with true arcs); for `CoordinateSystem` input, curves already
-    present in the layer survive the union exactly when their full discretized footprint
-    remains on the result boundary.
 
 ## 1.16.0 (2026-07-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,8 @@ The format of this changelog is based on
     are flattened and unioned before rounding, so corners are rounded correctly where
     separately-drawn shapes meet, and holes are preserved. Rounding is symbolic
     (`CurvilinearRegion` with true arcs); for `CoordinateSystem` input, curves already
-    present in the layer survive the union exactly.
+    present in the layer survive the union exactly when their full discretized footprint
+    remains on the result boundary.
 
 ## 1.16.0 (2026-07-20)
 

--- a/docs/src/reference/api.md
+++ b/docs/src/reference/api.md
@@ -188,6 +188,13 @@
     Polygons.StyleDict
 ```
 
+#### Post-render operations
+
+```@docs
+    round_layer
+    round_layer!
+```
+
 #### [Curvilinear geometry](@id api-curvilinear)
 
 ```@docs

--- a/src/DeviceLayout.jl
+++ b/src/DeviceLayout.jl
@@ -574,6 +574,10 @@ export Curvilinear,
     intersect2d_curved,
     xor2d_curved
 
+# After curvilinear.jl (rounding produces CurvilinearRegion) and cells.jl/render
+include("postrender.jl")
+export round_layer, round_layer!
+
 include("simple_shapes.jl")
 import .SimpleShapes:
     circular_arc,

--- a/src/postrender.jl
+++ b/src/postrender.jl
@@ -1,0 +1,175 @@
+# Post-render passes: operations applied to the rendered geometry of a layer as a whole,
+# as opposed to entity styles like `Rounded`, which are applied to entities as they are
+# created. The distinguishing feature is that these passes see the union of a layer's
+# flattened geometry, so they can handle results that emerge only after composition
+# (e.g. corners where separately-rendered polygons meet).
+
+"""
+    round_layer(geom::Union{Cell,CoordinateSystem}, layer::DeviceLayout.Meta, radius;
+        relative=false, min_side_len=nothing, min_angle=1e-3)
+
+Return the geometry of `geom` in `layer` as a `Vector{CurvilinearRegion}` with corners
+rounded to `radius`.
+
+The elements of `geom` matching `layer` (using [`layer_inclusion`](@ref) semantics,
+including elements inside references) are flattened and unioned before rounding, so
+corners are rounded correctly even where separately-drawn shapes meet. Rounding is
+symbolic: the fillets in the result are true arcs, and any holes in the unioned geometry
+are preserved as holes of the resulting regions (with their corners rounded too).
+
+For `CoordinateSystem` input, the union preserves curves already present in the input
+(arcs from paths, `Rounded` entities, circles, ...) using [`union2d_curved`](@ref), and
+corners between straight edges and arcs are rounded natively. For `Cell` input, elements
+are already plain polygons; they are unioned with [`union2d`](@ref) after widening integer
+coordinates to floating point (fillet arcs are not representable with integer coordinates).
+
+Note that the association between input elements and their metadata is intentionally
+aggregated: N input elements produce M ≤ N output regions, and no per-element metadata is
+carried over.
+
+# Keyword arguments
+
+  - `relative`: if `true`, `radius` must be a dimensionless number, and the radius of
+    curvature at each vertex is `radius * min(l₁, l₂)` where `l₁` and `l₂` are the lengths
+    of the two adjacent sides (see [`Polygons.Rounded`](@ref)).
+  - `min_side_len`: the minimum side length adjacent to a corner for that corner to be
+    rounded. Defaults to `radius` (or to zero if `relative=true`).
+  - `min_angle`: corners where adjacent sides are collinear within this tolerance (in
+    radians) are not rounded.
+"""
+function round_layer(
+    geom::Union{Cell, CoordinateSystem},
+    layer::Meta,
+    radius::Coordinate;
+    relative::Bool=false,
+    min_side_len=nothing,
+    min_angle::Real=1e-3
+)
+    sty = _round_layer_style(
+        float(coordinatetype(geom)),
+        radius,
+        relative,
+        min_side_len,
+        min_angle
+    )
+    return _rounded_regions(geom, layer, sty)
+end
+
+"""
+    round_layer!(geom::Union{Cell,CoordinateSystem}, layer::DeviceLayout.Meta, radius;
+        target_layer::DeviceLayout.Meta, remap_originals=nothing,
+        relative=false, min_side_len=nothing, min_angle=1e-3, kwargs...)
+
+Round the corners of the geometry of `geom` in `layer` to `radius`, rendering the result
+into `geom` itself with metadata `target_layer`.
+
+The rounded result is computed as in [`round_layer`](@ref) (flatten, union, round
+symbolically) and rendered at the top level of `geom`. The original elements are left in
+place; if `remap_originals` is set to a `DeviceLayout.Meta`, the top-level elements of
+`geom` matching `layer` are retagged with that metadata instead (elements inside
+referenced structures are not modified, since those structures may be shared). Text
+elements are unaffected.
+
+For a `CoordinateSystem` target, the rounded regions are placed symbolically (arcs stay
+exact). For a `Cell` target, they are discretized on render; keyword arguments (e.g.
+`atol`) are forwarded to `render!` to control the discretization, and `target_layer` and
+`remap_originals` must be `GDSMeta`. Because a `Cell` stores the discretized result, this
+pass should be applied only once, as a final step before export: re-applying it to its
+own output would operate on the sampled arc points rather than true arcs, multiplying
+vertices with each pass. (This does not apply to `CoordinateSystem` targets, where the
+result stays symbolic.)
+
+See [`round_layer`](@ref) for the rounding keyword arguments.
+"""
+function round_layer!(
+    geom::Union{Cell, CoordinateSystem},
+    layer::Meta,
+    radius::Coordinate;
+    target_layer::Meta,
+    remap_originals::Union{Meta, Nothing}=nothing,
+    relative::Bool=false,
+    min_side_len=nothing,
+    min_angle::Real=1e-3,
+    kwargs...
+)
+    if geom isa Cell
+        S = coordinatetype(geom)
+        float(S) === S || throw(
+            ArgumentError(
+                "cannot render rounded regions into a `Cell` with integer coordinate type $S; the discretized fillet arcs are not representable. Use `round_layer` to get the rounded regions instead."
+            )
+        )
+        target_layer isa GDSMeta ||
+            throw(ArgumentError("`target_layer` must be a `GDSMeta` for a `Cell` target."))
+        isnothing(remap_originals) ||
+            remap_originals isa GDSMeta ||
+            throw(
+                ArgumentError("`remap_originals` must be a `GDSMeta` for a `Cell` target.")
+            )
+    end
+    regions = round_layer(geom, layer, radius; relative, min_side_len, min_angle)
+    # Remap before rendering the rounded result, so that when `target_layer` matches
+    # `layer` the newly rendered elements are not themselves retagged.
+    if !isnothing(remap_originals)
+        keep = layer_inclusion(layer, [])
+        meta = element_metadata(geom)
+        for i in eachindex(meta)
+            keep(meta[i]) && (meta[i] = remap_originals)
+        end
+    end
+    for r in regions
+        render!(geom, r, target_layer; kwargs...)
+    end
+    return geom
+end
+
+# Build the `Rounded` style carrying all rounding parameters, with the style's coordinate
+# type pinned to the (float) coordinate type of the input geometry. `RelativeRounded` is
+# not used here because it guesses its coordinate type from preferred units, which fails
+# for unitless geometry.
+function _round_layer_style(
+    ::Type{V},
+    radius,
+    relative::Bool,
+    min_side_len,
+    min_angle
+) where {V}
+    if relative
+        radius isa Real || throw(
+            ArgumentError(
+                "`relative=true` requires a dimensionless `radius` (a fraction of the shorter adjacent side length), got $radius."
+            )
+        )
+        msl = isnothing(min_side_len) ? zero(V) : min_side_len
+        return Rounded{V}(;
+            rel_r=Float64(radius),
+            min_side_len=msl,
+            min_angle=Float64(min_angle)
+        )
+    end
+    r = convert(V, radius)
+    msl = isnothing(min_side_len) ? r : min_side_len
+    return Rounded{V}(; abs_r=r, min_side_len=msl, min_angle=Float64(min_angle))
+end
+
+function _rounded_regions(cell::Cell{S}, layer, sty) where {S}
+    V = float(S)
+    polys = flat_elements(cell, layer)
+    isempty(polys) && return CurvilinearRegion{V}[]
+    # Widen to float before the union so the fillet arcs produced by rounding are
+    # representable (they cannot have integer coordinates).
+    return to_curvilinear(union2d(convert.(Polygon{V}, polys)), sty)
+end
+
+function _rounded_regions(cs::CoordinateSystem{S}, layer, sty) where {S}
+    float(S) === S || throw(
+        ArgumentError(
+            "`round_layer` requires a floating-point coordinate type for `CoordinateSystem` input, got $S."
+        )
+    )
+    ents = flat_elements(cs, layer)
+    isempty(ents) && return CurvilinearRegion{S}[]
+    # Curve-preserving union: arcs already present in the input survive symbolically
+    # rather than being discretized, and line-arc corners are rounded natively.
+    return [to_curvilinear(r, sty) for r in union2d_curved(ents)]
+end

--- a/src/postrender.jl
+++ b/src/postrender.jl
@@ -19,9 +19,11 @@ are preserved as holes of the resulting regions (with their corners rounded too)
 
 For `CoordinateSystem` input, the union preserves curves already present in the input
 (arcs from paths, `Rounded` entities, circles, ...) using [`union2d_curved`](@ref), and
-corners between straight edges and arcs are rounded natively. For `Cell` input, elements
-are already plain polygons; they are unioned with [`union2d`](@ref) after widening integer
-coordinates to floating point (fillet arcs are not representable with integer coordinates).
+corners between straight edges and arcs are rounded natively. Curve recovery is
+all-or-nothing: an input curve cut by the union falls back to a polyline, as described in
+[`recover_curves`](@ref). For `Cell` input, elements are already plain polygons; they are
+unioned with [`union2d`](@ref) in their native coordinate type, then widened to floating
+point before rounding when necessary.
 
 Note that the association between input elements and their metadata is intentionally
 aggregated: N input elements produce M ≤ N output regions, and no per-element metadata is
@@ -73,11 +75,12 @@ elements are unaffected.
 For a `CoordinateSystem` target, the rounded regions are placed symbolically (arcs stay
 exact). For a `Cell` target, they are discretized on render; keyword arguments (e.g.
 `atol`) are forwarded to `render!` to control the discretization, and `target_layer` and
-`remap_originals` must be `GDSMeta`. Because a `Cell` stores the discretized result, this
-pass should be applied only once, as a final step before export: re-applying it to its
-own output would operate on the sampled arc points rather than true arcs, multiplying
-vertices with each pass. (This does not apply to `CoordinateSystem` targets, where the
-result stays symbolic.)
+`remap_originals` must be `GDSMeta`. Rendering to an exact coordinate type may throw an
+`InexactError` if a discretized point is not representable; in that case `geom` is left
+unchanged. Because a `Cell` stores the discretized result, this pass should be applied only
+once, as a final step before export: re-applying it to its own output would operate on the
+sampled arc points rather than true arcs, multiplying vertices with each pass. (This does
+not apply to `CoordinateSystem` targets, where the result stays symbolic.)
 
 See [`round_layer`](@ref) for the rounding keyword arguments.
 """
@@ -93,12 +96,6 @@ function round_layer!(
     kwargs...
 )
     if geom isa Cell
-        S = coordinatetype(geom)
-        float(S) === S || throw(
-            ArgumentError(
-                "cannot render rounded regions into a `Cell` with integer coordinate type $S; the discretized fillet arcs are not representable. Use `round_layer` to get the rounded regions instead."
-            )
-        )
         target_layer isa GDSMeta ||
             throw(ArgumentError("`target_layer` must be a `GDSMeta` for a `Cell` target."))
         isnothing(remap_originals) ||
@@ -108,20 +105,36 @@ function round_layer!(
             )
     end
     regions = round_layer(geom, layer, radius; relative, min_side_len, min_angle)
-    # Remap before rendering the rounded result, so that when `target_layer` matches
-    # `layer` the newly rendered elements are not themselves retagged.
-    if !isnothing(remap_originals)
-        keep = layer_inclusion(layer, [])
-        meta = element_metadata(geom)
-        for i in eachindex(meta)
-            keep(meta[i]) && (meta[i] = remap_originals)
-        end
-    end
+
+    # Stage rendering so conversion or discretization failures leave `geom` unchanged.
+    staged = _round_layer_staging(geom)
     for r in regions
-        render!(geom, r, target_layer; kwargs...)
+        render!(staged, r, target_layer; kwargs...)
+    end
+
+    geom_elements = elements(geom)
+    geom_meta = element_metadata(geom)
+    staged_elements = convert(Vector{eltype(geom_elements)}, elements(staged))
+    staged_meta = convert(Vector{eltype(geom_meta)}, element_metadata(staged))
+    converted_remap =
+        isnothing(remap_originals) ? nothing : convert(eltype(geom_meta), remap_originals)
+
+    # Capture original indices before appending so target_layer == layer does not cause the
+    # newly rendered elements to be remapped.
+    remap_idx =
+        isnothing(converted_remap) ? Int[] : findall(layer_inclusion(layer, []), geom_meta)
+
+    append!(geom_elements, staged_elements)
+    append!(geom_meta, staged_meta)
+    for i in remap_idx
+        geom_meta[i] = converted_remap
     end
     return geom
 end
+
+_round_layer_staging(::Cell{S}) where {S} = Cell{S}("round_layer_staging")
+_round_layer_staging(::CoordinateSystem{S}) where {S} =
+    CoordinateSystem{S}("round_layer_staging")
 
 # Build the `Rounded` style carrying all rounding parameters, with the style's coordinate
 # type pinned to the (float) coordinate type of the input geometry. `RelativeRounded` is
@@ -156,17 +169,12 @@ function _rounded_regions(cell::Cell{S}, layer, sty) where {S}
     V = float(S)
     polys = flat_elements(cell, layer)
     isempty(polys) && return CurvilinearRegion{V}[]
-    # Widen to float before the union so the fillet arcs produced by rounding are
-    # representable (they cannot have integer coordinates).
-    return to_curvilinear(union2d(convert.(Polygon{V}, polys)), sty)
+    # Keep exact-coordinate clipping on Clipper's native integer path, then widen its result
+    # for symbolic rounding.
+    return to_curvilinear(convert(ClippedPolygon{V}, union2d(polys)), sty)
 end
 
 function _rounded_regions(cs::CoordinateSystem{S}, layer, sty) where {S}
-    float(S) === S || throw(
-        ArgumentError(
-            "`round_layer` requires a floating-point coordinate type for `CoordinateSystem` input, got $S."
-        )
-    )
     ents = flat_elements(cs, layer)
     isempty(ents) && return CurvilinearRegion{S}[]
     # Curve-preserving union: arcs already present in the input survive symbolically

--- a/src/postrender.jl
+++ b/src/postrender.jl
@@ -6,7 +6,7 @@
 
 """
     round_layer(geom::Union{Cell,CoordinateSystem}, layer::DeviceLayout.Meta, radius;
-        min_side_len=nothing, min_angle=1e-3)
+        min_side_len=radius, min_angle=1e-3)
 
 Return the geometry of `geom` in `layer` as a `Vector{CurvilinearRegion}` with corners
 rounded to `radius`.
@@ -19,15 +19,10 @@ are preserved as holes of the resulting regions (with their corners rounded too)
 
 For `CoordinateSystem` input, the union preserves curves already present in the input
 (arcs from paths, `Rounded` entities, circles, ...) using [`union2d_curved`](@ref), and
-corners between straight edges and arcs are rounded natively. Curve recovery is
+corners between straight edges and arcs are rounded natively. Curve recovery is currently
 all-or-nothing: an input curve cut by the union falls back to a polyline, as described in
-[`recover_curves`](@ref). For `Cell` input, elements are already plain polygons; they are
-unioned with [`union2d`](@ref) in their native coordinate type, then widened to floating
-point before rounding when necessary.
-
-Note that the association between input elements and their metadata is intentionally
-aggregated: N input elements produce M ≤ N output regions, and no per-element metadata is
-carried over.
+[`recover_curves`](@ref). For `Cell` input, elements are already plain polygons, which are
+unioned with [`union2d`](@ref), then converted to rounded `CurvilinearRegion`s.
 
 # Keyword arguments
 
@@ -50,27 +45,24 @@ end
 """
     round_layer!(geom::Union{Cell,CoordinateSystem}, layer::DeviceLayout.Meta, radius;
         target_layer::DeviceLayout.Meta, remap_originals=nothing,
-        min_side_len=nothing, min_angle=1e-3, kwargs...)
+        min_side_len=radius, min_angle=1e-3, kwargs...)
 
 Round the corners of the geometry of `geom` in `layer` to `radius`, rendering the result
 into `geom` itself with metadata `target_layer`.
 
 The rounded result is computed as in [`round_layer`](@ref) (flatten, union, round
 symbolically) and rendered at the top level of `geom`. The original elements are left in
-place; if `remap_originals` is set to a `DeviceLayout.Meta`, the top-level elements of
-`geom` matching `layer` are retagged with that metadata instead (elements inside
-referenced structures are not modified, since those structures may be shared). Text
-elements are unaffected.
+place; if `remap_originals` is set to a `DeviceLayout.Meta`, the elements of
+`geom` matching `layer` are retagged with that metadata instead, including elements
+inside references (which may be shared by structures outside `geom`, making this operation
+unsafe). Text elements are unaffected.
 
 For a `CoordinateSystem` target, the rounded regions are placed symbolically (arcs stay
 exact). For a `Cell` target, they are discretized on render; keyword arguments (e.g.
 `atol`) are forwarded to `render!` to control the discretization, and `target_layer` and
-`remap_originals` must be `GDSMeta`. Rendering to an exact coordinate type may throw an
+`remap_originals` must be `GDSMeta`. Rendering to an integer coordinate type may throw an
 `InexactError` if a discretized point is not representable; in that case `geom` is left
-unchanged. Because a `Cell` stores the discretized result, this pass should be applied only
-once, as a final step before export: re-applying it to its own output would operate on the
-sampled arc points rather than true arcs, multiplying vertices with each pass. (This does
-not apply to `CoordinateSystem` targets, where the result stays symbolic.)
+unchanged.
 
 See [`round_layer`](@ref) for the rounding keyword arguments.
 """
@@ -80,49 +72,31 @@ function round_layer!(
     radius::Coordinate;
     target_layer::Meta,
     remap_originals::Union{Meta, Nothing}=nothing,
-    min_side_len=nothing,
+    min_side_len=radius,
     min_angle::Real=1e-3,
     kwargs...
 )
     regions = round_layer(geom, layer, radius; min_side_len, min_angle)
 
     # Stage rendering so conversion or discretization failures leave `geom` unchanged.
-    staged = _round_layer_staging(geom)
+    staged = coordsys_type(geom)("round_layer_staging")
     for r in regions
         render!(staged, r, target_layer; kwargs...)
     end
 
-    geom_elements = elements(geom)
-    geom_meta = element_metadata(geom)
-    staged_elements = convert(Vector{eltype(geom_elements)}, elements(staged))
-    staged_meta = convert(Vector{eltype(geom_meta)}, element_metadata(staged))
-    converted_remap =
-        isnothing(remap_originals) ? nothing : convert(eltype(geom_meta), remap_originals)
+    # Remap before adding new elements in case `layer == target_layer`
+    !isnothing(remap_originals) &&
+        map_metadata!(geom, m -> m == layer ? remap_originals : m)
 
-    # Capture original indices before appending so target_layer == layer does not cause the
-    # newly rendered elements to be remapped.
-    remap_idx =
-        isnothing(converted_remap) ? Int[] : findall(layer_inclusion(layer, []), geom_meta)
-
-    append!(geom_elements, staged_elements)
-    append!(geom_meta, staged_meta)
-    for i in remap_idx
-        geom_meta[i] = converted_remap
-    end
+    append!(elements(geom), elements(staged))
+    append!(element_metadata(geom), element_metadata(staged))
     return geom
 end
 
-_round_layer_staging(::Cell{S}) where {S} = Cell{S}("round_layer_staging")
-_round_layer_staging(::CoordinateSystem{S}) where {S} =
-    CoordinateSystem{S}("round_layer_staging")
-
 function _rounded_regions(cell::Cell{S}, layer, sty) where {S}
-    V = float(S)
     polys = flat_elements(cell, layer)
-    isempty(polys) && return CurvilinearRegion{V}[]
-    # Keep exact-coordinate clipping on Clipper's native integer path, then widen its result
-    # for symbolic rounding.
-    return to_curvilinear(convert(ClippedPolygon{V}, union2d(polys)), sty)
+    isempty(polys) && return CurvilinearRegion{S}[]
+    return to_curvilinear(union2d(polys), sty)
 end
 
 function _rounded_regions(cs::CoordinateSystem{S}, layer, sty) where {S}

--- a/src/postrender.jl
+++ b/src/postrender.jl
@@ -6,7 +6,7 @@
 
 """
     round_layer(geom::Union{Cell,CoordinateSystem}, layer::DeviceLayout.Meta, radius;
-        relative=false, min_side_len=nothing, min_angle=1e-3)
+        min_side_len=nothing, min_angle=1e-3)
 
 Return the geometry of `geom` in `layer` as a `Vector{CurvilinearRegion}` with corners
 rounded to `radius`.
@@ -31,11 +31,8 @@ carried over.
 
 # Keyword arguments
 
-  - `relative`: if `true`, `radius` must be a dimensionless number, and the radius of
-    curvature at each vertex is `radius * min(l₁, l₂)` where `l₁` and `l₂` are the lengths
-    of the two adjacent sides (see [`Polygons.Rounded`](@ref)).
   - `min_side_len`: the minimum side length adjacent to a corner for that corner to be
-    rounded. Defaults to `radius` (or to zero if `relative=true`).
+    rounded. Defaults to `radius`.
   - `min_angle`: corners where adjacent sides are collinear within this tolerance (in
     radians) are not rounded.
 """
@@ -43,24 +40,17 @@ function round_layer(
     geom::Union{Cell, CoordinateSystem},
     layer::Meta,
     radius::Coordinate;
-    relative::Bool=false,
-    min_side_len=nothing,
+    min_side_len=radius,
     min_angle::Real=1e-3
 )
-    sty = _round_layer_style(
-        float(coordinatetype(geom)),
-        radius,
-        relative,
-        min_side_len,
-        min_angle
-    )
+    sty = Rounded(radius; min_side_len, min_angle)
     return _rounded_regions(geom, layer, sty)
 end
 
 """
     round_layer!(geom::Union{Cell,CoordinateSystem}, layer::DeviceLayout.Meta, radius;
         target_layer::DeviceLayout.Meta, remap_originals=nothing,
-        relative=false, min_side_len=nothing, min_angle=1e-3, kwargs...)
+        min_side_len=nothing, min_angle=1e-3, kwargs...)
 
 Round the corners of the geometry of `geom` in `layer` to `radius`, rendering the result
 into `geom` itself with metadata `target_layer`.
@@ -90,21 +80,11 @@ function round_layer!(
     radius::Coordinate;
     target_layer::Meta,
     remap_originals::Union{Meta, Nothing}=nothing,
-    relative::Bool=false,
     min_side_len=nothing,
     min_angle::Real=1e-3,
     kwargs...
 )
-    if geom isa Cell
-        target_layer isa GDSMeta ||
-            throw(ArgumentError("`target_layer` must be a `GDSMeta` for a `Cell` target."))
-        isnothing(remap_originals) ||
-            remap_originals isa GDSMeta ||
-            throw(
-                ArgumentError("`remap_originals` must be a `GDSMeta` for a `Cell` target.")
-            )
-    end
-    regions = round_layer(geom, layer, radius; relative, min_side_len, min_angle)
+    regions = round_layer(geom, layer, radius; min_side_len, min_angle)
 
     # Stage rendering so conversion or discretization failures leave `geom` unchanged.
     staged = _round_layer_staging(geom)
@@ -135,35 +115,6 @@ end
 _round_layer_staging(::Cell{S}) where {S} = Cell{S}("round_layer_staging")
 _round_layer_staging(::CoordinateSystem{S}) where {S} =
     CoordinateSystem{S}("round_layer_staging")
-
-# Build the `Rounded` style carrying all rounding parameters, with the style's coordinate
-# type pinned to the (float) coordinate type of the input geometry. `RelativeRounded` is
-# not used here because it guesses its coordinate type from preferred units, which fails
-# for unitless geometry.
-function _round_layer_style(
-    ::Type{V},
-    radius,
-    relative::Bool,
-    min_side_len,
-    min_angle
-) where {V}
-    if relative
-        radius isa Real || throw(
-            ArgumentError(
-                "`relative=true` requires a dimensionless `radius` (a fraction of the shorter adjacent side length), got $radius."
-            )
-        )
-        msl = isnothing(min_side_len) ? zero(V) : min_side_len
-        return Rounded{V}(;
-            rel_r=Float64(radius),
-            min_side_len=msl,
-            min_angle=Float64(min_angle)
-        )
-    end
-    r = convert(V, radius)
-    msl = isnothing(min_side_len) ? r : min_side_len
-    return Rounded{V}(; abs_r=r, min_side_len=msl, min_angle=Float64(min_angle))
-end
 
 function _rounded_regions(cell::Cell{S}, layer, sty) where {S}
     V = float(S)

--- a/test/test_postrender.jl
+++ b/test/test_postrender.jl
@@ -171,21 +171,6 @@
             points(elements(cell)[only(findall(==(GDSMeta(2)), element_metadata(cell)))])
         )
         @test np(fine) > np(coarse)
-
-        # Cell targets require GDSMeta.
-        @test_throws ArgumentError round_layer!(
-            c,
-            GDSMeta(2),
-            1μm;
-            target_layer=SemanticMeta(:metal)
-        )
-        @test_throws ArgumentError round_layer!(
-            c,
-            GDSMeta(2),
-            1μm;
-            target_layer=GDSMeta(4),
-            remap_originals=SemanticMeta(:metal)
-        )
     end
 
     @testset "round_layer! on CoordinateSystem: symbolic placement" begin
@@ -206,61 +191,5 @@
         idx = findall(==(SemanticMeta(:metal_rounded)), element_metadata(cs))
         @test length(idx) == 1
         @test elements(cs)[only(idx)] isa CurvilinearRegion # stays symbolic
-    end
-
-    @testset "Exact coordinate types" begin
-        c = Cell{Int}("int")
-        push!(c.elements, Polygon(p(0, 0), p(1000, 0), p(1000, 1000), p(0, 1000)))
-        push!(c.element_metadata, GDSMeta(1))
-
-        # Out-of-place widens only after taking the exact-coordinate Clipper path.
-        regions = round_layer(c, GDSMeta(1), 100)
-        @test length(regions) == 1
-        @test coordinatetype(only(regions)) === Float64
-
-        # A coarse discretization whose points lie on the integer grid is representable.
-        round_layer!(c, GDSMeta(1), 100; target_layer=GDSMeta(2), atol=100)
-        @test count(==(GDSMeta(2)), element_metadata(c)) == 1
-
-        # A finer discretization is not representable, and failure is transactional.
-        c_fail = Cell{Int}("int_fail")
-        push!(c_fail.elements, Polygon(p(0, 0), p(1000, 0), p(1000, 1000), p(0, 1000)))
-        push!(c_fail.element_metadata, GDSMeta(1))
-        @test_throws InexactError round_layer!(
-            c_fail,
-            GDSMeta(1),
-            100;
-            target_layer=GDSMeta(2),
-            remap_originals=GDSMeta(3)
-        )
-        @test elements(c_fail) == [Polygon(p(0, 0), p(1000, 0), p(1000, 1000), p(0, 1000))]
-        @test element_metadata(c_fail) == [GDSMeta(1)]
-
-        # Large integer coordinates must not take the prescaled floating-point Clipper path.
-        c_large = Cell{Int}("int_large")
-        b = 10^12
-        push!(
-            c_large.elements,
-            Polygon(p(b, b), p(b + 1000, b), p(b + 1000, b + 1000), p(b, b + 1000))
-        )
-        push!(c_large.element_metadata, GDSMeta(1))
-        @test length(round_layer(c_large, GDSMeta(1), 100)) == 1
-
-        # Exact symbolic fillets remain valid in an integer CoordinateSystem.
-        cs = CoordinateSystem{Int}("int_cs")
-        place!(
-            cs,
-            Polygon(p(0, 0), p(1000, 0), p(1000, 1000), p(0, 1000)),
-            SemanticMeta(:metal)
-        )
-        cs_regions = round_layer(cs, SemanticMeta(:metal), 100)
-        @test coordinatetype(only(cs_regions)) === Int
-        @test length(only(cs_regions).exterior.curves) == 4
-        @test all(c -> c isa Paths.Turn{Int}, only(cs_regions).exterior.curves)
-
-        # Empty exact-coordinate targets are valid no-ops.
-        empty_cell = Cell{Int}("int_empty")
-        @test round_layer!(empty_cell, GDSMeta(1), 100; target_layer=GDSMeta(2)) ===
-              empty_cell
     end
 end

--- a/test/test_postrender.jl
+++ b/test/test_postrender.jl
@@ -77,19 +77,6 @@
         @test length(only(regions).exterior.curves) == 4
     end
 
-    @testset "round_layer: relative radius" begin
-        c = Cell{typeof(1.0nm)}("relative")
-        render!(
-            c,
-            Polygon(p(0μm, 0μm), p(20μm, 0μm), p(20μm, 10μm), p(0μm, 10μm)),
-            GDSMeta(1)
-        )
-        regions = round_layer(c, GDSMeta(1), 0.25; relative=true)
-        @test length(regions) == 1
-        @test length(only(regions).exterior.curves) == 4
-        @test_throws ArgumentError round_layer(c, GDSMeta(1), 1μm; relative=true)
-    end
-
     @testset "round_layer on CoordinateSystem: semantic filter, curve preservation" begin
         cs = CoordinateSystem{typeof(1.0nm)}("semantic")
         place!(

--- a/test/test_postrender.jl
+++ b/test/test_postrender.jl
@@ -1,0 +1,233 @@
+@testitem "Postrender" setup = [CommonTestSetup] begin
+    import DeviceLayout: CurvilinearRegion, SemanticMeta, coordinatetype
+
+    # Square ring built from four overlapping rectangles: union has one hole.
+    ring_polys(T) = [
+        Polygon(Point{T}[p(0μm, 0μm), p(10μm, 0μm), p(10μm, 30μm), p(0μm, 30μm)]),
+        Polygon(Point{T}[p(20μm, 0μm), p(30μm, 0μm), p(30μm, 30μm), p(20μm, 30μm)]),
+        Polygon(Point{T}[p(0μm, 0μm), p(30μm, 0μm), p(30μm, 10μm), p(0μm, 10μm)]),
+        Polygon(Point{T}[p(0μm, 20μm), p(30μm, 20μm), p(30μm, 30μm), p(0μm, 30μm)])
+    ]
+
+    @testset "round_layer on Cell: union-first, holes, filtering" begin
+        c = Cell{typeof(1.0nm)}("rounding")
+        # Two adjacent squares sharing a full edge: union-first means the shared edge
+        # must not produce rounded-apart corners.
+        render!(
+            c,
+            Polygon(p(0μm, 0μm), p(10μm, 0μm), p(10μm, 10μm), p(0μm, 10μm)),
+            GDSMeta(1)
+        )
+        render!(
+            c,
+            Polygon(p(10μm, 0μm), p(20μm, 0μm), p(20μm, 10μm), p(10μm, 10μm)),
+            GDSMeta(1)
+        )
+        # Unrelated layer must not participate.
+        render!(
+            c,
+            Polygon(p(0μm, 20μm), p(1μm, 20μm), p(1μm, 21μm), p(0μm, 21μm)),
+            GDSMeta(2)
+        )
+
+        regions = round_layer(c, GDSMeta(1), 1μm)
+        @test regions isa Vector{<:CurvilinearRegion}
+        @test length(regions) == 1
+        r = only(regions)
+        # Only the four outer corners of the merged 20×10 rectangle are rounded.
+        @test length(r.exterior.curves) == 4
+        @test all(t -> t isa Paths.Turn, r.exterior.curves)
+        @test isempty(r.holes)
+        # Input cell is untouched by the out-of-place pass.
+        @test length(elements(c)) == 3
+
+        # Empty selection.
+        @test isempty(round_layer(c, GDSMeta(99), 1μm))
+
+        # Holes are preserved and their corners rounded.
+        cring = Cell{typeof(1.0nm)}("ring")
+        for poly in ring_polys(typeof(1.0μm))
+            render!(cring, poly, GDSMeta(1))
+        end
+        ring_regions = round_layer(cring, GDSMeta(1), 1μm)
+        @test length(ring_regions) == 1
+        ring = only(ring_regions)
+        @test length(ring.holes) == 1
+        @test length(ring.exterior.curves) == 4
+        @test length(only(ring.holes).curves) == 4
+    end
+
+    @testset "round_layer on Cell: references are flattened" begin
+        sub = Cell{typeof(1.0nm)}("sub")
+        render!(
+            sub,
+            Polygon(p(0μm, 0μm), p(10μm, 0μm), p(10μm, 10μm), p(0μm, 10μm)),
+            GDSMeta(1)
+        )
+        top = Cell{typeof(1.0nm)}("top")
+        render!(
+            top,
+            Polygon(p(10μm, 0μm), p(20μm, 0μm), p(20μm, 10μm), p(10μm, 10μm)),
+            GDSMeta(1)
+        )
+        addref!(top, sub)
+        regions = round_layer(top, GDSMeta(1), 1μm)
+        # The referenced square merges with the top-level square across the shared edge.
+        @test length(regions) == 1
+        @test length(only(regions).exterior.curves) == 4
+    end
+
+    @testset "round_layer: relative radius" begin
+        c = Cell{typeof(1.0nm)}("relative")
+        render!(
+            c,
+            Polygon(p(0μm, 0μm), p(20μm, 0μm), p(20μm, 10μm), p(0μm, 10μm)),
+            GDSMeta(1)
+        )
+        regions = round_layer(c, GDSMeta(1), 0.25; relative=true)
+        @test length(regions) == 1
+        @test length(only(regions).exterior.curves) == 4
+        @test_throws ArgumentError round_layer(c, GDSMeta(1), 1μm; relative=true)
+    end
+
+    @testset "round_layer on CoordinateSystem: semantic filter, curve preservation" begin
+        cs = CoordinateSystem{typeof(1.0nm)}("semantic")
+        place!(
+            cs,
+            Polygon(p(0μm, 0μm), p(10μm, 0μm), p(10μm, 10μm), p(0μm, 10μm)),
+            SemanticMeta(:metal)
+        )
+        place!(
+            cs,
+            Polygon(p(10μm, 0μm), p(20μm, 0μm), p(20μm, 10μm), p(10μm, 10μm)),
+            SemanticMeta(:metal)
+        )
+        place!(
+            cs,
+            Polygon(p(0μm, 20μm), p(1μm, 20μm), p(1μm, 21μm), p(0μm, 21μm)),
+            SemanticMeta(:other)
+        )
+        regions = round_layer(cs, SemanticMeta(:metal), 1μm)
+        @test length(regions) == 1
+        @test length(only(regions).exterior.curves) == 4
+
+        # Curves already present in the input survive the union symbolically: a
+        # pre-rounded square keeps its four arcs (its corners are already round, so the
+        # pass adds none; tangent line-arc joints are collinear within min_angle).
+        cs2 = CoordinateSystem{typeof(1.0nm)}("curved")
+        sq = Polygon(p(0μm, 0μm), p(10μm, 0μm), p(10μm, 10μm), p(0μm, 10μm))
+        place!(cs2, Polygons.Rounded(2μm)(sq), SemanticMeta(:metal))
+        regions2 = round_layer(cs2, SemanticMeta(:metal), 1μm)
+        @test length(regions2) == 1
+        @test length(only(regions2).exterior.curves) == 4
+    end
+
+    @testset "round_layer! on Cell: render, remap, atol forwarding" begin
+        T = typeof(1.0nm)
+        c = Cell{T}("inplace")
+        render!(
+            c,
+            Polygon(p(0μm, 0μm), p(10μm, 0μm), p(10μm, 10μm), p(0μm, 10μm)),
+            GDSMeta(1)
+        )
+        render!(
+            c,
+            Polygon(p(10μm, 0μm), p(20μm, 0μm), p(20μm, 10μm), p(10μm, 10μm)),
+            GDSMeta(1)
+        )
+        round_layer!(
+            c,
+            GDSMeta(1),
+            1μm;
+            target_layer=GDSMeta(2),
+            remap_originals=GDSMeta(3)
+        )
+        # Originals retagged (not deleted), rounded result rendered on the target layer.
+        @test count(==(GDSMeta(3)), element_metadata(c)) == 2
+        @test count(==(GDSMeta(1)), element_metadata(c)) == 0
+        new_idx = findall(==(GDSMeta(2)), element_metadata(c))
+        @test length(new_idx) == 1
+        @test length(points(elements(c)[only(new_idx)])) > 4 # discretized fillets
+
+        # remap with target_layer == layer must not retag the newly rendered elements.
+        c2 = Cell{T}("inplace2")
+        render!(
+            c2,
+            Polygon(p(0μm, 0μm), p(10μm, 0μm), p(10μm, 10μm), p(0μm, 10μm)),
+            GDSMeta(1)
+        )
+        round_layer!(
+            c2,
+            GDSMeta(1),
+            1μm;
+            target_layer=GDSMeta(1),
+            remap_originals=GDSMeta(3)
+        )
+        @test count(==(GDSMeta(1)), element_metadata(c2)) == 1
+        @test count(==(GDSMeta(3)), element_metadata(c2)) == 1
+
+        # atol is forwarded to discretization.
+        fine = Cell{T}("fine")
+        coarse = Cell{T}("coarse")
+        for cc in (fine, coarse)
+            render!(
+                cc,
+                Polygon(p(0μm, 0μm), p(10μm, 0μm), p(10μm, 10μm), p(0μm, 10μm)),
+                GDSMeta(1)
+            )
+        end
+        round_layer!(fine, GDSMeta(1), 2μm; target_layer=GDSMeta(2), atol=1nm)
+        round_layer!(coarse, GDSMeta(1), 2μm; target_layer=GDSMeta(2), atol=100nm)
+        np(cell) = length(
+            points(elements(cell)[only(findall(==(GDSMeta(2)), element_metadata(cell)))])
+        )
+        @test np(fine) > np(coarse)
+
+        # Cell targets require GDSMeta.
+        @test_throws ArgumentError round_layer!(
+            c,
+            GDSMeta(2),
+            1μm;
+            target_layer=SemanticMeta(:metal)
+        )
+        @test_throws ArgumentError round_layer!(
+            c,
+            GDSMeta(2),
+            1μm;
+            target_layer=GDSMeta(4),
+            remap_originals=SemanticMeta(:metal)
+        )
+    end
+
+    @testset "round_layer! on CoordinateSystem: symbolic placement" begin
+        cs = CoordinateSystem{typeof(1.0nm)}("inplace_cs")
+        place!(
+            cs,
+            Polygon(p(0μm, 0μm), p(10μm, 0μm), p(10μm, 10μm), p(0μm, 10μm)),
+            SemanticMeta(:metal)
+        )
+        round_layer!(
+            cs,
+            SemanticMeta(:metal),
+            1μm;
+            target_layer=SemanticMeta(:metal_rounded),
+            remap_originals=SemanticMeta(:metal_original)
+        )
+        @test count(==(SemanticMeta(:metal_original)), element_metadata(cs)) == 1
+        idx = findall(==(SemanticMeta(:metal_rounded)), element_metadata(cs))
+        @test length(idx) == 1
+        @test elements(cs)[only(idx)] isa CurvilinearRegion # stays symbolic
+    end
+
+    @testset "Integer-coordinate Cells" begin
+        c = Cell{Int}("int")
+        push!(c.elements, Polygon(p(0, 0), p(1000, 0), p(1000, 1000), p(0, 1000)))
+        push!(c.element_metadata, GDSMeta(1))
+        # Out-of-place widens to float and works.
+        regions = round_layer(c, GDSMeta(1), 100)
+        @test length(regions) == 1
+        @test coordinatetype(only(regions)) === Float64
+        # In-place cannot store the result and throws cleanly.
+        @test_throws ArgumentError round_layer!(c, GDSMeta(1), 100; target_layer=GDSMeta(2))
+    end
+end

--- a/test/test_postrender.jl
+++ b/test/test_postrender.jl
@@ -119,7 +119,9 @@
         place!(cs2, Polygons.Rounded(2μm)(sq), SemanticMeta(:metal))
         regions2 = round_layer(cs2, SemanticMeta(:metal), 1μm)
         @test length(regions2) == 1
-        @test length(only(regions2).exterior.curves) == 4
+        preserved_curves = only(regions2).exterior.curves
+        @test length(preserved_curves) == 4
+        @test all(c -> c.r ≈ 2μm, preserved_curves)
     end
 
     @testset "round_layer! on Cell: render, remap, atol forwarding" begin
@@ -219,15 +221,59 @@
         @test elements(cs)[only(idx)] isa CurvilinearRegion # stays symbolic
     end
 
-    @testset "Integer-coordinate Cells" begin
+    @testset "Exact coordinate types" begin
         c = Cell{Int}("int")
         push!(c.elements, Polygon(p(0, 0), p(1000, 0), p(1000, 1000), p(0, 1000)))
         push!(c.element_metadata, GDSMeta(1))
-        # Out-of-place widens to float and works.
+
+        # Out-of-place widens only after taking the exact-coordinate Clipper path.
         regions = round_layer(c, GDSMeta(1), 100)
         @test length(regions) == 1
         @test coordinatetype(only(regions)) === Float64
-        # In-place cannot store the result and throws cleanly.
-        @test_throws ArgumentError round_layer!(c, GDSMeta(1), 100; target_layer=GDSMeta(2))
+
+        # A coarse discretization whose points lie on the integer grid is representable.
+        round_layer!(c, GDSMeta(1), 100; target_layer=GDSMeta(2), atol=100)
+        @test count(==(GDSMeta(2)), element_metadata(c)) == 1
+
+        # A finer discretization is not representable, and failure is transactional.
+        c_fail = Cell{Int}("int_fail")
+        push!(c_fail.elements, Polygon(p(0, 0), p(1000, 0), p(1000, 1000), p(0, 1000)))
+        push!(c_fail.element_metadata, GDSMeta(1))
+        @test_throws InexactError round_layer!(
+            c_fail,
+            GDSMeta(1),
+            100;
+            target_layer=GDSMeta(2),
+            remap_originals=GDSMeta(3)
+        )
+        @test elements(c_fail) == [Polygon(p(0, 0), p(1000, 0), p(1000, 1000), p(0, 1000))]
+        @test element_metadata(c_fail) == [GDSMeta(1)]
+
+        # Large integer coordinates must not take the prescaled floating-point Clipper path.
+        c_large = Cell{Int}("int_large")
+        b = 10^12
+        push!(
+            c_large.elements,
+            Polygon(p(b, b), p(b + 1000, b), p(b + 1000, b + 1000), p(b, b + 1000))
+        )
+        push!(c_large.element_metadata, GDSMeta(1))
+        @test length(round_layer(c_large, GDSMeta(1), 100)) == 1
+
+        # Exact symbolic fillets remain valid in an integer CoordinateSystem.
+        cs = CoordinateSystem{Int}("int_cs")
+        place!(
+            cs,
+            Polygon(p(0, 0), p(1000, 0), p(1000, 1000), p(0, 1000)),
+            SemanticMeta(:metal)
+        )
+        cs_regions = round_layer(cs, SemanticMeta(:metal), 100)
+        @test coordinatetype(only(cs_regions)) === Int
+        @test length(only(cs_regions).exterior.curves) == 4
+        @test all(c -> c isa Paths.Turn{Int}, only(cs_regions).exterior.curves)
+
+        # Empty exact-coordinate targets are valid no-ops.
+        empty_cell = Cell{Int}("int_empty")
+        @test round_layer!(empty_cell, GDSMeta(1), 100; target_layer=GDSMeta(2)) ===
+              empty_cell
     end
 end


### PR DESCRIPTION
Close #218. Has out-of-place and in-place versions, where the latter renders the out-of-place results to the top level in a target layer, and can optionally map the originals to another layer. Also has Cell and CoordinateSystem versions, where the latter uses `union2d_curved`.

There is no `relative` option, since there is no use case requiring that. There's also no special error handling -- coordinate type or metadata type mismatches will just throw wherever they need to.