### PR TITLE
Fix PeriodicStyle halo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ The format of this changelog is based on
   `OptionalStyle` as their outer style.
   - `ArrayReferences` as `Path` attachments now work with retrieving references and finding transformations (`refs` and `transformation`).
   - `SolidModelTarget` extrusion of levelwise layers treats positive thickness as "away from substrate" at all levels. Previously a levelwise `thickness` vector extruded levels 3 and 4 (and 7 and 8, and so on) toward the substrate instead of away from it.
+### Fixed
+
+  - `halo` of a `PeriodicStyle` is now taken substyle by substyle, as it already was for
+    `CompoundStyle`. Previously a `PeriodicStyle` fell through to the generic style method,
+    which decides whether to render a halo from the extent at the start of the style alone,
+    so a periodic style beginning with a zero-extent substyle (such as one alternating
+    `NoRender` with a trace) produced no halo at all.
 
 ## 1.16.1 (2026-07-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,13 +51,9 @@ The format of this changelog is based on
   `OptionalStyle` as their outer style.
   - `ArrayReferences` as `Path` attachments now work with retrieving references and finding transformations (`refs` and `transformation`).
   - `SolidModelTarget` extrusion of levelwise layers treats positive thickness as "away from substrate" at all levels. Previously a levelwise `thickness` vector extruded levels 3 and 4 (and 7 and 8, and so on) toward the substrate instead of away from it.
-### Fixed
-
-  - `halo` of a `PeriodicStyle` is now taken substyle by substyle, as it already was for
-    `CompoundStyle`. Previously a `PeriodicStyle` fell through to the generic style method,
-    which decides whether to render a halo from the extent at the start of the style alone,
-    so a periodic style beginning with a zero-extent substyle (such as one alternating
-    `NoRender` with a trace) produced no halo at all.
+  - `halo` of a `PeriodicStyle` is now taken substyle by substyle, as for
+    `CompoundStyle`. Previously, attachments on the periodic substyles were dropped
+    from the halo, and periodic styles starting with a zero-extent substyle produced no halo.
 
 ## 1.16.1 (2026-07-28)
 

--- a/src/paths/paths.jl
+++ b/src/paths/paths.jl
@@ -1620,9 +1620,7 @@ function halo(sty::Style, outer_delta, inner_delta=nothing; kwargs...)
     )
 end
 
-# Applies to every `AbstractCompoundStyle`, not just `CompoundStyle`: the generic `Style`
-# method decides whether to render a halo from the extent at `t == 0` alone, which discards
-# every later substyle if a compound style happens to start with a zero-extent one.
+# All compound styles should be taken style-by-style rather than falling back to generic
 function halo(sty::AbstractCompoundStyle, outer_delta, inner_delta=nothing; kwargs...)
     newsty = copy(sty)
     newsty.styles .= halo.(newsty.styles, Ref(outer_delta), Ref(inner_delta); kwargs...)

--- a/src/paths/paths.jl
+++ b/src/paths/paths.jl
@@ -1620,7 +1620,10 @@ function halo(sty::Style, outer_delta, inner_delta=nothing; kwargs...)
     )
 end
 
-function halo(sty::CompoundStyle, outer_delta, inner_delta=nothing; kwargs...)
+# Applies to every `AbstractCompoundStyle`, not just `CompoundStyle`: the generic `Style`
+# method decides whether to render a halo from the extent at `t == 0` alone, which discards
+# every later substyle if a compound style happens to start with a zero-extent one.
+function halo(sty::AbstractCompoundStyle, outer_delta, inner_delta=nothing; kwargs...)
     newsty = copy(sty)
     newsty.styles .= halo.(newsty.styles, Ref(outer_delta), Ref(inner_delta); kwargs...)
     return newsty

--- a/test/test_entity.jl
+++ b/test/test_entity.jl
@@ -154,6 +154,24 @@
         straight!(pth, 10μm, Paths.TaperTrace(10μm, 20μm))
         @test halo(pth[1].sty, 20μm, 10μm) ==
               Paths.TaperCPW{typeof(1.0μm)}(30μm, 10μm, 40μm, 10μm, 10μm)
