### PR TITLE
Add curvature-center mesh sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format of this changelog is based on
   - OpenCascade SolidModel rendering adds radius-sized mesh control points at the centers of
     exact circular arcs by default, locally capping rounded-corner and path-turn mesh sizes
     at the radius when `mesh_scale() <= 1`, without refining their entire enclosing entities.
+    For `extrude_z!` postrender operations, the controls are repeated along the extrusion.
     Pass `curvature_sizing=false` to `render!` or `render_conformal!` to retain perimeter-only sizing.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ The format of this changelog is based on
   - Path termination and `SimpleNoRender` halos now use constant-offset edges instead of the generic
     functional-offset fallback. The rendered discretization of these halos on curves may change but 
     will be geometrically equivalent within tolerance.
+### Added
+
+  - OpenCascade SolidModel rendering adds radius-sized mesh control points at the centers of
+    exact circular arcs by default, locally capping rounded-corner and path-turn mesh sizes
+    at the radius when `mesh_scale() <= 1`, without refining their entire enclosing entities.
+    Pass `curvature_sizing=false` to
+    `render!` or `render_conformal!` to retain perimeter-only sizing.
+
+### Fixed
+
+  - Mesh control-point sets that resolve to the same `(h, α)` no longer overwrite one another
+    when the default grading parameter is applied.
 
 ## 1.17.0 (2026-08-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,6 @@ The format of this changelog is based on
 
 ## Unreleased
 
-### Fixed
-
-  - Path termination and `SimpleNoRender` halos now use constant-offset edges instead of the generic
-    functional-offset fallback. The rendered discretization of these halos on curves may change but 
-    will be geometrically equivalent within tolerance.
 ### Added
 
   - OpenCascade SolidModel rendering adds radius-sized mesh control points at the centers of
@@ -24,6 +19,9 @@ The format of this changelog is based on
 
   - Mesh control-point sets that resolve to the same `(h, α)` no longer overwrite one another
     when the default grading parameter is applied.
+  - Path termination and `SimpleNoRender` halos now use constant-offset edges instead of the generic
+    functional-offset fallback. The rendered discretization of these halos on curves may change but 
+    will be geometrically equivalent within tolerance.
 
 ## 1.17.0 (2026-08-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ The format of this changelog is based on
   - OpenCascade SolidModel rendering adds radius-sized mesh control points at the centers of
     exact circular arcs by default, locally capping rounded-corner and path-turn mesh sizes
     at the radius when `mesh_scale() <= 1`, without refining their entire enclosing entities.
-    For `extrude_z!` postrender operations, the controls are repeated along the extrusion.
+    For `extrude_z!` postrender operations, generated perimeter and curvature controls are
+    repeated along the extrusion.
     Pass `curvature_sizing=false` to `render!` or `render_conformal!` to retain perimeter-only sizing.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,7 @@ The format of this changelog is based on
   - OpenCascade SolidModel rendering adds radius-sized mesh control points at the centers of
     exact circular arcs by default, locally capping rounded-corner and path-turn mesh sizes
     at the radius when `mesh_scale() <= 1`, without refining their entire enclosing entities.
-    Pass `curvature_sizing=false` to
-    `render!` or `render_conformal!` to retain perimeter-only sizing.
+    Pass `curvature_sizing=false` to `render!` or `render_conformal!` to retain perimeter-only sizing.
 
 ### Fixed
 

--- a/docs/src/concepts/solidmodels.md
+++ b/docs/src/concepts/solidmodels.md
@@ -130,6 +130,17 @@ incorporate this information back into the `MeshSized` style used on the origina
     Additionally, to generate a new mesh `SolidModels.gmsh.model.mesh.clear()` must be called
     otherwise `gmsh` will return only any previously generated mesh.
 
+### Mesh control points
+
+**Default mesh sizing is subject to change within major versions.**
+
+Currently, control points are generated for the following:
+
+  - `MeshSized` entities: control points are placed at intervals along each boundary.
+  - Path segments with CPW and trace styles: control points placed along trace and gap boundaries with `h = 2*min(trace, gap)` (or just `h = 2*trace` for trace styles). For variable-trace/gap styles, the minimum along the segment is used for `trace` and `gap`.
+  - Circular arcs, including on curved paths and in rounded polygons: a control point is generated at the circle's center with `h` equal to the radius. This can be disabled with the `curvature_sizing=false` keyword in `render!`.
+  - Extruded entities: any of the above control points are copied along the `z` axis in `extrude_z!` postrender operations. New control points are generated on the far extruded face, with intermediate control points spaced in `z` by at most `h`.
+
 ## Example
 
 Below, we create a 3D model of a meandered CPW on a chip, restricting the model to a small

--- a/examples/SingleTransmon/SingleTransmon.jl
+++ b/examples/SingleTransmon/SingleTransmon.jl
@@ -44,7 +44,7 @@ function single_transmon(;
     hanger_length=500μm,
     bend_radius=50μm,
     wave_ports::Bool=false,
-    save_mesh::Bool=true,
+    save_mesh::Bool=false,
     save_gds::Bool=false,
     mesh_order=2
 )
