### PR TITLE
Add ParameterSet bulk operations and graph extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,14 @@ The format of this changelog is based on
     `ParameterSet`, enabling independent programmatic templates such as
     `design.components.q1 = library.templates.qubit`.
   - Added recursive `merge` and `merge!` support for `ParameterSet`, with later sources taking
-    precedence and no mutable parameter data shared with the sources.
+    precedence and no mutable parameter data shared with the sources. `merge!` rebuilds the
+    destination's namespaces, so scoped views held from before the merge are stale and must be
+    re-derived.
   - Added `extract_parameter_set(g::SchematicGraph)` to create a detached parameter tree from
     supported final graph-component values, including defaults and recursively realized
-    composite subgraphs while preserving attached top-level metadata. Scalar leaves and ordinary
-    arrays are retained; unsupported custom values such as `Point`s are omitted.
+    composite subgraphs while preserving attached top-level metadata. Scalar leaves and
+    one-dimensional `AbstractArray`s including ranges and views are retained as plain vectors;
+    unsupported custom values such as `Point`s are omitted.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ The format of this changelog is based on
     supported final graph-component values, including defaults and recursively realized
     composite subgraphs while preserving attached top-level metadata. Scalar leaves and ordinary
     arrays are retained; unsupported custom values such as `Point`s are omitted.
+
+### Changed
+
+  - `ParameterSet` namespaces are now copied by assignment from another root or scoped
+    `ParameterSet`, enabling independent programmatic templates such as
+    `design.components.q1 = library.templates.qubit`.
   - Parameter-set YAML output now emits `Unitful.Quantity` values as unquoted plain scalars.
 
 ## 1.16.1 (2026-07-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ The format of this changelog is based on
     an arc tangent to both adjacent arcs, honoring `p0`/`inverse_selection` like the other
     corner types, on both the GDS and `SolidModel` paths. New exports
     `Curvilinear.arc_arc_cornerindices` and `Curvilinear.rounded_corner_segment_arc_arc`.
+  - `ParameterSet` namespaces can now be copied by assignment from another root or scoped
+    `ParameterSet`, enabling independent programmatic templates such as
+    `design.components.q1 = library.templates.qubit`.
+  - Added recursive `merge` and `merge!` support for `ParameterSet`, with later sources taking
+    precedence and no mutable parameter data shared with the sources.
+  - Added `extract_parameter_set(g::SchematicGraph)` to create a detached parameter tree from
+    supported final graph-component values, including defaults and recursively realized
+    composite subgraphs while preserving attached top-level metadata. Scalar leaves and ordinary
+    arrays are retained; unsupported custom values such as `Point`s are omitted.
+  - Parameter-set YAML output now emits `Unitful.Quantity` values as unquoted plain scalars.
 
 ## 1.16.1 (2026-07-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,6 @@ The format of this changelog is based on
     an arc tangent to both adjacent arcs, honoring `p0`/`inverse_selection` like the other
     corner types, on both the GDS and `SolidModel` paths. New exports
     `Curvilinear.arc_arc_cornerindices` and `Curvilinear.rounded_corner_segment_arc_arc`.
-  - `ParameterSet` namespaces can now be copied by assignment from another root or scoped
-    `ParameterSet`, enabling independent programmatic templates such as
-    `design.components.q1 = library.templates.qubit`.
   - Added recursive `merge` and `merge!` support for `ParameterSet`, with later sources taking
     precedence and no mutable parameter data shared with the sources. `merge!` rebuilds the
     destination's namespaces, so scoped views held from before the merge are stale and must be

--- a/Project.toml
+++ b/Project.toml
@@ -37,11 +37,11 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 ThreadSafeDicts = "4239201d-c60e-5e0a-9702-85d713665ba7"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 gmsh_jll = "630162c2-fc9b-58b3-9910-8442a8a132e6"
 
 [weakdeps]
 GraphMakie = "1ecd5474-83a3-4783-bb4f-06765db800d2"
-YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [extensions]
 ParameterSetYAMLExt = "YAML"

--- a/Project.toml
+++ b/Project.toml
@@ -37,11 +37,11 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 ThreadSafeDicts = "4239201d-c60e-5e0a-9702-85d713665ba7"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
-YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 gmsh_jll = "630162c2-fc9b-58b3-9910-8442a8a132e6"
 
 [weakdeps]
 GraphMakie = "1ecd5474-83a3-4783-bb4f-06765db800d2"
+YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [extensions]
 ParameterSetYAMLExt = "YAML"

--- a/docs/src/reference/parameter_set_api.md
+++ b/docs/src/reference/parameter_set_api.md
@@ -9,7 +9,12 @@ DeviceLayout.SchematicDrivenLayout.ParameterKeyError
 DeviceLayout.SchematicDrivenLayout.resolve
 DeviceLayout.SchematicDrivenLayout.leaf_params
 DeviceLayout.SchematicDrivenLayout.save_parameter_set
+DeviceLayout.SchematicDrivenLayout.extract_parameter_set
 ```
+
+`Base.merge` and `Base.merge!` are also implemented for root and scoped
+`ParameterSet`s. They recursively merge namespaces, deep-copy inserted values,
+and apply multiple sources from left to right.
 
 ## Component construction from a `ParameterSet`
 

--- a/docs/src/tutorials/parameter_set.md
+++ b/docs/src/tutorials/parameter_set.md
@@ -135,6 +135,19 @@ merged recursively; when a namespace and leaf occupy the same key, the later
 value replaces the earlier one. `merge(a, b, ...)` provides the same behavior
 without mutating `a` and returns a detached `ParameterSet`.
 
+!!! warning
+
+    `merge!` rebuilds the namespaces below the destination so that the result
+    never shares mutable data with a source. A scoped `ParameterSet` reaching
+    below the merge target still points at the superseded subtree, so re-derive
+    it from the destination afterwards rather than reusing the old handle:
+
+    ```julia
+    routing = design.components.q1.routing   # taken before the merge
+    merge!(design.components.q1, process.components.q1)
+    routing = design.components.q1.routing   # re-derive to see merged values
+    ```
+
 ## Reading Parameters
 
 Use dot syntax to navigate the hierarchy:

--- a/docs/src/tutorials/parameter_set.md
+++ b/docs/src/tutorials/parameter_set.md
@@ -75,6 +75,63 @@ using YAML  # activates the ParameterSetYAMLExt extension
 ps = ParameterSet("design_params.yaml")
 ```
 
+YAML anchors and merge keys are resolved when the file is loaded, so shared
+parameter templates can also be authored directly in YAML:
+
+```yaml
+templates:
+  qubit: &qubit
+    cap_width: 24μm
+    cap_length: 520μm
+    cap_gap: 30μm
+
+components:
+  q1:
+    <<: *qubit
+    cap_length: 600μm
+```
+
+## Programmatic Templates and Merging
+
+A template can live in any `ParameterSet` namespace, including a separate
+parameter-library set. Assigning a scoped `ParameterSet` copies its complete
+subtree:
+
+```julia
+library = ParameterSet()
+library.templates.qubit.cap_width = 24μm
+library.templates.qubit.cap_length = 520μm
+library.templates.qubit.routing.offsets = [0μm, 25μm]
+
+design = ParameterSet()
+design.components.q1 = library.templates.qubit
+design.components.q1.cap_length = 600μm
+```
+
+The copy is independent. Changing `design.components.q1` or one of its nested
+arrays does not mutate `library.templates.qubit`.
+
+Use `merge!` to recursively overlay one or more parameter subtrees:
+
+```julia
+process = ParameterSet()
+process.components.q1.cap_gap = 28μm
+
+local_overrides = ParameterSet()
+local_overrides.components.q1.cap_length = 650μm
+
+merge!(
+    design.components.q1,
+    process.components.q1,
+    local_overrides.components.q1,
+)
+```
+
+Sources are applied from left to right, so later values win. Namespaces are
+merged recursively; when a namespace and leaf occupy the same key, the later
+value replaces the earlier one. `merge(a, b, ...)` provides the same behavior
+without mutating `a` and returns a detached `ParameterSet`.
+
 ## Reading Parameters
 
 Use dot syntax to navigate the hierarchy:
