### PR TITLE
Fix levelwise extrusion sign accumulating across levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format of this changelog is based on
   - The style helpers are now idempotent, and will not change entities that already have the identical
   `OptionalStyle` as their outer style.
   - `ArrayReferences` as `Path` attachments now work with retrieving references and finding transformations (`refs` and `transformation`).
+  - `SolidModelTarget` extrusion of levelwise layers treats positive thickness as "away from substrate" at all levels. Previously a levelwise `thickness` vector extruded levels 3 and 4 (and 7 and 8, and so on) toward the substrate instead of away from it.
 
 ## 1.16.1 (2026-07-28)
 

--- a/src/schematics/solidmodels.jl
+++ b/src/schematics/solidmodels.jl
@@ -170,15 +170,18 @@ function layer_extrusions_dz(target, sch)
             end
         else
             for (lev, t_level) in pairs(t)
-                sgn = isodd(lev) ? sgn : -sgn
+                # Levelwise thickness is measured away from the substrate surface, using the
+                # same level convention as `layer_z`: odd levels are substrate tops (outward
+                # is +z), even levels are substrate bottoms (outward is -z).
+                lev_sgn = isodd(lev) ? sgn : -sgn
                 if ly in indexed_layers(target)
                     for m in element_metadata(sch.coordinate_system)
                         if layer(m) == ly && level(m) == lev
-                            t_dict[_map_meta_fn(target)(m)] = (sgn * t_level, dim)
+                            t_dict[_map_meta_fn(target)(m)] = (lev_sgn * t_level, dim)
                         end
                     end
                 else
-                    t_dict[string(ly) * "_L$lev"] = (sgn * t_level, dim)
+                    t_dict[string(ly) * "_L$lev"] = (lev_sgn * t_level, dim)
                 end
             end
         end

--- a/test/test_schematic_solidmodel.jl
+++ b/test/test_schematic_solidmodel.jl
@@ -1559,3 +1559,40 @@ end
         end
     end
 end
+
+@testitem "Schematic + SolidModel + levelwise extrusion signs" setup = [CommonTestSetup] begin
+    using .SchematicDrivenLayout
+
+    # A levelwise layer's thickness vector indexes levels 1, 2, ...; positive thickness is
+    # away from that level's substrate surface. Odd levels are substrate tops (outward is
+    # +z) and even levels are substrate bottoms (outward is -z), matching `layer_z`.
+    # A schematic is needed only to resolve indexed layers, so an empty one suffices.
+    sch = plan(SchematicGraph("levelwise_extrusion_signs"); log_dir=nothing)
+    dz_by_group(target) =
+        Dict(op[1] => op[3][2] for op in SchematicDrivenLayout.extrusion_ops(target, sch))
+
+    n = 6
+    thicknesses = [(10 * lev)nm for lev = 1:n]
+    outward(lev) = isodd(lev) ? 1 : -1
+
+    # Levels beyond 2 are reachable without a third substrate: in a two-chip flip-chip,
+    # level 3 is the outer face of the top chip.
+    tech = ProcessTechnology((;), (; thickness=(; metal=thicknesses)))
+    dz = dz_by_group(SolidModelTarget(tech; levelwise_layers=[:metal]))
+    for lev = 1:n
+        @test dz["metal_L$(lev)_extrusion"] == outward(lev) * thicknesses[lev]
+    end
+
+    # A substrate layer extrudes into its substrate, flipping the base sign at every level.
+    subtech = ProcessTechnology((;), (; thickness=(; chip_outline=thicknesses)))
+    subdz = dz_by_group(
+        SolidModelTarget(
+            subtech;
+            levelwise_layers=[:chip_outline],
+            substrate_layers=[:chip_outline]
+        )
+    )
+    for lev = 1:n
+        @test subdz["chip_outline_L$(lev)_extrusion"] == -outward(lev) * thicknesses[lev]
+    end
+end


### PR DESCRIPTION
`layer_extrusions_dz` flipped the loop-carried `sgn` in place while walking a levelwise layer's per-level thickness vector, so the per-level sign compounded instead of being derived from the layer's base sign. The resulting sequence has period four (+,-,-,+,...) rather than alternating, extruding levels 3 and 4 (then 7 and 8, and so on) toward the substrate instead of away from it. Levels 1 and 2 were correct by coincidence, and every levelwise thickness vector in the suite had length at most two.

The intended convention is the one `layer_z` already uses: odd levels are substrate tops, even levels are substrate bottoms, and positive thickness is away from the substrate.