@@ -71,7 +71,6 @@ function single_transmon(;
     qubit = ExampleRectangleTransmon(;
         jj_template=ExampleSimpleJunction(),
         name="qubit",
-        island_rounding=1μm,
         cap_length,
         cap_gap,
         cap_width

--- a/examples/SingleTransmon/SingleTransmon.jl
+++ b/examples/SingleTransmon/SingleTransmon.jl
@@ -44,7 +44,7 @@ function single_transmon(;
     hanger_length=500μm,
     bend_radius=50μm,
     wave_ports::Bool=false,
-    save_mesh::Bool=false,
+    save_mesh::Bool=true,
     save_gds::Bool=false,
     mesh_order=2
 )
@@ -71,6 +71,7 @@ function single_transmon(;
     qubit = ExampleRectangleTransmon(;
         jj_template=ExampleSimpleJunction(),
         name="qubit",
+        island_rounding=1μm,
         cap_length,
         cap_gap,
         cap_width

--- a/src/schematics/ExamplePDK/ExamplePDK.jl
+++ b/src/schematics/ExamplePDK/ExamplePDK.jl
@@ -225,6 +225,7 @@ const SINGLECHIP_SOLIDMODEL_TARGET = SolidModelTarget(
         ("vacuum", 3),
         ("substrate", 3),
         ("metal", 2),
+        ("metal_negative", 2),
         ("exterior_boundary", 2)
     ]
 )

--- a/src/solidmodels/conformal/conformal.jl
+++ b/src/solidmodels/conformal/conformal.jl
@@ -756,7 +756,7 @@ same shared orchestrator as [`render!`](@ref); the only differences are:
 
 Accepts all of `render!`'s keyword arguments (`map_meta`, `postrender_ops`,
 `retained_physical_groups`, `zmap`, `gmsh_options`, `skip_postrender`,
-`auto_union`, `skip_unused_layers`, `meshing_parameters`) in addition to:
+`auto_union`, `skip_unused_layers`, `curvature_sizing`, `meshing_parameters`) in addition to:
 
   - `context::ConformalRenderContext`: the edge/curve cache and merge tolerances.
     Pass an explicit context to customize tolerances or inspect cache stats

--- a/src/solidmodels/postrender.jl
+++ b/src/solidmodels/postrender.jl
@@ -1,9 +1,27 @@
 ######## Postrendering
-function _postrender!(sm::SolidModel, operations)
+function _postrender!(
+    sm::SolidModel,
+    operations;
+    curvature_points_by_group=nothing,
+    curvature_seen=nothing
+)
+    changed_curvature = false
     # Operations
     for (destination, op, args, kwargs...) in operations
-        sm[destination] = op(sm, args...; kwargs...)
+        result = op(sm, args...; kwargs...)
+        sm[destination] = result
+        if !isempty(result) &&
+           !isnothing(curvature_points_by_group) &&
+           !isnothing(curvature_seen)
+            changed_curvature |= _compose_curvature_meshsize!(
+                curvature_points_by_group,
+                op,
+                args,
+                curvature_seen
+            )
+        end
     end
+    return changed_curvature
 end
 
 function _fuse!(k, object, tool; tag=-1, remove_object=true, remove_tool=true)

--- a/src/solidmodels/postrender.jl
+++ b/src/solidmodels/postrender.jl
@@ -2,26 +2,20 @@
 function _postrender!(
     sm::SolidModel,
     operations;
-    curvature_points_by_group=nothing,
-    curvature_seen=nothing
+    mesh_points_by_group=nothing,
+    mesh_seen=nothing
 )
-    changed_curvature = false
+    changed_meshsize = false
     # Operations
     for (destination, op, args, kwargs...) in operations
         result = op(sm, args...; kwargs...)
         sm[destination] = result
-        if !isempty(result) &&
-           !isnothing(curvature_points_by_group) &&
-           !isnothing(curvature_seen)
-            changed_curvature |= _compose_curvature_meshsize!(
-                curvature_points_by_group,
-                op,
-                args,
-                curvature_seen
-            )
+        if !isempty(result) && !isnothing(mesh_points_by_group) && !isnothing(mesh_seen)
+            changed_meshsize |=
+                _compose_meshsize!(mesh_points_by_group, op, args, kwargs, mesh_seen)
         end
     end
-    return changed_curvature
+    return changed_meshsize
 end
 
 function _fuse!(k, object, tool; tag=-1, remove_object=true, remove_tool=true)

--- a/src/solidmodels/render.jl
+++ b/src/solidmodels/render.jl
@@ -605,14 +605,16 @@ _stp_float(x::Real) = Float64(x)
 # `add_mesh_size_point` additions and `α` changes can interleave first.
 
 """
-    _collect_mesh_control_points!(prims, h, α, z; curvature_sizing=true, curvature_seen=nothing)
+    _collect_mesh_control_points!(prims, h, α, z;
+        curvature_sizing=true, curvature_seen=nothing, curvature_points=nothing)
 
 Append mesh-size control points for `prims` (a primitive or vector of
 primitives from [`to_primitives`](@ref)) under `(h, α)` when `h > 0`, sampling each
 primitive's boundary at `⌈L / h⌉` evenly-spaced arc-length intervals at
 height `z`. When `curvature_sizing=true`, exact circular primitives also add a
-radius-sized control point at their center, including when `h <= 0`. Does NOT
-finalize the size field.
+radius-sized control point at their center, including when `h <= 0`. If
+`curvature_points` is provided, those points are also recorded for composition with
+postrender extrusions. Does NOT finalize the size field.
 """
 function _collect_mesh_control_points!(
     prims,
@@ -620,12 +622,13 @@ function _collect_mesh_control_points!(
     α::Real,
     z::Real;
     curvature_sizing::Bool=true,
-    curvature_seen::Union{Nothing, Set{NTuple{4, Float64}}}=nothing
+    curvature_seen::Union{Nothing, Set{NTuple{4, Float64}}}=nothing,
+    curvature_points::Union{Nothing, Set{NTuple{4, Float64}}}=nothing
 )
     h > 0 && _sample_meshsize!(prims, Float64(h), Float64(α), Float64(z))
     if curvature_sizing
         seen = isnothing(curvature_seen) ? Set{NTuple{4, Float64}}() : curvature_seen
-        _sample_curvature_meshsize!(prims, Float64(z), seen)
+        _sample_curvature_meshsize!(prims, Float64(z), seen, curvature_points)
     end
     return nothing
 end
@@ -707,10 +710,11 @@ _sample_meshsize!(::Any, ::Float64, ::Float64, ::Float64) = nothing
 function _sample_curvature_meshsize!(
     prims::AbstractVector,
     z::Float64,
-    seen::Set{NTuple{4, Float64}}
+    seen::Set{NTuple{4, Float64}},
+    points::Union{Nothing, Set{NTuple{4, Float64}}}
 )
     for prim in prims
-        _sample_curvature_meshsize!(prim, z, seen)
+        _sample_curvature_meshsize!(prim, z, seen, points)
     end
     return nothing
 end
@@ -718,10 +722,11 @@ end
 function _sample_curvature_meshsize!(
     cp::CurvilinearPolygon,
     z::Float64,
-    seen::Set{NTuple{4, Float64}}
+    seen::Set{NTuple{4, Float64}},
+    points::Union{Nothing, Set{NTuple{4, Float64}}}
 )
     for seg in cp.curves
-        _sample_segment_curvature_meshsize!(seg, z, seen)
+        _sample_segment_curvature_meshsize!(seg, z, seen, points)
     end
     return nothing
 end
@@ -729,44 +734,58 @@ end
 function _sample_curvature_meshsize!(
     cr::CurvilinearRegion,
     z::Float64,
-    seen::Set{NTuple{4, Float64}}
+    seen::Set{NTuple{4, Float64}},
+    points::Union{Nothing, Set{NTuple{4, Float64}}}
 )
-    _sample_curvature_meshsize!(cr.exterior, z, seen)
+    _sample_curvature_meshsize!(cr.exterior, z, seen, points)
     for hole in cr.holes
-        _sample_curvature_meshsize!(hole, z, seen)
+        _sample_curvature_meshsize!(hole, z, seen, points)
     end
     return nothing
 end
 
-function _sample_curvature_meshsize!(e::Ellipse, z::Float64, seen::Set{NTuple{4, Float64}})
+function _sample_curvature_meshsize!(
+    e::Ellipse,
+    z::Float64,
+    seen::Set{NTuple{4, Float64}},
+    points::Union{Nothing, Set{NTuple{4, Float64}}}
+)
     iscircle(e) || return nothing
     return _add_curvature_mesh_size_point!(
         _stp_float(e.center.x),
         _stp_float(e.center.y),
         abs(_stp_float(e.radii[1])),
         z,
-        seen
+        seen,
+        points
     )
 end
 
 function _sample_curvature_meshsize!(
     seg::Paths.Segment,
     z::Float64,
-    seen::Set{NTuple{4, Float64}}
+    seen::Set{NTuple{4, Float64}},
+    points::Union{Nothing, Set{NTuple{4, Float64}}}
 )
-    return _sample_segment_curvature_meshsize!(seg, z, seen)
+    return _sample_segment_curvature_meshsize!(seg, z, seen, points)
 end
 
-_sample_curvature_meshsize!(::Any, ::Float64, ::Set{NTuple{4, Float64}}) = nothing
+_sample_curvature_meshsize!(
+    ::Any,
+    ::Float64,
+    ::Set{NTuple{4, Float64}},
+    ::Union{Nothing, Set{NTuple{4, Float64}}}
+) = nothing
 
 # CompoundSegment in a CurvilinearPolygon is possible by manual construction
 function _sample_segment_curvature_meshsize!(
     seg::Paths.CompoundSegment,
     z::Float64,
-    seen::Set{NTuple{4, Float64}}
+    seen::Set{NTuple{4, Float64}},
+    points::Union{Nothing, Set{NTuple{4, Float64}}}
 )
     for subsegment in seg.segments
-        _sample_segment_curvature_meshsize!(subsegment, z, seen)
+        _sample_segment_curvature_meshsize!(subsegment, z, seen, points)
     end
     return nothing
 end
@@ -774,15 +793,17 @@ end
 function _sample_segment_curvature_meshsize!(
     seg::Paths.ConstantOffset{T, S},
     z::Float64,
-    seen::Set{NTuple{4, Float64}}
+    seen::Set{NTuple{4, Float64}},
+    points::Union{Nothing, Set{NTuple{4, Float64}}}
 ) where {T, S <: Paths.Turn{T}}
-    return _sample_segment_curvature_meshsize!(Paths.resolve_offset(seg), z, seen)
+    return _sample_segment_curvature_meshsize!(Paths.resolve_offset(seg), z, seen, points)
 end
 
 function _sample_segment_curvature_meshsize!(
     seg::Paths.Turn{T},
     z::Float64,
-    seen::Set{NTuple{4, Float64}}
+    seen::Set{NTuple{4, Float64}},
+    points::Union{Nothing, Set{NTuple{4, Float64}}}
 ) where {T}
     center = Paths.curvaturecenter(seg)
     radius = abs(_stp_float(Paths.curvatureradius(seg, zero(T))))
@@ -791,26 +812,59 @@ function _sample_segment_curvature_meshsize!(
         _stp_float(center.y),
         radius,
         z,
-        seen
+        seen,
+        points
     )
 end
 
-_sample_segment_curvature_meshsize!(::Paths.Segment, ::Float64, ::Set{NTuple{4, Float64}}) =
-    nothing
+_sample_segment_curvature_meshsize!(
+    ::Paths.Segment,
+    ::Float64,
+    ::Set{NTuple{4, Float64}},
+    ::Union{Nothing, Set{NTuple{4, Float64}}}
+) = nothing
 
 function _add_curvature_mesh_size_point!(
     x::Float64,
     y::Float64,
     radius::Float64,
     z::Float64,
-    seen::Set{NTuple{4, Float64}}
+    seen::Set{NTuple{4, Float64}},
+    points::Union{Nothing, Set{NTuple{4, Float64}}}=nothing
 )
-    all(isfinite, (x, y, radius, z)) && radius > 0 || return nothing
+    all(isfinite, (x, y, radius, z)) && radius > 0 || return false
     key = (x, y, radius, z)
-    key in seen && return nothing
+    !isnothing(points) && push!(points, key)
+    key in seen && return false
     push!(seen, key)
     add_mesh_size_point(Float64[x, y, z]; h=radius, α=-1)
-    return nothing
+    return true
+end
+
+function _compose_curvature_meshsize!(
+    points_by_group::Dict{Tuple{String, Int}, Set{NTuple{4, Float64}}},
+    op,
+    args,
+    seen::Set{NTuple{4, Float64}}
+)
+    # Only the built-in extrusion has the known point transformation needed here; arbitrary
+    # postrender operations retain the existing primitive-coordinate sizing behavior.
+    op === extrude_z! || return false
+    length(args) >= 2 || return false
+    groupdim = length(args) >= 3 ? Int(args[3]) : 2
+    source_points = get(points_by_group, (string(args[1]), groupdim), nothing)
+    isnothing(source_points) && return false
+    dz = _stp_float(args[2])
+    iszero(dz) && return false
+
+    changed = false
+    for (x, y, radius, z) in source_points
+        intervals = max(1, ceil(Int, abs(dz) / radius))
+        for z_offset in range(0.0, dz; length=intervals + 1)[2:end]
+            changed |= _add_curvature_mesh_size_point!(x, y, radius, z + z_offset, seen)
+        end
+    end
+    return changed
 end
 
 # Generic `Paths.Segment` sampler. Every concrete `Paths.Segment` (Straight,
@@ -1030,7 +1084,9 @@ Render `cs` to `sm`.
     This keeps indexed and levelwise variants (e.g. `"port_1"`) when the base layer (`"port"`)
     is referenced. Default is `false`.
   - `curvature_sizing`: If `true`, add radius-sized mesh control points at the centers of exact
-    circular primitives preserved by the rendering backend. Default is `true`.
+    circular primitives preserved by the rendering backend. Curvature controls are repeated
+    along `extrude_z!` postrender operations at intervals no larger than the radius. Default is
+    `true`.
 
 Available postrendering operations include [`translate!`](@ref), [`extrude_z!`](@ref), [`revolve!`](@ref),
 [`union_geom!`](@ref), [`intersect_geom!`](@ref), [`difference_geom!`](@ref), [`fragment_geom!`](@ref), and [`box_selection`](@ref).
@@ -1138,6 +1194,7 @@ function _render_orchestrator!(
 
     clear_mesh_control_points!()
     curvature_seen = Set{NTuple{4, Float64}}()
+    curvature_points_by_group = Dict{Tuple{String, Int}, Set{NTuple{4, Float64}}}()
 
     # Create RTree for avoiding duplicating points
     points_tree = RTree{Float64, 3}(Int32)
@@ -1179,15 +1236,29 @@ function _render_orchestrator!(
 
         # Sample mesh size control points from the same primitive form added to the model.
         z_of_meta = _stp_float(zmap(meta))
-        for (prims, (h, α)) in zip(els, meshsizes)
+        for (prims, (h, α), dts) in zip(els, meshsizes, group_dimtags_unflattened)
+            curvature_points = curvature_sizing ? Set{NTuple{4, Float64}}() : nothing
             _collect_mesh_control_points!(
                 prims,
                 h,
                 α,
                 z_of_meta;
                 curvature_sizing,
-                curvature_seen
+                curvature_seen,
+                curvature_points
             )
+            isnothing(curvature_points) && continue
+            primitive_dimtags = dts isa Vector ? dts : [dts]
+            for dim in unique(first.(primitive_dimtags))
+                union!(
+                    get!(
+                        curvature_points_by_group,
+                        (string(mapped_name), Int(dim)),
+                        Set{NTuple{4, Float64}}()
+                    ),
+                    curvature_points
+                )
+            end
         end
     end
     # Synchronize the entities to the model.
@@ -1208,10 +1279,14 @@ function _render_orchestrator!(
         _postrender!(sm, auto_union_ops)
         _synchronize!(sm)
     end
-    _postrender!(sm, postrender_ops)
+    curvature_composed =
+        _postrender!(sm, postrender_ops; curvature_points_by_group, curvature_seen)
     _synchronize!(sm)
     # Get rid of redundant entities and update groups accordingly.
     fragment!(sm)
+
+    # Rebuild KDTrees to include curvature controls composed with extrusions.
+    curvature_composed && finalize_size_fields!()
 
     # Pass in call back function for meshing against the vertices found previously.
     gmsh.model.mesh.setSizeCallback(gmsh_meshsize)

--- a/src/solidmodels/render.jl
+++ b/src/solidmodels/render.jl
@@ -623,10 +623,10 @@ function _collect_mesh_control_points!(
     curvature_seen::Union{Nothing, Set{NTuple{4, Float64}}}=nothing
 )
     h > 0 && _sample_meshsize!(prims, Float64(h), Float64(α), Float64(z))
-    if curvature_sizing
-        seen = isnothing(curvature_seen) ? Set{NTuple{4, Float64}}() : curvature_seen
-        _sample_curvature_meshsize!(prims, Float64(z), seen)
-    end
+    # if curvature_sizing
+    #     seen = isnothing(curvature_seen) ? Set{NTuple{4, Float64}}() : curvature_seen
+    #     _sample_curvature_meshsize!(prims, Float64(z), seen)
+    # end
     return nothing
 end
 
@@ -914,7 +914,7 @@ function populate_size_fields!(
     curvature_seen = Set{NTuple{4, Float64}}()
     for (el, meta) in zip(elements(flat), element_metadata(flat))
         h, α = sizeandgrading(el; kwargs...)
-        h > 0 || (curvature_sizing && _carries_curves(el)) || continue
+        h > 0 || curvature_sizing || continue
         _collect_mesh_control_points!(
             primitives_of(el; kwargs...),
             h,

--- a/src/solidmodels/render.jl
+++ b/src/solidmodels/render.jl
@@ -636,7 +636,7 @@ function _collect_mesh_control_points!(
         first_new = record_points ? length(get(mesh_control_points(), key, ())) + 1 : 1
         _sample_meshsize!(prims, h_float, α_float, Float64(z))
         if record_points
-            for point in Iterators.drop(get(mesh_control_points(), key, ()), first_new - 1)
+            for point in (@view mesh_control_points()[key][first_new:end])
                 record = (point[1], point[2], point[3], h_float, α_float)
                 !isnothing(mesh_seen) && push!(mesh_seen, record)
                 !isnothing(mesh_points) && push!(mesh_points, record)

--- a/src/solidmodels/render.jl
+++ b/src/solidmodels/render.jl
@@ -525,12 +525,16 @@ function finalize_size_fields!()
         Tuple{Float64, Float64},
         KDTree{SVector{3, Float64}, Euclidean, Float64, SVector{3, Float64}}
     }()
-    for (h, α) in keys(MESHSIZE_PARAMS[:cp])
+    normalized_points = Dict{Tuple{Float64, Float64}, Vector{SVector{3, Float64}}}()
+    for ((h, α), points) in MESHSIZE_PARAMS[:cp]
         # Substitute any negative grading value for the global default. Delaying this
         # substitution allows for modifying the size field after rendering, without needing
         # to recompute the locations of all control points.
-        MESHSIZE_PARAMS[:ct][(h, α < 0 ? MESHSIZE_PARAMS[:global_α] : α)] =
-            KDTree(MESHSIZE_PARAMS[:cp][(h, α)])
+        key = (h, α < 0 ? MESHSIZE_PARAMS[:global_α] : α)
+        append!(get!(normalized_points, key, SVector{3, Float64}[]), points)
+    end
+    for (key, points) in normalized_points
+        MESHSIZE_PARAMS[:ct][key] = KDTree(points)
     end
     return nothing
 end
@@ -606,12 +610,23 @@ _stp_float(x::Real) = Float64(x)
 Append mesh-size control points for `prims` (a primitive or vector of
 primitives from [`to_primitives`](@ref)) under `(h, α)`, sampling each
 primitive's boundary at `⌈L / h⌉` evenly-spaced arc-length intervals at
-height `z`. No-op when `h <= 0` (background-sized entities). Does NOT
+height `z`. When `curvature_sizing=true`, exact circular primitives also add a
+radius-sized control point at their center, including when `h <= 0`. Does NOT
 finalize the size field.
 """
-function _collect_mesh_control_points!(prims, h::Real, α::Real, z::Real)
-    h > 0 || return nothing
-    _sample_meshsize!(prims, Float64(h), Float64(α), Float64(z))
+function _collect_mesh_control_points!(
+    prims,
+    h::Real,
+    α::Real,
+    z::Real;
+    curvature_sizing::Bool=true,
+    curvature_seen::Union{Nothing, Set{NTuple{4, Float64}}}=nothing
+)
+    h > 0 && _sample_meshsize!(prims, Float64(h), Float64(α), Float64(z))
+    if curvature_sizing
+        seen = isnothing(curvature_seen) ? Set{NTuple{4, Float64}}() : curvature_seen
+        _sample_curvature_meshsize!(prims, Float64(z), seen)
+    end
     return nothing
 end
 
@@ -685,6 +700,135 @@ end
 # Fallback: any primitive without a specific sampler contributes no points.
 _sample_meshsize!(::Any, ::Float64, ::Float64, ::Float64) = nothing
 
+# Curvature sizing is a separate primitive walk because otherwise-unsized curved entities
+# still need a geometric resolution cap. For an exact circular arc of radius R, a control
+# point at its center with h=R contributes exactly R on the arc when mesh_scale() <= 1,
+# independently of the grading exponent.
+function _sample_curvature_meshsize!(
+    prims::Union{
+        AbstractVector,
+        CurvilinearPolygon,
+        CurvilinearRegion,
+        Ellipse,
+        Paths.Segment
+    },
+    z::Float64
+)
+    seen = Set{NTuple{4, Float64}}()
+    _sample_curvature_meshsize!(prims, z, seen)
+    return nothing
+end
+
+_sample_curvature_meshsize!(::Any, ::Float64) = nothing
+
+function _sample_curvature_meshsize!(
+    prims::AbstractVector,
+    z::Float64,
+    seen::Set{NTuple{4, Float64}}
+)
+    for prim in prims
+        _sample_curvature_meshsize!(prim, z, seen)
+    end
+    return nothing
+end
+
+function _sample_curvature_meshsize!(
+    cp::CurvilinearPolygon,
+    z::Float64,
+    seen::Set{NTuple{4, Float64}}
+)
+    for seg in cp.curves
+        _sample_segment_curvature_meshsize!(seg, z, seen)
+    end
+    return nothing
+end
+
+function _sample_curvature_meshsize!(
+    cr::CurvilinearRegion,
+    z::Float64,
+    seen::Set{NTuple{4, Float64}}
+)
+    _sample_curvature_meshsize!(cr.exterior, z, seen)
+    for hole in cr.holes
+        _sample_curvature_meshsize!(hole, z, seen)
+    end
+    return nothing
+end
+
+function _sample_curvature_meshsize!(e::Ellipse, z::Float64, seen::Set{NTuple{4, Float64}})
+    iscircle(e) || return nothing
+    return _add_curvature_mesh_size_point!(
+        _stp_float(e.center.x),
+        _stp_float(e.center.y),
+        abs(_stp_float(e.radii[1])),
+        z,
+        seen
+    )
+end
+
+function _sample_curvature_meshsize!(
+    seg::Paths.Segment,
+    z::Float64,
+    seen::Set{NTuple{4, Float64}}
+)
+    return _sample_segment_curvature_meshsize!(seg, z, seen)
+end
+
+_sample_curvature_meshsize!(::Any, ::Float64, ::Set{NTuple{4, Float64}}) = nothing
+
+function _sample_segment_curvature_meshsize!(
+    seg::Paths.CompoundSegment,
+    z::Float64,
+    seen::Set{NTuple{4, Float64}}
+)
+    for subsegment in seg.segments
+        _sample_segment_curvature_meshsize!(subsegment, z, seen)
+    end
+    return nothing
+end
+
+function _sample_segment_curvature_meshsize!(
+    seg::Paths.ConstantOffset{T, S},
+    z::Float64,
+    seen::Set{NTuple{4, Float64}}
+) where {T, S <: Paths.Turn{T}}
+    return _sample_segment_curvature_meshsize!(Paths.resolve_offset(seg), z, seen)
+end
+
+function _sample_segment_curvature_meshsize!(
+    seg::Paths.Turn{T},
+    z::Float64,
+    seen::Set{NTuple{4, Float64}}
+) where {T}
+    center = Paths.curvaturecenter(seg)
+    radius = abs(_stp_float(Paths.curvatureradius(seg, zero(T))))
+    return _add_curvature_mesh_size_point!(
+        _stp_float(center.x),
+        _stp_float(center.y),
+        radius,
+        z,
+        seen
+    )
+end
+
+_sample_segment_curvature_meshsize!(::Paths.Segment, ::Float64, ::Set{NTuple{4, Float64}}) =
+    nothing
+
+function _add_curvature_mesh_size_point!(
+    x::Float64,
+    y::Float64,
+    radius::Float64,
+    z::Float64,
+    seen::Set{NTuple{4, Float64}}
+)
+    all(isfinite, (x, y, radius, z)) && radius > 0 || return nothing
+    key = (x, y, radius, z)
+    key in seen && return nothing
+    push!(seen, key)
+    add_mesh_size_point(Float64[x, y, z]; h=radius, α=-1)
+    return nothing
+end
+
 # Generic `Paths.Segment` sampler. Every concrete `Paths.Segment` (Straight,
 # Turn, BSpline, ConstantOffset, …) supports `pathlength(seg)` and `seg(s)`
 # with `s` an arc-length parameter, so one uniform-in-s sampler at
@@ -753,12 +897,13 @@ _default_size_primitives(node::Paths.Node; kwargs...) = to_polygons(node; kwargs
 _default_size_primitives(el; kwargs...) = to_polygons(el; kwargs...)
 
 """
-    populate_size_fields!(cs::AbstractCoordinateSystem; kwargs...) -> mesh_control_points()
+    populate_size_fields!(cs::AbstractCoordinateSystem; curvature_sizing=true, kwargs...) -> mesh_control_points()
 
 Build the mesh-size control-point dictionary (`MESHSIZE_PARAMS[:cp]`) and its KDTrees
-from `cs`, without querying a geometry kernel. For every flattened element with a finite
+from `cs`, without querying a geometry kernel. For every flattened element with a positive
 mesh size, rendered primitive boundaries are sampled at `⌈L / h⌉` arc-length intervals
-and stored under `(h, α)`.
+and stored under `(h, α)`. Exact circular primitives can also contribute curvature-center
+points independently of their entity mesh size.
 
 This constructs the same data used by `render!`'s mesh-size callback, but can be called on
 a coordinate system before rendering to a `SolidModel`.
@@ -768,24 +913,31 @@ Keywords:
   - `primitives_of = _default_size_primitives`: element-to-primitives function. `render!`
     uses `el -> to_primitives(sm, el)` so the sampled primitive form matches the model.
   - `zmap = (_) -> 0.0`: metadata-to-height function for the generated control points.
+  - `curvature_sizing = true`: add radius-sized control points at the centers of exact
+    circular primitives when `primitives_of` preserves them. Disable to retain perimeter-only
+    sizing.
   - remaining keywords are forwarded to `sizeandgrading` and `primitives_of`.
 """
 function populate_size_fields!(
     cs::AbstractCoordinateSystem;
     primitives_of=_default_size_primitives,
     zmap=(_) -> 0.0,
+    curvature_sizing=true,
     kwargs...
 )
     flat = flatten(cs)
     clear_mesh_control_points!()
+    curvature_seen = Set{NTuple{4, Float64}}()
     for (el, meta) in zip(elements(flat), element_metadata(flat))
         h, α = sizeandgrading(el; kwargs...)
-        h > 0 || continue
+        h > 0 || curvature_sizing || continue
         _collect_mesh_control_points!(
             primitives_of(el; kwargs...),
             h,
             α,
-            _stp_float(zmap(meta))
+            _stp_float(zmap(meta));
+            curvature_sizing,
+            curvature_seen
         )
     end
     finalize_size_fields!()
@@ -854,7 +1006,7 @@ end
 """
     render!(sm::SolidModel, cs::AbstractCoordinateSystem{T}; map_meta=layer,
     postrender_ops=[], zmap=(_) -> zero(T), gmsh_options = Dict(), skip_postrender = false,
-    auto_union=false, skip_unused_layers=false, kwargs...) where {T}
+    auto_union=false, skip_unused_layers=false, curvature_sizing=true, kwargs...) where {T}
 
 Render `cs` to `sm`.
 
@@ -893,6 +1045,8 @@ Render `cs` to `sm`.
     its mapped name or its base layer name (from `layer(meta)`) appears in the referenced set.
     This keeps indexed and levelwise variants (e.g. `"port_1"`) when the base layer (`"port"`)
     is referenced. Default is `false`.
+  - `curvature_sizing`: If `true`, add radius-sized mesh control points at the centers of exact
+    circular primitives preserved by the rendering backend. Default is `true`.
 
 Available postrendering operations include [`translate!`](@ref), [`extrude_z!`](@ref), [`revolve!`](@ref),
 [`union_geom!`](@ref), [`intersect_geom!`](@ref), [`difference_geom!`](@ref), [`fragment_geom!`](@ref), and [`box_selection`](@ref).
@@ -914,6 +1068,7 @@ function render!(
     skip_postrender=false,
     auto_union=false,
     skip_unused_layers=false,
+    curvature_sizing=true,
     kwargs...
 ) where {T}
     return _render_orchestrator!(
@@ -938,6 +1093,7 @@ function render!(
         skip_postrender=skip_postrender,
         auto_union=auto_union,
         skip_unused_layers=skip_unused_layers,
+        curvature_sizing=curvature_sizing,
         kwargs...
     )
 end
@@ -975,6 +1131,7 @@ function _render_orchestrator!(
     skip_postrender=false,
     auto_union=false,
     skip_unused_layers=false,
+    curvature_sizing=true,
     kwargs...
 ) where {T}
     gmsh.model.set_current(name(sm))
@@ -996,6 +1153,7 @@ function _render_orchestrator!(
     flat = flatten(cs)
 
     clear_mesh_control_points!()
+    curvature_seen = Set{NTuple{4, Float64}}()
 
     # Create RTree for avoiding duplicating points
     points_tree = RTree{Float64, 3}(Int32)
@@ -1038,7 +1196,14 @@ function _render_orchestrator!(
         # Sample mesh size control points from the same primitive form added to the model.
         z_of_meta = _stp_float(zmap(meta))
         for (prims, (h, α)) in zip(els, meshsizes)
-            _collect_mesh_control_points!(prims, h, α, z_of_meta)
+            _collect_mesh_control_points!(
+                prims,
+                h,
+                α,
+                z_of_meta;
+                curvature_sizing,
+                curvature_seen
+            )
         end
     end
     # Synchronize the entities to the model.

--- a/src/solidmodels/render.jl
+++ b/src/solidmodels/render.jl
@@ -623,10 +623,10 @@ function _collect_mesh_control_points!(
     curvature_seen::Union{Nothing, Set{NTuple{4, Float64}}}=nothing
 )
     h > 0 && _sample_meshsize!(prims, Float64(h), Float64(α), Float64(z))
-    # if curvature_sizing
-    #     seen = isnothing(curvature_seen) ? Set{NTuple{4, Float64}}() : curvature_seen
-    #     _sample_curvature_meshsize!(prims, Float64(z), seen)
-    # end
+    if curvature_sizing
+        seen = isnothing(curvature_seen) ? Set{NTuple{4, Float64}}() : curvature_seen
+        _sample_curvature_meshsize!(prims, Float64(z), seen)
+    end
     return nothing
 end
 

--- a/src/solidmodels/render.jl
+++ b/src/solidmodels/render.jl
@@ -589,6 +589,9 @@ end
 _stp_float(x::Length) = Float64(ustrip(STP_UNIT, x))
 _stp_float(x::Real) = Float64(x)
 
+const _MeshControlPointRecord = NTuple{5, Float64} # (x, y, z, h, α)
+const _MeshControlPointOwners = Dict{Tuple{String, Int}, Set{_MeshControlPointRecord}}
+
 # ─── Kernel-independent mesh-size control-point sampling ──────────────────────
 #
 # These tools compute mesh-size control points directly from rendered geometry
@@ -606,14 +609,14 @@ _stp_float(x::Real) = Float64(x)
 
 """
     _collect_mesh_control_points!(prims, h, α, z;
-        curvature_sizing=true, curvature_seen=nothing, curvature_points=nothing)
+        curvature_sizing=true, mesh_seen=nothing, mesh_points=nothing)
 
 Append mesh-size control points for `prims` (a primitive or vector of
 primitives from [`to_primitives`](@ref)) under `(h, α)` when `h > 0`, sampling each
 primitive's boundary at `⌈L / h⌉` evenly-spaced arc-length intervals at
 height `z`. When `curvature_sizing=true`, exact circular primitives also add a
 radius-sized control point at their center, including when `h <= 0`. If
-`curvature_points` is provided, those points are also recorded for composition with
+`mesh_points` is provided, all generated controls are also recorded for composition with
 postrender extrusions. Does NOT finalize the size field.
 """
 function _collect_mesh_control_points!(
@@ -622,13 +625,27 @@ function _collect_mesh_control_points!(
     α::Real,
     z::Real;
     curvature_sizing::Bool=true,
-    curvature_seen::Union{Nothing, Set{NTuple{4, Float64}}}=nothing,
-    curvature_points::Union{Nothing, Set{NTuple{4, Float64}}}=nothing
+    mesh_seen::Union{Nothing, Set{_MeshControlPointRecord}}=nothing,
+    mesh_points::Union{Nothing, Set{_MeshControlPointRecord}}=nothing
 )
-    h > 0 && _sample_meshsize!(prims, Float64(h), Float64(α), Float64(z))
+    if h > 0
+        h_float = Float64(h)
+        α_float = Float64(α < 0 ? -1 : α)
+        key = (h_float, α_float)
+        record_points = !isnothing(mesh_seen) || !isnothing(mesh_points)
+        first_new = record_points ? length(get(mesh_control_points(), key, ())) + 1 : 1
+        _sample_meshsize!(prims, h_float, α_float, Float64(z))
+        if record_points
+            for point in Iterators.drop(get(mesh_control_points(), key, ()), first_new - 1)
+                record = (point[1], point[2], point[3], h_float, α_float)
+                !isnothing(mesh_seen) && push!(mesh_seen, record)
+                !isnothing(mesh_points) && push!(mesh_points, record)
+            end
+        end
+    end
     if curvature_sizing
-        seen = isnothing(curvature_seen) ? Set{NTuple{4, Float64}}() : curvature_seen
-        _sample_curvature_meshsize!(prims, Float64(z), seen, curvature_points)
+        seen = isnothing(mesh_seen) ? Set{_MeshControlPointRecord}() : mesh_seen
+        _sample_curvature_meshsize!(prims, Float64(z), seen, mesh_points)
     end
     return nothing
 end
@@ -710,8 +727,8 @@ _sample_meshsize!(::Any, ::Float64, ::Float64, ::Float64) = nothing
 function _sample_curvature_meshsize!(
     prims::AbstractVector,
     z::Float64,
-    seen::Set{NTuple{4, Float64}},
-    points::Union{Nothing, Set{NTuple{4, Float64}}}
+    seen::Set{_MeshControlPointRecord},
+    points::Union{Nothing, Set{_MeshControlPointRecord}}
 )
     for prim in prims
         _sample_curvature_meshsize!(prim, z, seen, points)
@@ -722,8 +739,8 @@ end
 function _sample_curvature_meshsize!(
     cp::CurvilinearPolygon,
     z::Float64,
-    seen::Set{NTuple{4, Float64}},
-    points::Union{Nothing, Set{NTuple{4, Float64}}}
+    seen::Set{_MeshControlPointRecord},
+    points::Union{Nothing, Set{_MeshControlPointRecord}}
 )
     for seg in cp.curves
         _sample_segment_curvature_meshsize!(seg, z, seen, points)
@@ -734,8 +751,8 @@ end
 function _sample_curvature_meshsize!(
     cr::CurvilinearRegion,
     z::Float64,
-    seen::Set{NTuple{4, Float64}},
-    points::Union{Nothing, Set{NTuple{4, Float64}}}
+    seen::Set{_MeshControlPointRecord},
+    points::Union{Nothing, Set{_MeshControlPointRecord}}
 )
     _sample_curvature_meshsize!(cr.exterior, z, seen, points)
     for hole in cr.holes
@@ -747,8 +764,8 @@ end
 function _sample_curvature_meshsize!(
     e::Ellipse,
     z::Float64,
-    seen::Set{NTuple{4, Float64}},
-    points::Union{Nothing, Set{NTuple{4, Float64}}}
+    seen::Set{_MeshControlPointRecord},
+    points::Union{Nothing, Set{_MeshControlPointRecord}}
 )
     iscircle(e) || return nothing
     return _add_curvature_mesh_size_point!(
@@ -764,8 +781,8 @@ end
 function _sample_curvature_meshsize!(
     seg::Paths.Segment,
     z::Float64,
-    seen::Set{NTuple{4, Float64}},
-    points::Union{Nothing, Set{NTuple{4, Float64}}}
+    seen::Set{_MeshControlPointRecord},
+    points::Union{Nothing, Set{_MeshControlPointRecord}}
 )
     return _sample_segment_curvature_meshsize!(seg, z, seen, points)
 end
@@ -773,16 +790,16 @@ end
 _sample_curvature_meshsize!(
     ::Any,
     ::Float64,
-    ::Set{NTuple{4, Float64}},
-    ::Union{Nothing, Set{NTuple{4, Float64}}}
+    ::Set{_MeshControlPointRecord},
+    ::Union{Nothing, Set{_MeshControlPointRecord}}
 ) = nothing
 
 # CompoundSegment in a CurvilinearPolygon is possible by manual construction
 function _sample_segment_curvature_meshsize!(
     seg::Paths.CompoundSegment,
     z::Float64,
-    seen::Set{NTuple{4, Float64}},
-    points::Union{Nothing, Set{NTuple{4, Float64}}}
+    seen::Set{_MeshControlPointRecord},
+    points::Union{Nothing, Set{_MeshControlPointRecord}}
 )
     for subsegment in seg.segments
         _sample_segment_curvature_meshsize!(subsegment, z, seen, points)
@@ -793,8 +810,8 @@ end
 function _sample_segment_curvature_meshsize!(
     seg::Paths.ConstantOffset{T, S},
     z::Float64,
-    seen::Set{NTuple{4, Float64}},
-    points::Union{Nothing, Set{NTuple{4, Float64}}}
+    seen::Set{_MeshControlPointRecord},
+    points::Union{Nothing, Set{_MeshControlPointRecord}}
 ) where {T, S <: Paths.Turn{T}}
     return _sample_segment_curvature_meshsize!(Paths.resolve_offset(seg), z, seen, points)
 end
@@ -802,8 +819,8 @@ end
 function _sample_segment_curvature_meshsize!(
     seg::Paths.Turn{T},
     z::Float64,
-    seen::Set{NTuple{4, Float64}},
-    points::Union{Nothing, Set{NTuple{4, Float64}}}
+    seen::Set{_MeshControlPointRecord},
+    points::Union{Nothing, Set{_MeshControlPointRecord}}
 ) where {T}
     center = Paths.curvaturecenter(seg)
     radius = abs(_stp_float(Paths.curvatureradius(seg, zero(T))))
@@ -820,32 +837,77 @@ end
 _sample_segment_curvature_meshsize!(
     ::Paths.Segment,
     ::Float64,
-    ::Set{NTuple{4, Float64}},
-    ::Union{Nothing, Set{NTuple{4, Float64}}}
+    ::Set{_MeshControlPointRecord},
+    ::Union{Nothing, Set{_MeshControlPointRecord}}
 ) = nothing
+
+function _add_composable_mesh_size_point!(
+    x::Float64,
+    y::Float64,
+    z::Float64,
+    h::Float64,
+    α::Float64,
+    seen::Set{_MeshControlPointRecord},
+    points::Union{Nothing, Set{_MeshControlPointRecord}}=nothing
+)
+    all(isfinite, (x, y, z, h, α)) && h > 0 || return false
+    record = (x, y, z, h, α < 0 ? -1.0 : α)
+    !isnothing(points) && push!(points, record)
+    record in seen && return false
+    push!(seen, record)
+    add_mesh_size_point(Float64[x, y, z]; h=h, α=α)
+    return true
+end
 
 function _add_curvature_mesh_size_point!(
     x::Float64,
     y::Float64,
     radius::Float64,
     z::Float64,
-    seen::Set{NTuple{4, Float64}},
-    points::Union{Nothing, Set{NTuple{4, Float64}}}=nothing
+    seen::Set{_MeshControlPointRecord},
+    points::Union{Nothing, Set{_MeshControlPointRecord}}=nothing
 )
-    all(isfinite, (x, y, radius, z)) && radius > 0 || return false
-    key = (x, y, radius, z)
-    !isnothing(points) && push!(points, key)
-    key in seen && return false
-    push!(seen, key)
-    add_mesh_size_point(Float64[x, y, z]; h=radius, α=-1)
-    return true
+    return _add_composable_mesh_size_point!(x, y, z, radius, -1.0, seen, points)
 end
 
-function _compose_curvature_meshsize!(
-    points_by_group::Dict{Tuple{String, Int}, Set{NTuple{4, Float64}}},
+function _extrusion_z_offsets(dz::Float64, h::Float64, kwargs)
+    # Explicit extrusion layers determine where the mesh needs controls. Without them, use
+    # enough uniform intervals to keep every sidewall point within h of another control.
+    options = (; kwargs...)
+    num_elements = get(options, :num_elements, ())
+    heights = get(options, :heights, ())
+    if isempty(num_elements)
+        intervals = max(1, ceil(Int, abs(dz) / h))
+        return range(0.0, dz; length=intervals + 1)[2:end]
+    end
+
+    total_elements = sum(num_elements)
+    total_elements > 0 || return Float64[]
+    if isempty(heights)
+        return range(0.0, dz; length=total_elements + 1)[2:end]
+    end
+
+    length(heights) == length(num_elements) ||
+        throw(ArgumentError("heights and num_elements must have the same length"))
+    normalized_offsets = Float64[]
+    layer_start = 0.0
+    for (elements, layer_end) in zip(num_elements, heights)
+        elements > 0 || throw(ArgumentError("num_elements entries must be positive"))
+        append!(
+            normalized_offsets,
+            range(layer_start, Float64(layer_end); length=elements + 1)[2:end]
+        )
+        layer_start = Float64(layer_end)
+    end
+    return dz .* normalized_offsets
+end
+
+function _compose_meshsize!(
+    points_by_group::_MeshControlPointOwners,
     op,
     args,
-    seen::Set{NTuple{4, Float64}}
+    kwargs,
+    seen::Set{_MeshControlPointRecord}
 )
     # Only the built-in extrusion has the known point transformation needed here; arbitrary
     # postrender operations retain the existing primitive-coordinate sizing behavior.
@@ -858,10 +920,9 @@ function _compose_curvature_meshsize!(
     iszero(dz) && return false
 
     changed = false
-    for (x, y, radius, z) in source_points
-        intervals = max(1, ceil(Int, abs(dz) / radius))
-        for z_offset in range(0.0, dz; length=intervals + 1)[2:end]
-            changed |= _add_curvature_mesh_size_point!(x, y, radius, z + z_offset, seen)
+    for (x, y, z, h, α) in source_points
+        for z_offset in _extrusion_z_offsets(dz, h, kwargs)
+            changed |= _add_composable_mesh_size_point!(x, y, z + z_offset, h, α, seen)
         end
     end
     return changed
@@ -965,7 +1026,7 @@ function populate_size_fields!(
 )
     flat = flatten(cs)
     clear_mesh_control_points!()
-    curvature_seen = Set{NTuple{4, Float64}}()
+    mesh_seen = Set{_MeshControlPointRecord}()
     for (el, meta) in zip(elements(flat), element_metadata(flat))
         h, α = sizeandgrading(el; kwargs...)
         h > 0 || curvature_sizing || continue
@@ -975,7 +1036,7 @@ function populate_size_fields!(
             α,
             _stp_float(zmap(meta));
             curvature_sizing,
-            curvature_seen
+            mesh_seen
         )
     end
     finalize_size_fields!()
@@ -1084,9 +1145,10 @@ Render `cs` to `sm`.
     This keeps indexed and levelwise variants (e.g. `"port_1"`) when the base layer (`"port"`)
     is referenced. Default is `false`.
   - `curvature_sizing`: If `true`, add radius-sized mesh control points at the centers of exact
-    circular primitives preserved by the rendering backend. Curvature controls are repeated
-    along `extrude_z!` postrender operations at intervals no larger than the radius. Default is
-    `true`.
+    circular primitives preserved by the rendering backend. For `extrude_z!` postrender
+    operations, generated perimeter and curvature controls are repeated at requested extrusion
+    mesh layers, or at intervals no larger than each control's target size when no layers are
+    specified. Default is `true`.
 
 Available postrendering operations include [`translate!`](@ref), [`extrude_z!`](@ref), [`revolve!`](@ref),
 [`union_geom!`](@ref), [`intersect_geom!`](@ref), [`difference_geom!`](@ref), [`fragment_geom!`](@ref), and [`box_selection`](@ref).
@@ -1193,8 +1255,8 @@ function _render_orchestrator!(
     flat = flatten(cs)
 
     clear_mesh_control_points!()
-    curvature_seen = Set{NTuple{4, Float64}}()
-    curvature_points_by_group = Dict{Tuple{String, Int}, Set{NTuple{4, Float64}}}()
+    mesh_seen = Set{_MeshControlPointRecord}()
+    mesh_points_by_group = _MeshControlPointOwners()
 
     # Create RTree for avoiding duplicating points
     points_tree = RTree{Float64, 3}(Int32)
@@ -1237,26 +1299,26 @@ function _render_orchestrator!(
         # Sample mesh size control points from the same primitive form added to the model.
         z_of_meta = _stp_float(zmap(meta))
         for (prims, (h, α), dts) in zip(els, meshsizes, group_dimtags_unflattened)
-            curvature_points = curvature_sizing ? Set{NTuple{4, Float64}}() : nothing
+            mesh_points = Set{_MeshControlPointRecord}()
             _collect_mesh_control_points!(
                 prims,
                 h,
                 α,
                 z_of_meta;
                 curvature_sizing,
-                curvature_seen,
-                curvature_points
+                mesh_seen,
+                mesh_points
             )
-            isnothing(curvature_points) && continue
+            isempty(mesh_points) && continue
             primitive_dimtags = dts isa Vector ? dts : [dts]
             for dim in unique(first.(primitive_dimtags))
                 union!(
                     get!(
-                        curvature_points_by_group,
+                        mesh_points_by_group,
                         (string(mapped_name), Int(dim)),
-                        Set{NTuple{4, Float64}}()
+                        Set{_MeshControlPointRecord}()
                     ),
-                    curvature_points
+                    mesh_points
                 )
             end
         end
@@ -1279,14 +1341,13 @@ function _render_orchestrator!(
         _postrender!(sm, auto_union_ops)
         _synchronize!(sm)
     end
-    curvature_composed =
-        _postrender!(sm, postrender_ops; curvature_points_by_group, curvature_seen)
+    meshsize_composed = _postrender!(sm, postrender_ops; mesh_points_by_group, mesh_seen)
     _synchronize!(sm)
     # Get rid of redundant entities and update groups accordingly.
     fragment!(sm)
 
-    # Rebuild KDTrees to include curvature controls composed with extrusions.
-    curvature_composed && finalize_size_fields!()
+    # Rebuild KDTrees to include mesh-size controls composed with extrusions.
+    meshsize_composed && finalize_size_fields!()
 
     # Pass in call back function for meshing against the vertices found previously.
     gmsh.model.mesh.setSizeCallback(gmsh_meshsize)

--- a/src/solidmodels/render.jl
+++ b/src/solidmodels/render.jl
@@ -605,10 +605,10 @@ _stp_float(x::Real) = Float64(x)
 # `add_mesh_size_point` additions and `α` changes can interleave first.
 
 """
-    _collect_mesh_control_points!(prims, h, α, z)
+    _collect_mesh_control_points!(prims, h, α, z; curvature_sizing=true, curvature_seen=nothing)
 
 Append mesh-size control points for `prims` (a primitive or vector of
-primitives from [`to_primitives`](@ref)) under `(h, α)`, sampling each
+primitives from [`to_primitives`](@ref)) under `(h, α)` when `h > 0`, sampling each
 primitive's boundary at `⌈L / h⌉` evenly-spaced arc-length intervals at
 height `z`. When `curvature_sizing=true`, exact circular primitives also add a
 radius-sized control point at their center, including when `h <= 0`. Does NOT
@@ -705,23 +705,6 @@ _sample_meshsize!(::Any, ::Float64, ::Float64, ::Float64) = nothing
 # point at its center with h=R contributes exactly R on the arc when mesh_scale() <= 1,
 # independently of the grading exponent.
 function _sample_curvature_meshsize!(
-    prims::Union{
-        AbstractVector,
-        CurvilinearPolygon,
-        CurvilinearRegion,
-        Ellipse,
-        Paths.Segment
-    },
-    z::Float64
-)
-    seen = Set{NTuple{4, Float64}}()
-    _sample_curvature_meshsize!(prims, z, seen)
-    return nothing
-end
-
-_sample_curvature_meshsize!(::Any, ::Float64) = nothing
-
-function _sample_curvature_meshsize!(
     prims::AbstractVector,
     z::Float64,
     seen::Set{NTuple{4, Float64}}
@@ -776,6 +759,7 @@ end
 
 _sample_curvature_meshsize!(::Any, ::Float64, ::Set{NTuple{4, Float64}}) = nothing
 
+# CompoundSegment in a CurvilinearPolygon is possible by manual construction
 function _sample_segment_curvature_meshsize!(
     seg::Paths.CompoundSegment,
     z::Float64,
@@ -930,7 +914,7 @@ function populate_size_fields!(
     curvature_seen = Set{NTuple{4, Float64}}()
     for (el, meta) in zip(elements(flat), element_metadata(flat))
         h, α = sizeandgrading(el; kwargs...)
-        h > 0 || curvature_sizing || continue
+        h > 0 || (curvature_sizing && _carries_curves(el)) || continue
         _collect_mesh_control_points!(
             primitives_of(el; kwargs...),
             h,

--- a/src/solidmodels/solidmodels.jl
+++ b/src/solidmodels/solidmodels.jl
@@ -76,6 +76,7 @@ import DeviceLayout.Polygons:
     orientation,
     StyleDict,
     cornerindices,
+    iscircle,
     perimeter,
     center,
     angle,

--- a/src/solidmodels/solidmodels.jl
+++ b/src/solidmodels/solidmodels.jl
@@ -84,7 +84,7 @@ import DeviceLayout.Polygons:
     r2,
     radius
 import DeviceLayout.Curvilinear:
-    islinear, round_to_curvilinearpolygon, to_curvilinear, styled_loop
+    islinear, round_to_curvilinearpolygon, to_curvilinear, styled_loop, _carries_curves
 import Unitful: μm, mm, ustrip, °, uconvert, Length
 import FileIO: File
 

--- a/src/solidmodels/solidmodels.jl
+++ b/src/solidmodels/solidmodels.jl
@@ -84,7 +84,7 @@ import DeviceLayout.Polygons:
     r2,
     radius
 import DeviceLayout.Curvilinear:
-    islinear, round_to_curvilinearpolygon, to_curvilinear, styled_loop, _carries_curves
+    islinear, round_to_curvilinearpolygon, to_curvilinear, styled_loop
 import Unitful: μm, mm, ustrip, °, uconvert, Length
 import FileIO: File
 

--- a/src/styles.jl
+++ b/src/styles.jl
@@ -168,12 +168,12 @@ modification.
 
 Each `MeshSized` entity generates a corresponding set of
 [`DeviceLayout.SolidModels.mesh_control_points`](@ref) during the call to
-[`DeviceLayout.SolidModels.render!`](@ref) along the perimeter of the styled entity.
-Controlling the mesh only at the edges of entities, rather than within the interior, ensures
-that geometric entities are resolved whilst avoiding overrefinement in surface regions which
-can be reasonably achieved through adaptive mesh refinement. Increasing resolution of edges
-of entities can be achieved through reducing the value of `h` on the particular entity or
-``s_g`` to affect all entities globally.
+[`DeviceLayout.SolidModels.render!`](@ref) along the perimeter of the styled entity. Exact
+circular arcs also generate radius-sized points at their curvature centers unless
+`curvature_sizing=false` is passed to `render!`. Keeping the general entity sizing controls
+on boundaries avoids overrefinement in surface regions that can be handled by adaptive mesh
+refinement. Increasing resolution of entity edges can be achieved by reducing `h` on the
+particular entity or ``s_g`` globally.
 
 For the set of all [`DeviceLayout.SolidModels.mesh_control_points`](@ref) computed, a
 corresponding mesh size will be computed, and the resulting mesh size is then the minimum

--- a/src/styles.jl
+++ b/src/styles.jl
@@ -170,9 +170,10 @@ Each `MeshSized` entity generates a corresponding set of
 [`DeviceLayout.SolidModels.mesh_control_points`](@ref) during the call to
 [`DeviceLayout.SolidModels.render!`](@ref) along the perimeter of the styled entity. Exact
 circular arcs also generate radius-sized points at their curvature centers unless
-`curvature_sizing=false` is passed to `render!`. When curved geometry is extruded with a
-postrender `extrude_z!` operation, those points are repeated along the extrusion at intervals
-no larger than the radius. Keeping the general entity sizing controls on boundaries avoids
+`curvature_sizing=false` is passed to `render!`. When geometry is extruded with a postrender
+`extrude_z!` operation, its perimeter and curvature controls are repeated at requested
+extrusion mesh layers, or at intervals no larger than each control's target size when no
+layers are specified. Keeping the general entity sizing controls on boundaries avoids
 overrefinement in surface regions that can be handled by adaptive mesh
 refinement. Increasing resolution of entity edges can be achieved by reducing `h` on the
 particular entity or ``s_g`` globally.

--- a/src/styles.jl
+++ b/src/styles.jl
@@ -170,8 +170,10 @@ Each `MeshSized` entity generates a corresponding set of
 [`DeviceLayout.SolidModels.mesh_control_points`](@ref) during the call to
 [`DeviceLayout.SolidModels.render!`](@ref) along the perimeter of the styled entity. Exact
 circular arcs also generate radius-sized points at their curvature centers unless
-`curvature_sizing=false` is passed to `render!`. Keeping the general entity sizing controls
-on boundaries avoids overrefinement in surface regions that can be handled by adaptive mesh
+`curvature_sizing=false` is passed to `render!`. When curved geometry is extruded with a
+postrender `extrude_z!` operation, those points are repeated along the extrusion at intervals
+no larger than the radius. Keeping the general entity sizing controls on boundaries avoids
+overrefinement in surface regions that can be handled by adaptive mesh
 refinement. Increasing resolution of entity edges can be achieved by reducing `h` on the
 particular entity or ``s_g`` globally.
 

--- a/test/test_conformal_render.jl
+++ b/test/test_conformal_render.jl
@@ -203,8 +203,13 @@
         sm = SolidModel("cvr"; overwrite=true)
         render_conformal!(sm, cs)
         @test hasgroup(sm, "l1", 2)
+        @test length(SolidModels.mesh_control_points()[(5.0, -1.0)]) == 4
         # A rounded rectangle should produce a single surface with curved edges.
         @test length(gmsh.model.occ.getEntities(2)) >= 1
+
+        sm_off = SolidModel("cvr_off"; overwrite=true)
+        render_conformal!(sm_off, cs; curvature_sizing=false)
+        @test isempty(SolidModels.mesh_control_points())
         gmsh.finalize()
     end
 

--- a/test/test_schematic_solidmodel.jl
+++ b/test/test_schematic_solidmodel.jl
@@ -527,7 +527,9 @@ end
         render!(sm, floorplan, target)
         cp_rendered = SolidModels.mesh_control_points()
         @test !isempty(cp_rendered)
-        @test Set(keys(cp_rendered)) == Set(keys(cp_schematic))
+        # Solid-model projections can preserve circular path turns that the default
+        # schematic projection flattens, adding radius-sized curvature buckets.
+        @test issubset(Set(keys(cp_schematic)), Set(keys(cp_rendered)))
 
         @test SolidModels.hasgroup(sm, "substrates", 3)
         @test SolidModels.hasgroup(sm, "vacuum", 3)

--- a/test/test_size_fields.jl
+++ b/test/test_size_fields.jl
@@ -34,4 +34,29 @@
         0.0
     )
     @test isempty(SolidModels.mesh_control_points())
+
+    circle_cs = CoordinateSystem("circle_size_fields", nm)
+    render!(circle_cs, Circle(Point(3μm, 4μm), 2μm), SemanticMeta(:circle))
+    render!(circle_cs, Circle(Point(3μm, 4μm), 2μm), SemanticMeta(:circle_copy))
+    preserve_primitives(el; kwargs...) = el
+
+    cp = SolidModels.populate_size_fields!(
+        circle_cs;
+        primitives_of=preserve_primitives,
+        zmap=_ -> 7μm
+    )
+    @test collect(only(cp[(2.0, -1.0)])) == [3.0, 4.0, 7.0]
+
+    primitive_calls = Ref(0)
+    function count_primitives(el; kwargs...)
+        primitive_calls[] += 1
+        return el
+    end
+    SolidModels.populate_size_fields!(
+        circle_cs;
+        primitives_of=count_primitives,
+        curvature_sizing=false
+    )
+    @test primitive_calls[] == 0
+    @test isempty(SolidModels.mesh_control_points())
 end

--- a/test/test_size_fields.jl
+++ b/test/test_size_fields.jl
@@ -47,6 +47,20 @@
     )
     @test collect(only(cp[(2.0, -1.0)])) == [3.0, 4.0, 7.0]
 
+    plain_cs = CoordinateSystem("custom_primitives", nm)
+    render!(plain_cs, Rectangle(10μm, 10μm), SemanticMeta(:plain))
+    custom_calls = Ref(0)
+    function circle_from_plain(el; kwargs...)
+        custom_calls[] += 1
+        return Circle(Point(3μm, 4μm), 2μm)
+    end
+    custom_cp = SolidModels.populate_size_fields!(
+        plain_cs;
+        primitives_of=circle_from_plain
+    )
+    @test custom_calls[] == 1
+    @test collect(only(custom_cp[(2.0, -1.0)])) == [3.0, 4.0, 0.0]
+
     primitive_calls = Ref(0)
     function count_primitives(el; kwargs...)
         primitive_calls[] += 1

--- a/test/test_size_fields.jl
+++ b/test/test_size_fields.jl
@@ -54,10 +54,7 @@
         custom_calls[] += 1
         return Circle(Point(3μm, 4μm), 2μm)
     end
-    custom_cp = SolidModels.populate_size_fields!(
-        plain_cs;
-        primitives_of=circle_from_plain
-    )
+    custom_cp = SolidModels.populate_size_fields!(plain_cs; primitives_of=circle_from_plain)
     @test custom_calls[] == 1
     @test collect(only(custom_cp[(2.0, -1.0)])) == [3.0, 4.0, 0.0]
 

--- a/test/test_solidmodel.jl
+++ b/test/test_solidmodel.jl
@@ -1612,6 +1612,48 @@
             @test isempty(SolidModels.mesh_control_points())
         end
 
+        @testset "Postrender curvature sizing follows final geometry" begin
+            moved_cs = CoordinateSystem("translated_circle", nm)
+            render!(
+                moved_cs,
+                Circle(Point(0μm, 0μm), 2μm),
+                SemanticMeta(:circle)
+            )
+            moved_sm = SolidModel("translated_circle", overwrite=true)
+            render!(
+                moved_sm,
+                moved_cs;
+                postrender_ops=[(
+                    "moved",
+                    SolidModels.translate!,
+                    ("circle", 100μm, 0μm, 0μm),
+                    :copy => false
+                )]
+            )
+            moved_cps = SolidModels.mesh_control_points()
+            @test only(moved_cps[(2.0, -1.0)]) ≈ SVector(100.0, 0.0, 0.0)
+
+            extruded_cs = CoordinateSystem("extruded_rounding", nm)
+            render!(
+                extruded_cs,
+                Polygons.Rounded(2μm)(Rectangle(10μm, 10μm)),
+                SemanticMeta(:rounded)
+            )
+            extruded_sm = SolidModel("extruded_rounding", overwrite=true)
+            render!(
+                extruded_sm,
+                extruded_cs;
+                postrender_ops=[(
+                    "volume",
+                    SolidModels.extrude_z!,
+                    ("rounded", 100μm)
+                )]
+            )
+            extruded_cps = SolidModels.mesh_control_points()[(2.0, -1.0)]
+            @test count(p -> p[3] ≈ 0.0, extruded_cps) == 4
+            @test count(p -> p[3] ≈ 100.0, extruded_cps) == 4
+        end
+
         # Checking option access
         SolidModels.set_gmsh_option("Mesh.ElementOrder", 3)
         SolidModels.set_gmsh_option("Geometry.OCCTargetUnit", "M")

--- a/test/test_solidmodel.jl
+++ b/test/test_solidmodel.jl
@@ -1612,42 +1612,103 @@
             @test isempty(SolidModels.mesh_control_points())
         end
 
-        @testset "Curvature extrusion ladder" begin
+        @testset "Mesh-size extrusion ladder" begin
             SolidModels.clear_mesh_control_points!()
-            seen = Set{NTuple{4, Float64}}()
-            source_points = Set{NTuple{4, Float64}}()
-            SolidModels._add_curvature_mesh_size_point!(
+            seen = Set{NTuple{5, Float64}}()
+            source_points = Set{NTuple{5, Float64}}()
+            SolidModels._add_composable_mesh_size_point!(
                 0.0,
                 0.0,
-                2.0,
                 5.0,
+                2.0,
+                0.8,
                 seen,
                 source_points
             )
             points_by_group = Dict(("curve", 1) => source_points)
 
-            @test SolidModels._compose_curvature_meshsize!(
+            @test SolidModels._compose_meshsize!(
                 points_by_group,
                 SolidModels.extrude_z!,
                 ("curve", -5μm, 1),
+                (),
                 seen
             )
-            z_levels = sort([p[3] for p in SolidModels.mesh_control_points()[(2.0, -1.0)]])
+            z_levels = sort([p[3] for p in SolidModels.mesh_control_points()[(2.0, 0.8)]])
             @test first(z_levels) ≈ 0.0
             @test last(z_levels) ≈ 5.0
             @test maximum(diff(z_levels)) <= 2.0
-            @test !SolidModels._compose_curvature_meshsize!(
+            @test !SolidModels._compose_meshsize!(
                 points_by_group,
                 SolidModels.extrude_z!,
                 ("curve", 1μm, 2),
+                (),
                 seen
             )
-            @test !SolidModels._compose_curvature_meshsize!(
+            @test !SolidModels._compose_meshsize!(
                 points_by_group,
                 SolidModels.extrude_z!,
                 ("curve", 0μm, 1),
+                (),
                 seen
             )
+
+            SolidModels.clear_mesh_control_points!()
+            empty!(seen)
+            empty!(source_points)
+            SolidModels._add_composable_mesh_size_point!(
+                0.0,
+                0.0,
+                0.0,
+                2.0,
+                0.8,
+                seen,
+                source_points
+            )
+            @test SolidModels._compose_meshsize!(
+                points_by_group,
+                SolidModels.extrude_z!,
+                ("curve", 10μm, 1),
+                (:num_elements => [2, 1], :heights => [0.4, 1.0]),
+                seen
+            )
+            z_levels = sort([p[3] for p in SolidModels.mesh_control_points()[(2.0, 0.8)]])
+            @test z_levels ≈ [0.0, 2.0, 4.0, 10.0]
+        end
+
+        @testset "Mesh sizing composes with extrusion" begin
+            sized_cs = CoordinateSystem("extruded_mesh_sizing", nm)
+            render!(
+                sized_cs,
+                styled(Rectangle(4μm, 4μm), MeshSized(2μm, 0.8)),
+                SemanticMeta(:sized)
+            )
+            render!(
+                sized_cs,
+                styled(
+                    Rectangle(Point(10μm, 10μm), Point(14μm, 14μm)),
+                    MeshSized(2μm, 0.8)
+                ),
+                SemanticMeta(:unextruded)
+            )
+            sized_sm = SolidModel("extruded_mesh_sizing", overwrite=true)
+            render!(
+                sized_sm,
+                sized_cs;
+                curvature_sizing=false,
+                postrender_ops=[(
+                    "volume",
+                    SolidModels.extrude_z!,
+                    ("sized", 5μm),
+                    :num_elements => [2, 1],
+                    :heights => [0.4, 1.0]
+                )]
+            )
+            sized_cps = SolidModels.mesh_control_points()[(2.0, 0.8)]
+            z_levels = sort(unique(p[3] for p in sized_cps))
+            @test z_levels ≈ [0.0, 1.0, 2.0, 5.0]
+            @test count(p -> p[3] ≈ 0.0, sized_cps) == 16
+            @test all(z -> count(p -> p[3] ≈ z, sized_cps) == 8, z_levels[2:end])
         end
 
         @testset "Curvature sizing composes with extrusion" begin

--- a/test/test_solidmodel.jl
+++ b/test/test_solidmodel.jl
@@ -1612,46 +1612,65 @@
             @test isempty(SolidModels.mesh_control_points())
         end
 
-        @testset "Postrender curvature sizing follows final geometry" begin
-            moved_cs = CoordinateSystem("translated_circle", nm)
-            render!(
-                moved_cs,
-                Circle(Point(0μm, 0μm), 2μm),
-                SemanticMeta(:circle)
+        @testset "Curvature extrusion ladder" begin
+            SolidModels.clear_mesh_control_points!()
+            seen = Set{NTuple{4, Float64}}()
+            source_points = Set{NTuple{4, Float64}}()
+            SolidModels._add_curvature_mesh_size_point!(
+                0.0,
+                0.0,
+                2.0,
+                5.0,
+                seen,
+                source_points
             )
-            moved_sm = SolidModel("translated_circle", overwrite=true)
-            render!(
-                moved_sm,
-                moved_cs;
-                postrender_ops=[(
-                    "moved",
-                    SolidModels.translate!,
-                    ("circle", 100μm, 0μm, 0μm),
-                    :copy => false
-                )]
-            )
-            moved_cps = SolidModels.mesh_control_points()
-            @test only(moved_cps[(2.0, -1.0)]) ≈ SVector(100.0, 0.0, 0.0)
+            points_by_group = Dict(("curve", 1) => source_points)
 
+            @test SolidModels._compose_curvature_meshsize!(
+                points_by_group,
+                SolidModels.extrude_z!,
+                ("curve", -5μm, 1),
+                seen
+            )
+            z_levels = sort([p[3] for p in SolidModels.mesh_control_points()[(2.0, -1.0)]])
+            @test first(z_levels) ≈ 0.0
+            @test last(z_levels) ≈ 5.0
+            @test maximum(diff(z_levels)) <= 2.0
+            @test !SolidModels._compose_curvature_meshsize!(
+                points_by_group,
+                SolidModels.extrude_z!,
+                ("curve", 1μm, 2),
+                seen
+            )
+            @test !SolidModels._compose_curvature_meshsize!(
+                points_by_group,
+                SolidModels.extrude_z!,
+                ("curve", 0μm, 1),
+                seen
+            )
+        end
+
+        @testset "Curvature sizing composes with extrusion" begin
             extruded_cs = CoordinateSystem("extruded_rounding", nm)
             render!(
                 extruded_cs,
                 Polygons.Rounded(2μm)(Rectangle(10μm, 10μm)),
                 SemanticMeta(:rounded)
             )
+            render!(extruded_cs, Circle(Point(30μm, 30μm), 2μm), SemanticMeta(:unextruded))
             extruded_sm = SolidModel("extruded_rounding", overwrite=true)
             render!(
                 extruded_sm,
                 extruded_cs;
-                postrender_ops=[(
-                    "volume",
-                    SolidModels.extrude_z!,
-                    ("rounded", 100μm)
-                )]
+                postrender_ops=[("volume", SolidModels.extrude_z!, ("rounded", 100μm))]
             )
             extruded_cps = SolidModels.mesh_control_points()[(2.0, -1.0)]
-            @test count(p -> p[3] ≈ 0.0, extruded_cps) == 4
-            @test count(p -> p[3] ≈ 100.0, extruded_cps) == 4
+            z_levels = sort(unique(p[3] for p in extruded_cps))
+            @test first(z_levels) ≈ 0.0
+            @test last(z_levels) ≈ 100.0
+            @test maximum(diff(z_levels)) <= 2.0
+            @test count(p -> p[3] ≈ first(z_levels), extruded_cps) == 5
+            @test all(z -> count(p -> p[3] ≈ z, extruded_cps) == 4, z_levels[2:end])
         end
 
         # Checking option access

--- a/test/test_solidmodel.jl
+++ b/test/test_solidmodel.jl
@@ -1439,6 +1439,24 @@
         SolidModels.finalize_size_fields!()
         @test all(sort(collect(keys(SolidModels.mesh_control_trees()))) .== [(0.5, 0.75)])
 
+        # Explicit and default grading can normalize to the same tree key. Both point sets
+        # must survive finalization.
+        SolidModels.clear_mesh_control_points!()
+        SolidModels.add_mesh_size_point([0.0, 0.0, 0.0]; h=0.5, α=-1)
+        SolidModels.add_mesh_size_point([10.0, 0.0, 0.0]; h=0.5, α=0.75)
+        SolidModels.finalize_size_fields!()
+        @test collect(keys(SolidModels.mesh_control_trees())) == [(0.5, 0.75)]
+        for x in (0.0, 10.0)
+            @test SolidModels.gmsh_meshsize(
+                Cint(0),
+                Cint(0),
+                Cdouble(x),
+                Cdouble(0.0),
+                Cdouble(0.0),
+                Cdouble(0.0)
+            ) == 0.5
+        end
+
         # Check that the KDTree implementation matches a brute force search
         import Random: seed!, default_rng, rand
         rng = seed!(default_rng(), 111)
@@ -1516,6 +1534,82 @@
             cps = first(values(SolidModels.mesh_control_points()))
             @test !isempty(cps)
             @test all(p -> p[3] == 5.0, cps)
+        end
+
+        @testset "Curvature-center control points" begin
+            turn = Paths.Turn(90°, 2.0μm; p0=Point(0.0μm, 0.0μm), α0=0°)
+
+            SolidModels.clear_mesh_control_points!()
+            SolidModels._collect_mesh_control_points!(turn, 0.0, -1.0, 5.0)
+            cps = SolidModels.mesh_control_points()
+            @test collect(keys(cps)) == [(2.0, -1.0)]
+            @test only(cps[(2.0, -1.0)]) ≈ SVector(0.0, 2.0, 5.0)
+
+            SolidModels.finalize_size_fields!()
+            for s in range(zero(pathlength(turn)), pathlength(turn), length=3)
+                p = turn(s)
+                @test SolidModels.gmsh_meshsize(
+                    Cint(0),
+                    Cint(0),
+                    Cdouble(ustrip(STP_UNIT, p.x)),
+                    Cdouble(ustrip(STP_UNIT, p.y)),
+                    Cdouble(5.0),
+                    Cdouble(0.0)
+                ) ≈ 2.0
+            end
+
+            SolidModels.clear_mesh_control_points!()
+            offset_turn = Paths.offset(turn, 0.5μm)
+            SolidModels._collect_mesh_control_points!(offset_turn, 0.0, -1.0, 3.0)
+            cps = SolidModels.mesh_control_points()
+            @test collect(keys(cps)) == [(1.5, -1.0)]
+            @test only(cps[(1.5, -1.0)]) ≈ SVector(0.0, 2.0, 3.0)
+
+            circle = Circle(Point(3μm, 4μm), 2μm)
+            SolidModels.clear_mesh_control_points!()
+            SolidModels._collect_mesh_control_points!(circle, 0.0, -1.0, 7.0)
+            cps = SolidModels.mesh_control_points()
+            @test collect(keys(cps)) == [(2.0, -1.0)]
+            @test only(cps[(2.0, -1.0)]) ≈ SVector(3.0, 4.0, 7.0)
+
+            SolidModels.clear_mesh_control_points!()
+            SolidModels._collect_mesh_control_points!(
+                CurvilinearPolygon(circle),
+                0.0,
+                -1.0,
+                7.0
+            )
+            @test length(only(values(SolidModels.mesh_control_points()))) == 1
+
+            SolidModels.clear_mesh_control_points!()
+            ellipse = Ellipse(Point(3μm, 4μm), (2μm, 1μm), 0°)
+            SolidModels._collect_mesh_control_points!(ellipse, 0.0, -1.0, 7.0)
+            @test isempty(SolidModels.mesh_control_points())
+
+            SolidModels.clear_mesh_control_points!()
+            SolidModels._collect_mesh_control_points!(
+                turn,
+                0.0,
+                -1.0,
+                5.0;
+                curvature_sizing=false
+            )
+            @test isempty(SolidModels.mesh_control_points())
+        end
+
+        @testset "Rounded geometry curvature sizing" begin
+            cs = CoordinateSystem("curvature_sizing", nm)
+            render!(cs, Polygons.Rounded(2μm)(Rectangle(10μm, 10μm)), SemanticMeta(:curved))
+
+            sm_curved = SolidModel("curvature_sizing_on", overwrite=true)
+            render!(sm_curved, cs)
+            cps = SolidModels.mesh_control_points()
+            @test haskey(cps, (2.0, -1.0))
+            @test length(cps[(2.0, -1.0)]) == 4
+
+            sm_uncontrolled = SolidModel("curvature_sizing_off", overwrite=true)
+            render!(sm_uncontrolled, cs; curvature_sizing=false)
+            @test isempty(SolidModels.mesh_control_points())
         end
 
         # Checking option access


### PR DESCRIPTION
Close #18 by adding mesh size control points at the curvature center of exact arcs, with h=r. This puts 2 elements on a 90 degree arc, which with second-order elements is already ~0.1% geometry error. This is intended as a fixed, conservatively large mesh size for resolving curves (so this doesn't quite satisfy #138 for custom curvature resolution). It is on by default but can be disabled.

On the SingleTransmon example, we can look at minimum quality (gamma) of 3D elements:

- No rounding: 0.1827903093877442
- 1um rounding, no rounded-corner sizing: 0.041183499343592944, with 62 elements below gamma=0.2
- 1um rounding, rounded-corner sizing (this PR): 0.11744784707292887, with 2 elements below gamma=0.2

From other experiments I believe we don't really see a difference in AMR convergence at this level, but it would be nice to find a case where the difference is measurable.

(The "shield" between transmon and resonator claw gets rounded on the transmon side but is rectangular in the mesh control geometry on the resonator side, which is a little awkward, but doesn't seem to hurt that much. Really the claw should be part of the transmon component, though, and get rounded as well.)