@@ -162,6 +219,36 @@ cap2_node = fuse!(g, cap1_node => :p1, cap2 => :p0)
 
 sch = plan(g; log_dir=nothing)
 ```
+
+## Extracting Final Parameters from a Graph
+
+An attached parameter set is the source document and may contain only
+overrides. Use `extract_parameter_set` to obtain a detached set containing the
+supported final parameters of the component instances in a constructed graph:
+
+```julia
+resolved = extract_parameter_set(g)
+
+resolved.components.cap1.finger_length
+resolved.components.cap1.finger_gap  # included even when it came from a default
+```
+
+Components are addressed by their unique graph node IDs. Dotted IDs become
+nested namespaces, and composite subcomponents are nested below their parent:
+
+```julia
+resolved.components.module.q1.island.cap_width
+```
+
+The graph's attached `global` and other top-level metadata are copied into the
+result, while its source `components` namespace is replaced by the final graph
+contents. Composite extraction realizes lazy subgraphs. The result has no
+source path or access history and shares no mutable parameter data with the
+graph or its attached source.
+
+Extraction retains scalar parameter leaves and ordinary Julia `Array`s.
+`NamedTuple`s and dictionaries become namespaces. Unsupported custom values,
+including `Point`s and component-valued parameters, are omitted.
 
 ## Composite Components with ParameterSet
 

--- a/docs/src/tutorials/parameter_set.md
+++ b/docs/src/tutorials/parameter_set.md
@@ -91,6 +91,9 @@ components:
     cap_length: 600μm
 ```
 
+Loaded aliases are detached from one another. Mutating `components.q1` does not
+mutate `templates.qubit`.
+
 ## Programmatic Templates and Merging
 
 A template can live in any `ParameterSet` namespace, including a separate
@@ -210,8 +213,14 @@ ps.components.cap2.finger_count = 8
 g = SchematicGraph("two_caps", ps)
 
 # Create components from parameter set
-cap1 = create_component(MyCapacitor, ps, "components.cap1")
-cap2 = create_component(MyCapacitor, ps, "components.cap2")
+cap1 = set_parameters(
+    create_component(MyCapacitor, ps, "components.cap1"),
+    "cap1",
+)
+cap2 = set_parameters(
+    create_component(MyCapacitor, ps, "components.cap2"),
+    "cap2",
+)
 
 # Build schematic
 cap1_node = add_node!(g, cap1)
@@ -246,9 +255,9 @@ contents. Composite extraction realizes lazy subgraphs. The result has no
 source path or access history and shares no mutable parameter data with the
 graph or its attached source.
 
-Extraction retains scalar parameter leaves and ordinary Julia `Array`s.
-`NamedTuple`s and dictionaries become namespaces. Unsupported custom values,
-including `Point`s and component-valued parameters, are omitted.
+Extraction retains scalar parameter leaves and ordinary one-dimensional Julia
+`Array`s. `NamedTuple`s and dictionaries become namespaces. Unsupported custom
+values, including `Point`s and component-valued parameters, are omitted.
 
 ## Composite Components with ParameterSet
 

--- a/ext/ParameterSetYAMLExt.jl
+++ b/ext/ParameterSetYAMLExt.jl
@@ -5,6 +5,12 @@ import DeviceLayout.SchematicDrivenLayout: ParameterSet
 import YAML
 import Unitful
 
+struct _PlainYAMLString
+    value::String
+end
+
+Base.string(value::_PlainYAMLString) = value.value
+
 """
     _parse_units!(data::Dict{String, Any})
 
@@ -35,7 +41,7 @@ function _parse_unit_value(v::Dict{String, Any})
     return v
 end
 
-_parse_unit_value(v::AbstractVector) = map(_parse_unit_value, v)
+_parse_unit_value(v::Array) = map(_parse_unit_value, v)
 _parse_unit_value(v) = v
 
 function _parse_units!(data::Dict{String, Any})
@@ -56,8 +62,9 @@ function _serialize_unit_value(v::Dict{String, Any})
     return _serialize_units(v)
 end
 
-_serialize_unit_value(v::AbstractVector) = map(_serialize_unit_value, v)
-_serialize_unit_value(v::Unitful.Quantity) = "$(Unitful.ustrip(v))$(Unitful.unit(v))"
+_serialize_unit_value(v::Array) = map(_serialize_unit_value, v)
+_serialize_unit_value(v::Unitful.Quantity) =
+    _PlainYAMLString("$(Unitful.ustrip(v))$(Unitful.unit(v))")
 _serialize_unit_value(v) = v
 
 function _serialize_units(data::Dict{String, Any})

--- a/ext/ParameterSetYAMLExt.jl
+++ b/ext/ParameterSetYAMLExt.jl
@@ -1,15 +1,20 @@
 module ParameterSetYAMLExt
 
 import DeviceLayout
-import DeviceLayout.SchematicDrivenLayout: ParameterSet
+import DeviceLayout.SchematicDrivenLayout: ParameterSet, _parameter_value_copy
 import YAML
 import Unitful
 
-struct _PlainYAMLString
+struct _PlainYAMLScalar
     value::String
 end
 
-Base.string(value::_PlainYAMLString) = value.value
+Base.string(value::_PlainYAMLScalar) = value.value
+Base.show(io::IO, value::_PlainYAMLScalar) = print(io, value.value)
+
+const _PARAMETER_SET_YAML_CONSTRUCTORS = Dict{String, Function}(
+    "!symbol" => (constructor, node) -> Symbol(YAML.construct_scalar(constructor, node))
+)
 
 """
     _parse_units!(data::Dict{String, Any})
@@ -41,7 +46,7 @@ function _parse_unit_value(v::Dict{String, Any})
     return v
 end
 
-_parse_unit_value(v::Array) = map(_parse_unit_value, v)
+_parse_unit_value(v::Vector) = map(_parse_unit_value, v)
 _parse_unit_value(v) = v
 
 function _parse_units!(data::Dict{String, Any})
@@ -55,16 +60,25 @@ end
     _serialize_units(data::Dict{String, Any}) -> Dict{String, Any}
 
 Return a deep copy of `data` with `Unitful.Quantity` values, including values
-inside arrays, converted to strings like `"150μm"` (no space, round-trips
-through `Unitful.uparse`).
+inside arrays, converted to unquoted YAML scalars like `150μm` (no space,
+round-trips through `Unitful.uparse`).
 """
 function _serialize_unit_value(v::Dict{String, Any})
     return _serialize_units(v)
 end
 
-_serialize_unit_value(v::Array) = map(_serialize_unit_value, v)
+_serialize_unit_value(v::Vector) = map(_serialize_unit_value, v)
+function _serialize_unit_value(v::AbstractArray)
+    throw(
+        ArgumentError(
+            "Cannot save ParameterSet value of type $(typeof(v)): " *
+            "only one-dimensional Array values are supported."
+        )
+    )
+end
 _serialize_unit_value(v::Unitful.Quantity) =
-    _PlainYAMLString("$(Unitful.ustrip(v))$(Unitful.unit(v))")
+    _PlainYAMLScalar("$(Unitful.ustrip(v))$(Unitful.unit(v))")
+_serialize_unit_value(v::Symbol) = _PlainYAMLScalar("!symbol $(repr(String(v)))")
 _serialize_unit_value(v) = v
 
 function _serialize_units(data::Dict{String, Any})
@@ -86,7 +100,12 @@ converted in place.
 Requires `YAML.jl` to be loaded (`using YAML`).
 """
 function ParameterSet(io::IO, path::String="")
-    data = YAML.load(io; dicttype=Dict{String, Any})
+    data = YAML.load(
+        io,
+        _PARAMETER_SET_YAML_CONSTRUCTORS;
+        dicttype=Dict{String, Any}
+    )
+    data = _parameter_value_copy(data)
     _parse_units!(data)
     return DeviceLayout.SchematicDrivenLayout.ParameterSet(path, data)
 end