+
+        # A compound style is haloed substyle by substyle, so one starting with a
+        # zero-extent substyle still gets a halo for its remaining substyles. Both
+        # `AbstractCompoundStyle` subtypes must agree: `PeriodicStyle` here, and the
+        # `CompoundStyle` covering the same styles over the same intervals as a control.
+        periodic = Paths.PeriodicStyle([Paths.NoRender(), Paths.Trace(10μm)], [5μm, 5μm])
+        compound = Paths.CompoundStyle(
+            Paths.Style[Paths.NoRender(), Paths.Trace(10μm)],
+            [0.0μm, 5.0μm, 10.0μm],
+            :halo_periodic_control
+        )
+        for sty in (periodic, compound)
+            h = halo(sty, 2μm)
+            @test !isa(h, Paths.NoRender)
+            @test iszero(Paths.extent(h, 2μm))       # zero-extent substyle stays unrendered
+            @test Paths.extent(h, 7μm) ≈ 7μm         # 5μm trace half-width plus 2μm
+        end
+        @test halo(periodic, 2μm).lengths == periodic.lengths
     end
 end
 

--- a/test/test_entity.jl
+++ b/test/test_entity.jl
@@ -173,10 +173,8 @@
         end
         @test halo(periodic, 2μm).lengths == periodic.lengths
 
-        # `docs/src/tutorials/working_with_paths.md` gives two equivalent ways to bridge a
-        # path: overlaying a `PeriodicStyle` built from a template path, and `attach!` over a
-        # range. Their halos must agree, attachments included -- a halo is used as a keepout,
-        # so bridges missing from it invite fill or routing directly on top of them.
+        # Two equivalent canonical ways of bridging a path must agree on halos:
+        # Overlaying a `PeriodicStyle` built from a template path, and `attach!` over a range.
         bridge_cs = CoordinateSystem(uniquename("bridge"), nm)
         place!(bridge_cs, centered(Rectangle(10μm, 40μm)), SemanticMeta(:bridge))
         template = Path()

--- a/test/test_entity.jl
+++ b/test/test_entity.jl
@@ -172,6 +172,36 @@
             @test Paths.extent(h, 7μm) ≈ 7μm         # 5μm trace half-width plus 2μm
         end
         @test halo(periodic, 2μm).lengths == periodic.lengths
+
+        # `docs/src/tutorials/working_with_paths.md` gives two equivalent ways to bridge a
+        # path: overlaying a `PeriodicStyle` built from a template path, and `attach!` over a
+        # range. Their halos must agree, attachments included -- a halo is used as a keepout,
+        # so bridges missing from it invite fill or routing directly on top of them.
+        bridge_cs = CoordinateSystem(uniquename("bridge"), nm)
+        place!(bridge_cs, centered(Rectangle(10μm, 40μm)), SemanticMeta(:bridge))
+        template = Path()
+        straight!(template, 100μm, Paths.NoRender())
+        attach!(template, sref(bridge_cs), 50μm)
+        function bridged(use_overlay)
+            pa = Path(Point(0μm, 0μm))
+            straight!(pa, 500μm, Paths.CPW(10μm, 6μm))
+            if use_overlay
+                overlay!(pa, Paths.PeriodicStyle(template), DeviceLayout.NORENDER_META)
+            else
+                attach!(pa, sref(bridge_cs), (50μm):(100μm):(450μm))
+            end
+            cs = CoordinateSystem(uniquename("bridged"), nm)
+            place!(cs, pa, SemanticMeta(:base))
+            return cs
+        end
+        nbridges(cs) =
+            count(m -> layer(m) == :bridge, DeviceLayout.element_metadata(flatten(cs)))
+
+        overlay_halo = halo(bridged(true), 5μm)
+        attach_halo = halo(bridged(false), 5μm)
+        @test nbridges(attach_halo) == 5
+        @test nbridges(overlay_halo) == nbridges(attach_halo)
+        @test bounds(overlay_halo) ≈ bounds(attach_halo)
     end
 end
 


### PR DESCRIPTION
`halo` of a PeriodicStyle used the generic style fallback, which could drop attachments or result in no halo. This fix makes it use the same substyle-by-substyle method as `CompoundStyle`.