--- a/src/schematics/SchematicDrivenLayout.jl
+++ b/src/schematics/SchematicDrivenLayout.jl
@@ -18,6 +18,7 @@ import Logging:
     shouldlog,
     with_logger
 import LoggingExtras: FormatLogger, MinLevelLogger, TeeLogger
+import StaticArrays
 
 import DeviceLayout:
     AbstractComponent,

--- a/src/schematics/SchematicDrivenLayout.jl
+++ b/src/schematics/SchematicDrivenLayout.jl
@@ -83,6 +83,7 @@ export @component,
     components,
     create_component,
     default_parameters,
+    extract_parameter_set,
     facing,
     filter_parameters,
     find_components,
@@ -141,6 +142,7 @@ include("components/components.jl")
 include("components/compdef.jl")
 include("components/composite_components.jl")
 include("components/builtin_components.jl")
+include("parameter_set_extraction.jl")
 include("routes.jl")
 include("components/variants.jl")
 include("solidmodels.jl")

--- a/src/schematics/parameter_set.jl
+++ b/src/schematics/parameter_set.jl
@@ -112,7 +112,15 @@ function _missing_error(d::MissingNamespace)
     throw(ParameterKeyError(d.key, _namespace_path(d)))
 end
 
-_parameter_value_copy(value::ParameterSet) = _parameter_value_copy(getfield(value, :data))
+function _parameter_value_copy(value::ParameterSet)
+    result = _parameter_value_copy(getfield(value, :data))
+    if isempty(getfield(value, :prefix))
+        for namespace in REQUIRED_NAMESPACES
+            isempty(result[namespace]) && delete!(result, namespace)
+        end
+    end
+    return result
+end
 _parameter_value_copy(value::Pair) =
     Dict{String, Any}(string(first(value)) => _parameter_value_copy(last(value)))
 function _parameter_value_copy(value::AbstractDict)
@@ -123,6 +131,7 @@ end
 _parameter_value_copy(value) = deepcopy(value)
 
 _parameter_assignment_value(value::ParameterSet) = _parameter_value_copy(value)
+_parameter_assignment_value(value::AbstractDict) = _parameter_value_copy(value)
 _parameter_assignment_value(value::Pair) =
     Dict{String, Any}(string(first(value)) => _parameter_assignment_value(last(value)))
 _parameter_assignment_value(value) = value
@@ -239,10 +248,30 @@ not mark any leaves as accessed.
 """
 function Base.merge!(destination::ParameterSet, sources::ParameterSet...)
     destination_data = getfield(destination, :data)
-    for source in sources
-        _merge_parameter_data!(destination_data, getfield(source, :data))
+    source_data = [
+        _parameter_value_copy(getfield(source, :data)) for
+        source in sources if getfield(source, :data) !== destination_data
+    ]
+    isempty(source_data) && return destination
+
+    detached_destination = _parameter_value_copy(destination_data)
+    empty!(destination_data)
+    _merge_parameter_data!(destination_data, detached_destination)
+    for data in source_data
+        _merge_parameter_data!(destination_data, data)
     end
     return destination
+end
+
+function Base.merge!(destination::MissingNamespace, sources::ParameterSet...)
+    data = _materialize!(destination)
+    scoped = ParameterSet(
+        "",
+        data,
+        getfield(destination, :accessed),
+        _namespace_path(destination)
+    )
+    return merge!(scoped, sources...)
 end
 
 """
@@ -436,8 +465,8 @@ leaf_params(ps::ParameterSet) = leaf_params(getproperty(ps, :data))
 
 Save a `ParameterSet` to a YAML file at `path` or write YAML to an `IO` stream.
 
-`Unitful.Quantity` values are serialized as `"<value><unit>"` (e.g. `"150μm"`)
-for lossless round-tripping.
+`Unitful.Quantity` values are serialized as unquoted `<value><unit>` scalars
+(e.g. `150μm`) for lossless round-tripping.
 
 Requires `YAML.jl` to be loaded (`using YAML`).
 """

--- a/src/schematics/parameter_set.jl
+++ b/src/schematics/parameter_set.jl
@@ -112,6 +112,21 @@ function _missing_error(d::MissingNamespace)
     throw(ParameterKeyError(d.key, _namespace_path(d)))
 end
 
+_parameter_value_copy(value::ParameterSet) = _parameter_value_copy(getfield(value, :data))
+_parameter_value_copy(value::Pair) =
+    Dict{String, Any}(string(first(value)) => _parameter_value_copy(last(value)))
+function _parameter_value_copy(value::AbstractDict)
+    return Dict{String, Any}(
+        string(key) => _parameter_value_copy(child) for (key, child) in value
+    )
+end
+_parameter_value_copy(value) = deepcopy(value)
+
+_parameter_assignment_value(value::ParameterSet) = _parameter_value_copy(value)
+_parameter_assignment_value(value::Pair) =
+    Dict{String, Any}(string(first(value)) => _parameter_assignment_value(last(value)))
+_parameter_assignment_value(value) = value
+
 """
     _materialize!(d::MissingNamespace) -> Dict{String, Any}
 
@@ -172,9 +187,8 @@ function Base.setproperty!(d::MissingNamespace, s::Symbol, value)
         error("MissingNamespace.$s is an internal field and cannot be assigned")
     materialized = _materialize!(d)
     # Julia convention: `a.b = x` evaluates to `x`, so return the original RHS
-    # even when we wrap a `Pair` into a nested namespace Dict for storage.
-    stored = value isa Pair ? Dict{String, Any}(String(value.first) => value.second) : value
-    materialized[String(s)] = stored
+    # even when we normalize a namespace value for storage.
+    materialized[String(s)] = _parameter_assignment_value(value)
     return value
 end
 
@@ -197,6 +211,54 @@ ParameterSet(path::String, data::Dict{String, Any}) =
     ParameterSet(path, data, Set{String}())
 ParameterSet(data::Dict{String, Any}) = ParameterSet("", data)
 ParameterSet() = ParameterSet(Dict{String, Any}())
+
+function _merge_parameter_data!(destination::Dict{String, Any}, source::Dict{String, Any})
+    destination === source && return destination
+    for (key, source_value) in source
+        if haskey(destination, key) &&
+           destination[key] isa Dict{String, Any} &&
+           source_value isa Dict{String, Any}
+            _merge_parameter_data!(destination[key], source_value)
+        else
+            destination[key] = _parameter_value_copy(source_value)
+        end
+    end
+    return destination
+end
+
+"""
+    merge!(destination::ParameterSet, sources::ParameterSet...)
+
+Recursively merge `sources` into `destination`, from left to right.
+
+When both sides contain a namespace, their contents are merged recursively.
+Otherwise the later value replaces the earlier value. Inserted values are
+deep-copied, so the destination never shares mutable parameter data with a
+source. Source paths, scopes, and access logs are not merged, and merging does
+not mark any leaves as accessed.
+"""
+function Base.merge!(destination::ParameterSet, sources::ParameterSet...)
+    destination_data = getfield(destination, :data)
+    for source in sources
+        _merge_parameter_data!(destination_data, getfield(source, :data))
+    end
+    return destination
+end
+
+"""
+    merge(first::ParameterSet, rest::ParameterSet...)
+
+Return a detached recursive merge of the supplied parameter sets.
+
+The result has the same scope prefix as `first`, an empty source path, and an
+empty access log. Later sets take precedence, with the same behavior as
+[`merge!`](@ref).
+"""
+function Base.merge(first::ParameterSet, rest::ParameterSet...)
+    data = _parameter_value_copy(getfield(first, :data))
+    result = ParameterSet("", data, Set{String}(), getfield(first, :prefix))
+    return merge!(result, rest...)
+end
 
 function Base.getproperty(ps::ParameterSet, s::Symbol)
     s in (:path, :data, :accessed, :prefix) && return getfield(ps, s)
@@ -227,9 +289,8 @@ function Base.setproperty!(ps::ParameterSet, s::Symbol, value)
     )
     d = getfield(ps, :data)
     # Julia convention: `a.b = x` evaluates to `x`, so return the original RHS
-    # even when we wrap a `Pair` into a nested namespace Dict for storage.
-    stored = value isa Pair ? Dict{String, Any}(String(value.first) => value.second) : value
-    d[String(s)] = stored
+    # even when we normalize a namespace value for storage.
+    d[String(s)] = _parameter_assignment_value(value)
     return value
 end
 

--- a/src/schematics/parameter_set.jl
+++ b/src/schematics/parameter_set.jl
@@ -245,6 +245,17 @@ Otherwise the later value replaces the earlier value. Inserted values are
 deep-copied, so the destination never shares mutable parameter data with a
 source. Source paths, scopes, and access logs are not merged, and merging does
 not mark any leaves as accessed.
+
+!!! warning "Nested scoped views are invalidated"
+
+    To guarantee detachment even when `destination` already aliases parameter
+    data owned by a source, every namespace strictly below `destination` is
+    rebuilt. A view at the merge target level stays valid, because
+    `destination`'s own dict is reused, but scoped views
+    (`sub = ps.components.q1.routing`) and `MissingNamespace` handles reaching
+    deeper keep referring to the superseded dictionaries: they neither observe
+    merged values nor write back into `destination`. Re-derive them from
+    `destination` after merging.
 """
 function Base.merge!(destination::ParameterSet, sources::ParameterSet...)
     destination_data = getfield(destination, :data)

--- a/src/schematics/parameter_set_extraction.jl
+++ b/src/schematics/parameter_set_extraction.jl
@@ -3,7 +3,12 @@ const _UNSUPPORTED_PARAMETER_VALUE = _UnsupportedParameterValue()
 
 _extracted_array_value(value::Union{Number, AbstractString, Symbol, Nothing}) =
     _parameter_value_copy(value)
-function _extracted_array_value(value::Array)
+function _extracted_array_value(value::Vector)
+    if isempty(value) &&
+       eltype(value) !== Any &&
+       !(eltype(value) <: Union{Number, AbstractString, Symbol, Nothing, Vector})
+        return _UNSUPPORTED_PARAMETER_VALUE
+    end
     result = map(_extracted_array_value, value)
     any(child -> child isa _UnsupportedParameterValue, result) &&
         return _UNSUPPORTED_PARAMETER_VALUE
@@ -17,6 +22,7 @@ function _extracted_parameter_value(value::NamedTuple)
         extracted = _extracted_parameter_value(child)
         extracted isa _UnsupportedParameterValue || (result[string(key)] = extracted)
     end
+    !isempty(value) && isempty(result) && return _UNSUPPORTED_PARAMETER_VALUE
     return result
 end
 function _extracted_parameter_value(value::AbstractDict)
@@ -25,9 +31,10 @@ function _extracted_parameter_value(value::AbstractDict)
         extracted = _extracted_parameter_value(child)
         extracted isa _UnsupportedParameterValue || (result[string(key)] = extracted)
     end
+    !isempty(value) && isempty(result) && return _UNSUPPORTED_PARAMETER_VALUE
     return result
 end
-_extracted_parameter_value(value::Array) = _extracted_array_value(value)
+_extracted_parameter_value(value::Vector) = _extracted_array_value(value)
 _extracted_parameter_value(value::Union{Number, AbstractString, Symbol, Nothing}) =
     _parameter_value_copy(value)
 _extracted_parameter_value(::Any) = _UNSUPPORTED_PARAMETER_VALUE
@@ -103,6 +110,8 @@ function _extract_graph_components!(
 
         namespace = _extraction_namespace!(destination, segments, parent_address)
         parameter_data = _extracted_parameter_value(parameters(component(node)))
+        parameter_data isa _UnsupportedParameterValue &&
+            (parameter_data = Dict{String, Any}())
         _merge_extracted_namespaces!(namespace, parameter_data, address_segments)
 
         comp = component(node)
@@ -128,9 +137,9 @@ Each component is stored below `components` at its unique node ID. Dots in node
 IDs become nested namespace segments, and composite-component graphs are
 recursively nested below their parent component. Parameter values are taken
 from the constructed component instances, so defaults and applied overrides
-are both included. Scalar values and ordinary `Array`s are retained. Named
-tuples and dictionaries form parameter namespaces. Other values, including
-`Point`s and component-valued parameters, are omitted.
+are both included. Scalar values and ordinary one-dimensional `Array`s are
+retained. Named tuples and dictionaries form parameter namespaces. Other
+values, including `Point`s and component-valued parameters, are omitted.
 
 If `g` carries a source `ParameterSet`, its top-level namespaces other than
 `components` are deep-copied into the result. The source `components` namespace
@@ -145,7 +154,10 @@ function extract_parameter_set(g::SchematicGraph)
     data = if isnothing(parameter_set(g))
         Dict{String, Any}()
     else
-        _parameter_value_copy(getfield(parameter_set(g), :data))
+        Dict{String, Any}(
+            key => _parameter_value_copy(value) for
+            (key, value) in getfield(parameter_set(g), :data) if key != "components"
+        )
     end
     extracted_components = Dict{String, Any}()
     data["components"] = extracted_components

--- a/src/schematics/parameter_set_extraction.jl
+++ b/src/schematics/parameter_set_extraction.jl
@@ -1,0 +1,154 @@
+struct _UnsupportedParameterValue end
+const _UNSUPPORTED_PARAMETER_VALUE = _UnsupportedParameterValue()
+
+_extracted_array_value(value::Union{Number, AbstractString, Symbol, Nothing}) =
+    _parameter_value_copy(value)
+function _extracted_array_value(value::Array)
+    result = map(_extracted_array_value, value)
+    any(child -> child isa _UnsupportedParameterValue, result) &&
+        return _UNSUPPORTED_PARAMETER_VALUE
+    return result
+end
+_extracted_array_value(::Any) = _UNSUPPORTED_PARAMETER_VALUE
+
+function _extracted_parameter_value(value::NamedTuple)
+    result = Dict{String, Any}()
+    for (key, child) in pairs(value)
+        extracted = _extracted_parameter_value(child)
+        extracted isa _UnsupportedParameterValue || (result[string(key)] = extracted)
+    end
+    return result
+end
+function _extracted_parameter_value(value::AbstractDict)
+    result = Dict{String, Any}()
+    for (key, child) in value
+        extracted = _extracted_parameter_value(child)
+        extracted isa _UnsupportedParameterValue || (result[string(key)] = extracted)
+    end
+    return result
+end
+_extracted_parameter_value(value::Array) = _extracted_array_value(value)
+_extracted_parameter_value(value::Union{Number, AbstractString, Symbol, Nothing}) =
+    _parameter_value_copy(value)
+_extracted_parameter_value(::Any) = _UNSUPPORTED_PARAMETER_VALUE
+
+function _merge_extracted_namespaces!(
+    destination::Dict{String, Any},
+    source::Dict{String, Any},
+    address::Vector{String}
+)
+    for (key, value) in source
+        if !haskey(destination, key)
+            destination[key] = value
+        elseif destination[key] isa Dict{String, Any} && value isa Dict{String, Any}
+            _merge_extracted_namespaces!(destination[key], value, [address; key])
+        else
+            path = join([address; key], ".")
+            throw(
+                ArgumentError(
+                    "Cannot extract ParameterSet: component path collides with " *
+                    "parameter leaf \"$path\"."
+                )
+            )
+        end
+    end
+    return destination
+end
+
+function _extraction_namespace!(
+    destination::Dict{String, Any},
+    segments::Vector{String},
+    parent_address::Vector{String}
+)
+    current = destination
+    for (index, segment) in enumerate(segments)
+        isempty(segment) && throw(
+            ArgumentError(
+                "Cannot extract ParameterSet: node ID \"$(join(segments, "."))\" " *
+                "contains an empty address segment."
+            )
+        )
+        if !haskey(current, segment)
+            current[segment] = Dict{String, Any}()
+        elseif !(current[segment] isa Dict{String, Any})
+            path = join([parent_address; segments[1:index]], ".")
+            throw(
+                ArgumentError(
+                    "Cannot extract ParameterSet: component path collides with " *
+                    "parameter leaf \"$path\"."
+                )
+            )
+        end
+        current = current[segment]
+    end
+    return current
+end
+
+function _extract_graph_components!(
+    destination::Dict{String, Any},
+    schematic_graph::SchematicGraph,
+    parent_address::Vector{String},
+    component_addresses::Set{String}
+)
+    for node in nodes(schematic_graph)
+        segments = String.(split(node.id, '.'; keepempty=true))
+        address_segments = [parent_address; segments]
+        address = join(address_segments, ".")
+        address in component_addresses && throw(
+            ArgumentError(
+                "Cannot extract ParameterSet: multiple components resolve to \"$address\"."
+            )
+        )
+        push!(component_addresses, address)
+
+        namespace = _extraction_namespace!(destination, segments, parent_address)
+        parameter_data = _extracted_parameter_value(parameters(component(node)))
+        _merge_extracted_namespaces!(namespace, parameter_data, address_segments)
+
+        comp = component(node)
+        if comp isa AbstractCompositeComponent
+            _extract_graph_components!(
+                namespace,
+                graph(comp),
+                address_segments,
+                component_addresses
+            )
+        end
+    end
+    return destination
+end
+
+"""
+    extract_parameter_set(g::SchematicGraph) -> ParameterSet
+
+Create a detached `ParameterSet` containing the supported final parameters of
+the components in `g`.
+
+Each component is stored below `components` at its unique node ID. Dots in node
+IDs become nested namespace segments, and composite-component graphs are
+recursively nested below their parent component. Parameter values are taken
+from the constructed component instances, so defaults and applied overrides
+are both included. Scalar values and ordinary `Array`s are retained. Named
+tuples and dictionaries form parameter namespaces. Other values, including
+`Point`s and component-valued parameters, are omitted.
+
+If `g` carries a source `ParameterSet`, its top-level namespaces other than
+`components` are deep-copied into the result. The source `components` namespace
+is replaced with the graph-derived component tree. The result has an empty
+source path and access log and shares no mutable parameter data with the graph
+or source set.
+
+Extraction realizes lazy composite graphs. An `ArgumentError` is thrown if a
+component path collides with a parameter leaf.
+"""
+function extract_parameter_set(g::SchematicGraph)
+    data = if isnothing(parameter_set(g))
+        Dict{String, Any}()
+    else
+        _parameter_value_copy(getfield(parameter_set(g), :data))
+    end
+    extracted_components = Dict{String, Any}()
+    data["components"] = extracted_components
+    _extract_graph_components!(extracted_components, g, ["components"], Set{String}())
+    return ParameterSet(data)
+end

--- a/src/schematics/parameter_set_extraction.jl
+++ b/src/schematics/parameter_set_extraction.jl
@@ -1,19 +1,28 @@
 struct _UnsupportedParameterValue end
 const _UNSUPPORTED_PARAMETER_VALUE = _UnsupportedParameterValue()
 
+# An empty array carries no elements to inspect, so support is decided from its
+# element type alone.
+_supported_array_element_type(::Type{Any}) = true
+_supported_array_element_type(::Type{T}) where {T} =
+    T <: Union{Number, AbstractString, Symbol, Nothing, AbstractVector} &&
+    !(T <: StaticArrays.StaticVector)
+
 _extracted_array_value(value::Union{Number, AbstractString, Symbol, Nothing}) =
     _parameter_value_copy(value)
-function _extracted_array_value(value::Vector)
-    if isempty(value) &&
-       eltype(value) !== Any &&
-       !(eltype(value) <: Union{Number, AbstractString, Symbol, Nothing, Vector})
+function _extracted_array_value(value::AbstractVector)
+    isempty(value) &&
+        !_supported_array_element_type(eltype(value)) &&
         return _UNSUPPORTED_PARAMETER_VALUE
-    end
-    result = map(_extracted_array_value, value)
+    result = map(_extracted_array_value, collect(value))
     any(child -> child isa _UnsupportedParameterValue, result) &&
         return _UNSUPPORTED_PARAMETER_VALUE
     return result
 end
+# `Point` and other `StaticVector`s are `AbstractVector`s, but they represent
+# single geometric values rather than parameter arrays, so they stay unsupported
+# instead of degrading into plain vectors of coordinates.
+_extracted_array_value(::StaticArrays.StaticVector) = _UNSUPPORTED_PARAMETER_VALUE
 _extracted_array_value(::Any) = _UNSUPPORTED_PARAMETER_VALUE
 
 function _extracted_parameter_value(value::NamedTuple)
@@ -34,7 +43,8 @@ function _extracted_parameter_value(value::AbstractDict)
     !isempty(value) && isempty(result) && return _UNSUPPORTED_PARAMETER_VALUE
     return result
 end
-_extracted_parameter_value(value::Vector) = _extracted_array_value(value)
+_extracted_parameter_value(value::AbstractVector) = _extracted_array_value(value)
+_extracted_parameter_value(::StaticArrays.StaticVector) = _UNSUPPORTED_PARAMETER_VALUE
 _extracted_parameter_value(value::Union{Number, AbstractString, Symbol, Nothing}) =
     _parameter_value_copy(value)
 _extracted_parameter_value(::Any) = _UNSUPPORTED_PARAMETER_VALUE
@@ -137,9 +147,11 @@ Each component is stored below `components` at its unique node ID. Dots in node
 IDs become nested namespace segments, and composite-component graphs are
 recursively nested below their parent component. Parameter values are taken
 from the constructed component instances, so defaults and applied overrides
-are both included. Scalar values and ordinary one-dimensional `Array`s are
-retained. Named tuples and dictionaries form parameter namespaces. Other
-values, including `Point`s and component-valued parameters, are omitted.
+are both included. Scalar values are retained, as are one-dimensional
+`AbstractArray`s of supported values; ranges and views are materialized as plain
+`Vector`s. Named tuples and dictionaries form parameter namespaces. Other
+values are omitted, including component-valued parameters and `Point`s, which
+are `StaticVector`s standing for single geometric values rather than arrays.
 
 If `g` carries a source `ParameterSet`, its top-level namespaces other than
 `components` are deep-copied into the result. The source `components` namespace

--- a/test/test_parameter_set.jl
+++ b/test/test_parameter_set.jl
@@ -728,7 +728,16 @@ end
         name = "array_component"
         offsets = [0μm, 25μm]
         unsupported_points = typeof(Point(0μm, 0μm))[]
+        mixed_values = Any[1, Point(0μm, 0μm)]
+        settings = Dict{String, Any}("gain" => 2, "origin" => Point(0μm, 0μm))
+        unsupported_settings = Dict{String, Any}("origin" => Point(0μm, 0μm))
         unsupported_matrix = [0μm 25μm; 50μm 75μm]
+    end
+
+    @compdef struct ExtractionMergeCollisionComponent <: Component
+        name = "parent"
+        settings = (gain=2,)
+        child = 1
     end
 
     @testset "Complete detached extraction" begin
@@ -803,6 +812,10 @@ end
         extracted = extract_parameter_set(g)
         @test extracted.components.route.offsets == [0μm, 25μm]
         @test !haskey(extracted.components.route.data, "unsupported_points")
+        @test !haskey(extracted.components.route.data, "mixed_values")
+        @test extracted.components.route.settings.gain == 2
+        @test !haskey(extracted.components.route.settings.data, "origin")
+        @test !haskey(extracted.components.route.data, "unsupported_settings")
         @test !haskey(extracted.components.route.data, "unsupported_matrix")
 
         push!(extracted.components.route.offsets, 50μm)
@@ -845,6 +858,24 @@ end
         @test err isa ArgumentError
         @test occursin("components.collision.child", err.msg)
         @test occursin("parameter leaf", err.msg)
+
+        merge_g = SchematicGraph("merge_collision")
+        add_node!(
+            merge_g,
+            ExampleRectangleIsland(name="nested");
+            base_id="parent.settings.nested"
+        )
+        add_node!(merge_g, ExampleRectangleIsland(name="child"); base_id="parent.child")
+        add_node!(merge_g, ExtractionMergeCollisionComponent(); base_id="parent")
+        merge_err = try
+            extract_parameter_set(merge_g)
+            nothing
+        catch e
+            e
+        end
+        @test merge_err isa ArgumentError
+        @test occursin("components.parent.child", merge_err.msg)
+        @test occursin("parameter leaf", merge_err.msg)
     end
 end
 

--- a/test/test_parameter_set.jl
+++ b/test/test_parameter_set.jl
@@ -253,6 +253,92 @@
         @test_throws "a.b" (mn2.c = 1)
     end
 
+    @testset "Copied subtree assignment" begin
+        library = ParameterSet()
+        library.templates.qubit.width = 300
+        library.templates.qubit.routing.offsets = [1, 2]
+
+        design = ParameterSet()
+        assigned = (design.components.q1 = library.templates.qubit)
+        @test assigned isa ParameterSet
+        @test assigned.data === library.templates.qubit.data
+        @test isempty(library.accessed)
+        @test design.components.q1.width == 300
+        @test design.components.q1.routing.offsets == [1, 2]
+
+        design.components.q1.width = 350
+        push!(design.components.q1.routing.offsets, 3)
+        @test library.templates.qubit.width == 300
+        @test library.templates.qubit.routing.offsets == [1, 2]
+
+        # The same copy behavior applies when a missing destination path must
+        # first be materialized.
+        design2 = ParameterSet()
+        design2.variants.fast.q1 = library.templates.qubit
+        design2.variants.fast.q1.width = 400
+        @test library.templates.qubit.width == 300
+    end
+
+    @testset "Recursive ParameterSet merge" begin
+        base = ParameterSet()
+        base.components.q1.width = 300
+        base.components.q1.routing.gap = 20
+        base.components.q1.routing.offsets = [1, 2]
+        base.components.q1.mode.options = 1
+        base.components.q1.replaced = 1
+
+        process = ParameterSet()
+        process.components.q1.routing.gap = 25
+        process.components.q1.mode = "fast"
+        process.components.q1.replaced.value = 2
+
+        local_overrides = ParameterSet()
+        local_overrides.components.q1.width = 350
+
+        result =
+            merge(base.components.q1, process.components.q1, local_overrides.components.q1)
+        @test isempty(base.accessed)
+        @test isempty(process.accessed)
+        @test isempty(local_overrides.accessed)
+        @test result.width == 350
+        @test result.routing.gap == 25
+        @test result.routing.offsets == [1, 2]
+        @test result.mode == "fast"
+        @test result.replaced.value == 2
+        @test result.path == ""
+        @test result.prefix == "components.q1"
+
+        # The non-mutating result and mutating destination are both detached
+        # from every source.
+        push!(result.routing.offsets, 3)
+        @test base.components.q1.routing.offsets == [1, 2]
+
+        destination = ParameterSet()
+        destination.components.q1 = base.components.q1
+        empty!(base.accessed)
+        returned = merge!(
+            destination.components.q1,
+            process.components.q1,
+            local_overrides.components.q1
+        )
+        @test returned isa ParameterSet
+        @test isempty(destination.accessed)
+        @test isempty(base.accessed)
+        @test isempty(process.accessed)
+        @test isempty(local_overrides.accessed)
+        @test destination.components.q1.width == 350
+        @test destination.components.q1.routing.gap == 25
+        @test destination.components.q1.mode == "fast"
+        @test destination.components.q1.replaced.value == 2
+
+        process.components.q1.routing.gap = 99
+        @test destination.components.q1.routing.gap == 25
+
+        # Self-merge is a no-op rather than recursively descending forever.
+        @test merge!(destination.components.q1, destination.components.q1) isa ParameterSet
+        @test destination.components.q1.width == 350
+    end
+
     @testset "propertynames" begin
         ps = ParameterSet()
         ps.extra = 42
@@ -547,6 +633,173 @@ end
     end
 end
 
+@testitem "SchematicGraph ParameterSet extraction" setup = [CommonTestSetup] begin
+    using .SchematicDrivenLayout
+    using DeviceLayout.SchematicDrivenLayout.ExamplePDK.Transmons: ExampleRectangleIsland
+    using Unitful: μm
+    using YAML
+
+    @compdef struct ExtractionComposite <: CompositeComponent
+        name = "assembly"
+        cap_length = 600μm
+        template = ExampleRectangleIsland(name="template", cap_width=30μm)
+    end
+
+    function SchematicDrivenLayout._build_subcomponents(c::ExtractionComposite)
+        island = set_parameters(c.template, "island"; cap_length=c.cap_length)
+        return (; island)
+    end
+
+    function SchematicDrivenLayout._graph!(
+        g::SchematicGraph,
+        ::ExtractionComposite,
+        subcomponents::NamedTuple
+    )
+        add_node!(g, subcomponents.island)
+        return g
+    end
+
+    SchematicDrivenLayout.map_hooks(::Type{ExtractionComposite}) =
+        Dict{Pair{Int, Symbol}, Symbol}()
+
+    @compdef struct ExtractionCollisionComposite <: CompositeComponent
+        name = "collision"
+        child = 1
+    end
+
+    function SchematicDrivenLayout._build_subcomponents(::ExtractionCollisionComposite)
+        return (; child=ExampleRectangleIsland(name="child"))
+    end
+
+    function SchematicDrivenLayout._graph!(
+        g::SchematicGraph,
+        ::ExtractionCollisionComposite,
+        subcomponents::NamedTuple
+    )
+        add_node!(g, subcomponents.child)
+        return g
+    end
+
+    SchematicDrivenLayout.map_hooks(::Type{ExtractionCollisionComposite}) =
+        Dict{Pair{Int, Symbol}, Symbol}()
+
+    @compdef struct ExtractionArrayComponent <: Component
+        name = "array_component"
+        offsets = [0μm, 25μm]
+    end
+
+    @testset "Complete detached extraction" begin
+        source = ParameterSet()
+        source.global.process = "fab-v3"
+        source.templates.qubit.cap_width = 24μm
+        source.custom.revision = 7
+        source.components.stale.width = 999μm
+
+        g = SchematicGraph("chip", source)
+        assembly = ExtractionComposite(cap_length=700μm)
+        add_node!(g, assembly; base_id="module.q1")
+        shared = ExampleRectangleIsland(name="shared", cap_width=40μm)
+        add_node!(g, shared; base_id="q2")
+        add_node!(g, shared; base_id="q3")
+
+        extracted = extract_parameter_set(g)
+
+        @test extracted.path == ""
+        @test isempty(extracted.accessed)
+        @test extracted.global.process == "fab-v3"
+        @test extracted.templates.qubit.cap_width == 24μm
+        @test extracted.custom.revision == 7
+        @test !haskey(extracted.data["components"], "stale")
+
+        # Dotted IDs become nested namespaces. Supported parent defaults and
+        # overrides are represented; component-valued parameters are omitted.
+        q1 = extracted.components.module.q1
+        @test q1.name == "assembly"
+        @test q1.cap_length == 700μm
+        @test !haskey(q1.data, "template")
+
+        # Accessing the composite child realizes its lazy graph and captures
+        # the child's final parameters, including the forwarded parent value.
+        @test q1.island.name == "island"
+        @test q1.island.cap_width == 30μm
+        @test q1.island.cap_length == 700μm
+
+        @test extracted.components.q2.cap_width == 40μm
+        @test extracted.components.q3.cap_width == 40μm
+
+        extracted.global.process = "changed"
+        extracted.templates.qubit.cap_width = 100μm
+        extracted.components.q2.cap_width = 10μm
+        @test source.global.process == "fab-v3"
+        @test source.templates.qubit.cap_width == 24μm
+        @test parameters(shared).cap_width == 40μm
+        @test parameter_set(g) === source
+    end
+
+    @testset "Unsupported Point is omitted" begin
+        g = SchematicGraph("spacer")
+        add_node!(g, Spacer(10μm, 20μm); base_id="anchor")
+
+        extracted = extract_parameter_set(g)
+        @test extracted.components.anchor.name == "spacer"
+        @test !haskey(extracted.components.anchor.data, "p1")
+
+        io = IOBuffer()
+        @test save_parameter_set(io, extracted) === io
+        reloaded = ParameterSet(IOBuffer(take!(io)))
+        @test reloaded.components.anchor.name == "spacer"
+        @test !haskey(reloaded.components.anchor.data, "p1")
+    end
+
+    @testset "Ordinary Array is retained" begin
+        component = ExtractionArrayComponent()
+        g = SchematicGraph("array")
+        add_node!(g, component; base_id="route")
+
+        extracted = extract_parameter_set(g)
+        @test extracted.components.route.offsets == [0μm, 25μm]
+
+        push!(extracted.components.route.offsets, 50μm)
+        @test parameters(component).offsets == [0μm, 25μm]
+    end
+
+    @testset "Extraction without attached source and YAML round-trip" begin
+        g = SchematicGraph("bare")
+        add_node!(
+            g,
+            ExampleRectangleIsland(name="island", cap_width=41μm);
+            base_id="island"
+        )
+
+        extracted = extract_parameter_set(g)
+        @test isempty(extracted.global.data)
+        @test extracted.components.island.cap_width == 41μm
+        @test extracted.components.island.cap_length ==
+              parameters(ExampleRectangleIsland()).cap_length
+
+        io = IOBuffer()
+        save_parameter_set(io, extracted)
+        reloaded = ParameterSet(IOBuffer(take!(io)))
+        @test reloaded.components.island.cap_width == 41μm
+        @test reloaded.components.island.cap_length ==
+              parameters(ExampleRectangleIsland()).cap_length
+    end
+
+    @testset "Component path collision" begin
+        g = SchematicGraph("collision")
+        add_node!(g, ExtractionCollisionComposite())
+        err = try
+            extract_parameter_set(g)
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        @test occursin("components.collision.child", err.msg)
+        @test occursin("parameter leaf", err.msg)
+    end
+end
+
 @testitem "ParameterSet YAML IO" setup = [CommonTestSetup] begin
     using DeviceLayout.SchematicDrivenLayout:
         ParameterSet, resolve, leaf_params, save_parameter_set
@@ -556,6 +809,7 @@ end
     @testset "save_parameter_set to IO" begin
         ps = ParameterSet()
         ps.global.version = 1
+        ps.global.process_node = "fab_v3"
         ps.components.cap.finger_length = 150μm
         ps.components.cap.finger_count = 6
 
@@ -563,12 +817,17 @@ end
         save_parameter_set(io, ps)
         yaml_str = String(take!(io))
 
-        # Unitful quantities serialized as quoted unit strings
-        @test contains(yaml_str, "finger_length: \"150μm\"") ||
-              contains(yaml_str, "finger_length: \"150.0μm\"")
+        # Unitful quantities use plain YAML scalars.
+        @test contains(yaml_str, "finger_length: 150μm") ||
+              contains(yaml_str, "finger_length: 150.0μm")
+        # Ordinary strings retain YAML.jl's default quoting.
+        @test contains(yaml_str, "process_node: \"fab_v3\"")
         # Plain numbers stay as numbers
         @test contains(yaml_str, "finger_count: 6")
         @test contains(yaml_str, "version: 1")
+
+        reloaded = ParameterSet(IOBuffer(yaml_str))
+        @test reloaded.global.process_node == "fab_v3"
     end
 
     @testset "ParameterSet from IO" begin
@@ -590,6 +849,27 @@ end
         @test ps.components.qubit.finger_count == 4
     end
 
+    @testset "YAML anchors and merge keys" begin
+        yaml_str = """
+        global:
+          version: 1
+        templates:
+          qubit: &qubit
+            cap_width: 24μm
+            cap_length: 520μm
+            cap_gap: 30μm
+        components:
+          q1:
+            <<: *qubit
+            cap_length: 600μm
+        """
+        ps = ParameterSet(IOBuffer(yaml_str))
+
+        @test ps.components.q1.cap_width == 24μm
+        @test ps.components.q1.cap_length == 600μm
+        @test ps.components.q1.cap_gap == 30μm
+    end
+
     @testset "ParameterSet from IO parses unit arrays" begin
         # Each element is its own YAML scalar (`0μm`), so the array walk in
         # `_parse_units!` converts them element-wise to ContextUnits quantities.
@@ -605,6 +885,17 @@ end
         @test all(x -> x isa Unitful.Quantity, offsets)
         @test all(x -> Unitful.unit(x) isa Unitful.ContextUnits, offsets)
         @test leaf_params(ps.components.routing).pad_offsets == offsets
+    end
+
+    @testset "Ordinary arrays save and reload" begin
+        ps = ParameterSet()
+        ps.components.routing.pad_offsets = [0μm, 25μm, 50μm]
+
+        io = IOBuffer()
+        save_parameter_set(io, ps)
+        reloaded = ParameterSet(IOBuffer(take!(io)))
+
+        @test reloaded.components.routing.pad_offsets == [0μm, 25μm, 50μm]
     end
 
     @testset "Factored unit after a flow sequence is not valid YAML" begin

--- a/test/test_parameter_set.jl
+++ b/test/test_parameter_set.jl
@@ -377,6 +377,37 @@
         push!(aliased_destination.components.q1.routing.offsets, 3)
         @test shared["offsets"] == [1, 2]
         @test aliased_source.components.q1.routing.offsets == [1, 2]
+
+        # Rebuilding the destination subtree is what buys detachment, so scoped
+        # views taken before the merge are stale in both directions.
+        stale_destination = ParameterSet()
+        stale_destination.components.q1.width = 300
+        stale_source = ParameterSet()
+        stale_source.components.q1.width = 350
+
+        stale_view = stale_destination.components.q1
+        merge!(stale_destination, stale_source)
+        @test stale_destination.components.q1.width == 350
+        @test stale_view.width == 300
+        stale_view.width = 999
+        @test stale_destination.components.q1.width == 350
+        # A view re-derived after the merge tracks the destination again.
+        fresh_view = stale_destination.components.q1
+        fresh_view.width = 375
+        @test stale_destination.components.q1.width == 375
+
+        # Only namespaces strictly below the merge target are rebuilt, so a view
+        # at the target level survives while a deeper one goes stale.
+        level_destination = ParameterSet()
+        level_destination.components.q1.routing.gap = 10
+        level_source = ParameterSet()
+        level_source.components.q1.routing.gap = 99
+
+        same_level_view = level_destination.components.q1
+        nested_view = level_destination.components.q1.routing
+        merge!(level_destination.components.q1, level_source.components.q1)
+        @test same_level_view.routing.gap == 99
+        @test nested_view.gap == 10
     end
 
     @testset "propertynames" begin
@@ -732,6 +763,10 @@ end
         settings = Dict{String, Any}("gain" => 2, "origin" => Point(0μm, 0μm))
         unsupported_settings = Dict{String, Any}("origin" => Point(0μm, 0μm))
         unsupported_matrix = [0μm 25μm; 50μm 75μm]
+        stepped_offsets = (0μm):(25μm):(50μm)
+        counted_indices = 1:3
+        viewed_offsets = view([0μm, 25μm, 50μm], 1:2)
+        unsupported_point = Point(0μm, 0μm)
     end
 
     @compdef struct ExtractionMergeCollisionComponent <: Component
@@ -818,8 +853,27 @@ end
         @test !haskey(extracted.components.route.data, "unsupported_settings")
         @test !haskey(extracted.components.route.data, "unsupported_matrix")
 
+        # Non-`Vector` `AbstractVector`s (ranges, views) are materialized as
+        # plain vectors rather than dropped.
+        @test extracted.components.route.stepped_offsets == [0μm, 25μm, 50μm]
+        @test extracted.components.route.stepped_offsets isa Vector
+        @test extracted.components.route.counted_indices == [1, 2, 3]
+        @test extracted.components.route.counted_indices isa Vector
+        @test extracted.components.route.viewed_offsets == [0μm, 25μm]
+        @test extracted.components.route.viewed_offsets isa Vector
+        # `Point` is a `StaticVector`, so it stays omitted instead of becoming
+        # a two-element coordinate array.
+        @test !haskey(extracted.components.route.data, "unsupported_point")
+
         push!(extracted.components.route.offsets, 50μm)
         @test parameters(component).offsets == [0μm, 25μm]
+
+        io = IOBuffer()
+        save_parameter_set(io, extracted)
+        reloaded = ParameterSet(IOBuffer(take!(io)))
+        @test reloaded.components.route.stepped_offsets == [0μm, 25μm, 50μm]
+        @test reloaded.components.route.counted_indices == [1, 2, 3]
+        @test reloaded.components.route.viewed_offsets == [0μm, 25μm]
     end
 
     @testset "Extraction without attached source and YAML round-trip" begin

--- a/test/test_parameter_set.jl
+++ b/test/test_parameter_set.jl
@@ -277,6 +277,22 @@
         design2.variants.fast.q1 = library.templates.qubit
         design2.variants.fast.q1.width = 400
         @test library.templates.qubit.width == 300
+
+        root_template = ParameterSet()
+        root_template.width = 500
+        root_template.routing.offsets = [4, 5]
+        design.components.q2 = root_template
+        @test design.components.q2.width == 500
+        @test !haskey(design.components.q2.data, "global")
+        @test !haskey(design.components.q2.data, "components")
+
+        raw_template = Dict{String, Any}(
+            "width" => 600,
+            "routing" => Dict{String, Any}("offsets" => [6, 7])
+        )
+        design.components.q3 = raw_template
+        push!(design.components.q3.routing.offsets, 8)
+        @test raw_template["routing"]["offsets"] == [6, 7]
     end
 
     @testset "Recursive ParameterSet merge" begin
@@ -337,6 +353,30 @@
         # Self-merge is a no-op rather than recursively descending forever.
         @test merge!(destination.components.q1, destination.components.q1) isa ParameterSet
         @test destination.components.q1.width == 350
+
+        auto = ParameterSet()
+        merge!(auto.components.q1, base.components.q1)
+        @test auto.components.q1.width == 300
+
+        shared = Dict{String, Any}("offsets" => [1, 2])
+        aliased_destination = ParameterSet(
+            Dict{String, Any}(
+                "global" => Dict{String, Any}(),
+                "components" =>
+                    Dict{String, Any}("q1" => Dict{String, Any}("routing" => shared))
+            )
+        )
+        aliased_source = ParameterSet(
+            Dict{String, Any}(
+                "global" => Dict{String, Any}(),
+                "components" =>
+                    Dict{String, Any}("q1" => Dict{String, Any}("routing" => shared))
+            )
+        )
+        merge!(aliased_destination.components.q1, aliased_source.components.q1)
+        push!(aliased_destination.components.q1.routing.offsets, 3)
+        @test shared["offsets"] == [1, 2]
+        @test aliased_source.components.q1.routing.offsets == [1, 2]
     end
 
     @testset "propertynames" begin
@@ -643,6 +683,7 @@ end
         name = "assembly"
         cap_length = 600μm
         template = ExampleRectangleIsland(name="template", cap_width=30μm)
+        templates = (island=ExampleRectangleIsland(name="nested_template"),)
     end
 
     function SchematicDrivenLayout._build_subcomponents(c::ExtractionComposite)
@@ -686,6 +727,8 @@ end
     @compdef struct ExtractionArrayComponent <: Component
         name = "array_component"
         offsets = [0μm, 25μm]
+        unsupported_points = typeof(Point(0μm, 0μm))[]
+        unsupported_matrix = [0μm 25μm; 50μm 75μm]
     end
 
     @testset "Complete detached extraction" begin
@@ -717,6 +760,7 @@ end
         @test q1.name == "assembly"
         @test q1.cap_length == 700μm
         @test !haskey(q1.data, "template")
+        @test !haskey(q1.data, "templates")
 
         # Accessing the composite child realizes its lazy graph and captures
         # the child's final parameters, including the forwarded parent value.
@@ -758,6 +802,8 @@ end
 
         extracted = extract_parameter_set(g)
         @test extracted.components.route.offsets == [0μm, 25μm]
+        @test !haskey(extracted.components.route.data, "unsupported_points")
+        @test !haskey(extracted.components.route.data, "unsupported_matrix")
 
         push!(extracted.components.route.offsets, 50μm)
         @test parameters(component).offsets == [0μm, 25μm]
@@ -776,6 +822,7 @@ end
         @test extracted.components.island.cap_width == 41μm
         @test extracted.components.island.cap_length ==
               parameters(ExampleRectangleIsland()).cap_length
+        @test extracted.components.island.junction_pos == :bottom
 
         io = IOBuffer()
         save_parameter_set(io, extracted)
@@ -783,6 +830,7 @@ end
         @test reloaded.components.island.cap_width == 41μm
         @test reloaded.components.island.cap_length ==
               parameters(ExampleRectangleIsland()).cap_length
+        @test reloaded.components.island.junction_pos == :bottom
     end
 
     @testset "Component path collision" begin
@@ -810,6 +858,7 @@ end
         ps = ParameterSet()
         ps.global.version = 1
         ps.global.process_node = "fab_v3"
+        ps.global.junction_pos = :bottom
         ps.components.cap.finger_length = 150μm
         ps.components.cap.finger_count = 6
 
@@ -822,12 +871,14 @@ end
               contains(yaml_str, "finger_length: 150.0μm")
         # Ordinary strings retain YAML.jl's default quoting.
         @test contains(yaml_str, "process_node: \"fab_v3\"")
+        @test contains(yaml_str, "junction_pos: !symbol \"bottom\"")
         # Plain numbers stay as numbers
         @test contains(yaml_str, "finger_count: 6")
         @test contains(yaml_str, "version: 1")
 
         reloaded = ParameterSet(IOBuffer(yaml_str))
         @test reloaded.global.process_node == "fab_v3"
+        @test reloaded.global.junction_pos == :bottom
     end
 
     @testset "ParameterSet from IO" begin
@@ -858,6 +909,8 @@ end
             cap_width: 24μm
             cap_length: 520μm
             cap_gap: 30μm
+            routing:
+              offsets: [0μm, 25μm]
         components:
           q1:
             <<: *qubit
@@ -868,6 +921,8 @@ end
         @test ps.components.q1.cap_width == 24μm
         @test ps.components.q1.cap_length == 600μm
         @test ps.components.q1.cap_gap == 30μm
+        push!(ps.components.q1.routing.offsets, 50μm)
+        @test ps.templates.qubit.routing.offsets == [0μm, 25μm]
     end
 
     @testset "ParameterSet from IO parses unit arrays" begin
@@ -896,6 +951,16 @@ end
         reloaded = ParameterSet(IOBuffer(take!(io)))
 
         @test reloaded.components.routing.pad_offsets == [0μm, 25μm, 50μm]
+    end
+
+    @testset "Unsupported array-like values fail clearly" begin
+        point_ps = ParameterSet()
+        point_ps.components.anchor.p1 = Point(10μm, 20μm)
+        @test_throws ArgumentError save_parameter_set(IOBuffer(), point_ps)
+
+        matrix_ps = ParameterSet()
+        matrix_ps.components.routing.offsets = [0μm 25μm; 50μm 75μm]
+        @test_throws ArgumentError save_parameter_set(IOBuffer(), matrix_ps)
     end
 
     @testset "Factored unit after a flow sequence is not valid YAML" begin


### PR DESCRIPTION
## Summary

- add deep-copied ParameterSet subtree assignment and recursive `merge`/`merge!` overlays
- add `extract_parameter_set` for detached graph-derived component parameters, including nested composite graphs
- harden YAML round-tripping for quantities, symbols, arrays, aliases, and unsupported values
- document programmatic templates, YAML merge keys, precedence, and graph extraction

## Testing

- `test/runtests.jl ParameterSet` (327/327 passed)
- `scripts/format.jl check`
- `git diff --check`