### PR TITLE
`_get_or_add_point!`: O(1) stale-tag probe + closest-of-many picker

### DIFF
--- a/src/solidmodels/conformal/conformal.jl
+++ b/src/solidmodels/conformal/conformal.jl
@@ -155,11 +155,11 @@ function _cached_point_relaxed!(
     x::Float64,
     y::Float64,
     z::Float64,
-    points_tree
+    points_cache
 )
     tag =
-        isnothing(points_tree) ? k.add_point(x, y, z) :
-        _get_or_add_point!(k, x, y, z, points_tree; atol=ctx.vertex_merge_atol)
+        isnothing(points_cache) ? k.add_point(x, y, z) :
+        _get_or_add_point!(k, x, y, z, points_cache; atol=ctx.vertex_merge_atol)
     # Record coords for later midpoint computation; the tag returned by
     # `_get_or_add_point!` may correspond to a previously-inserted nearby point,
     # so `get!` preserves the first-writer coords rather than overwriting.
@@ -175,11 +175,11 @@ function _cached_point_strict!(
     x::Float64,
     y::Float64,
     z::Float64,
-    points_tree
+    points_cache
 )
     tag =
-        isnothing(points_tree) ? k.add_point(x, y, z) :
-        _get_or_add_point!(k, x, y, z, points_tree; atol=ctx.center_merge_atol)
+        isnothing(points_cache) ? k.add_point(x, y, z) :
+        _get_or_add_point!(k, x, y, z, points_cache; atol=ctx.center_merge_atol)
     get!(ctx.point_coords, tag, (x, y, z))
     return tag
 end
@@ -392,7 +392,7 @@ _add_conformal!(
     m::Meta,
     k;
     zmap=(_) -> zero(coordinatetype(x)),
-    points_tree=nothing,
+    points_cache=nothing,
     kwargs...
 ) = _add_conformal!(
     ctx,
@@ -400,7 +400,7 @@ _add_conformal!(
     m,
     k;
     zmap=zmap,
-    points_tree=points_tree,
+    points_cache=points_cache,
     kwargs...
 )
 
@@ -414,13 +414,13 @@ function _add_conformal!(
     m::Meta,
     k::OpenCascade;
     zmap=(_) -> zero(T),
-    points_tree=nothing,
+    points_cache=nothing,
     atol=onenanometer(T),
     kwargs...
 ) where {T}
     z = zmap(m)
-    outer_loop = _add_conformal_loop!(ctx, surf.exterior, k, z; points_tree, atol)
-    hole_loops = _add_conformal_loop!.(Ref(ctx), surf.holes, k, z; points_tree, atol)
+    outer_loop = _add_conformal_loop!(ctx, surf.exterior, k, z; points_cache, atol)
+    hole_loops = _add_conformal_loop!.(Ref(ctx), surf.holes, k, z; points_cache, atol)
     surftag = k.add_plane_surface([outer_loop; hole_loops...])
     return (Int32(2), surftag)
 end
@@ -432,13 +432,19 @@ function _add_conformal!(
     m::Meta,
     k::OpenCascade;
     zmap=(_) -> zero(T),
-    points_tree=nothing,
+    points_cache=nothing,
     atol=onenanometer(T),
     kwargs...
 ) where {T}
     z = zmap(m)
-    loop =
-        _add_conformal_loop!(ctx, CurvilinearPolygon(points(poly)), k, z; points_tree, atol)
+    loop = _add_conformal_loop!(
+        ctx,
+        CurvilinearPolygon(points(poly)),
+        k,
+        z;
+        points_cache,
+        atol
+    )
     surf = k.add_plane_surface([loop])
     return (Int32(2), surf)
 end
@@ -450,7 +456,7 @@ function _add_conformal!(
     m::Meta,
     k::OpenCascade;
     zmap=(_) -> zero(T),
-    points_tree=nothing,
+    points_cache=nothing,
     atol=onenanometer(T),
     kwargs...
 ) where {T}
@@ -461,7 +467,7 @@ function _add_conformal!(
         Float64(ustrip(STP_UNIT, getx(line.p0))),
         Float64(ustrip(STP_UNIT, gety(line.p0))),
         Float64(ustrip(STP_UNIT, z)),
-        points_tree
+        points_cache
     )
     p1 = _cached_point_relaxed!(
         k,
@@ -469,7 +475,7 @@ function _add_conformal!(
         Float64(ustrip(STP_UNIT, getx(line.p1))),
         Float64(ustrip(STP_UNIT, gety(line.p1))),
         Float64(ustrip(STP_UNIT, z)),
-        points_tree
+        points_cache
     )
     linetag = _cached_add_line!(k, ctx, p0, p1)
     return (Int32(1), linetag)
@@ -485,7 +491,7 @@ _add_conformal!(ctx::ConformalRenderContext, els::AbstractVector, m::Meta, k; kw
 
 """
     add_conformal_loop!(ctx::ConformalRenderContext, cl::CurvilinearPolygon,
-        k::OpenCascade, z; points_tree=nothing, atol=onenanometer(...))
+        k::OpenCascade, z; points_cache=nothing, atol=onenanometer(...))
 
 Build an OCC curve loop for `cl` using the conformal edge/curve cache.
 
@@ -494,10 +500,10 @@ than using [`render_conformal!`](@ref)'s orchestrator). Typical usage:
 
 ```julia
 ctx = ConformalRenderContext()
-points_tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+points_cache = SpatialIndexing.RTree{Float64, 3}(Int32)
 for region in regions
-    outer = add_conformal_loop!(ctx, region.exterior, k, z; points_tree)
-    holes = [add_conformal_loop!(ctx, h, k, z; points_tree) for h in region.holes]
+    outer = add_conformal_loop!(ctx, region.exterior, k, z; points_cache)
+    holes = [add_conformal_loop!(ctx, h, k, z; points_cache) for h in region.holes]
     k.add_plane_surface([outer; holes...])
 end
 ```
@@ -510,10 +516,10 @@ function add_conformal_loop!(
     cl::CurvilinearPolygon,
     k::OpenCascade,
     z;
-    points_tree=nothing,
+    points_cache=nothing,
     atol=onenanometer(coordinatetype(cl))
 )
-    return _add_conformal_loop!(ctx, cl, k, z; points_tree, atol)
+    return _add_conformal_loop!(ctx, cl, k, z; points_cache, atol)
 end
 
 function _add_conformal_loop!(
@@ -521,7 +527,7 @@ function _add_conformal_loop!(
     cl::CurvilinearPolygon,
     k::OpenCascade,
     z;
-    points_tree=nothing,
+    points_cache=nothing,
     atol=onenanometer(coordinatetype(cl))
 )
     poly_pts = points(cl)
@@ -532,7 +538,7 @@ function _add_conformal_loop!(
             Float64(ustrip(STP_UNIT, getx(p))),
             Float64(ustrip(STP_UNIT, gety(p))),
             Float64(ustrip(STP_UNIT, z)),
-            points_tree
+            points_cache
         ) for p in poly_pts
     ]
     n = length(pts)
@@ -549,7 +555,7 @@ function _add_conformal_loop!(
                 cl.curves[curve_idx],
                 k,
                 z,
-                points_tree;
+                points_cache;
                 atol
             )
             if result isa AbstractVector
@@ -579,7 +585,7 @@ function _add_conformal_curve!(
     seg::Paths.Turn,
     k::OpenCascade,
     z,
-    points_tree;
+    points_cache;
     kwargs...
 )
     center_pt =
@@ -591,7 +597,7 @@ function _add_conformal_curve!(
         Float64(ustrip(STP_UNIT, getx(center_pt))),
         Float64(ustrip(STP_UNIT, gety(center_pt))),
         Float64(ustrip(STP_UNIT, z)),
-        points_tree
+        points_cache
     )
 
     if abs(seg.α) >= 180°
@@ -606,7 +612,7 @@ function _add_conformal_curve!(
                 Float64(ustrip(STP_UNIT, getx(mp))),
                 Float64(ustrip(STP_UNIT, gety(mp))),
                 Float64(ustrip(STP_UNIT, z)),
-                points_tree
+                points_cache
             ) for mp in middle_pts
         ]
         tags = [endpoints[1]; middle_tags; endpoints[2]]
@@ -635,7 +641,7 @@ function _add_conformal_curve!(
     seg::Paths.BSpline,
     k::OpenCascade,
     z,
-    points_tree;
+    points_cache;
     kwargs...
 )
     midpts = [
@@ -645,7 +651,7 @@ function _add_conformal_curve!(
             Float64(ustrip(STP_UNIT, getx(p))),
             Float64(ustrip(STP_UNIT, gety(p))),
             Float64(ustrip(STP_UNIT, z)),
-            points_tree
+            points_cache
         ) for p in seg.p[2:(end - 1)]
     ]
     pts = [endpoints[1], midpts..., endpoints[2]]
@@ -670,7 +676,7 @@ function _add_conformal_curve!(
     seg::Paths.OffsetSegment,
     k::OpenCascade,
     z,
-    points_tree;
+    points_cache;
     kwargs...
 )
     base = seg.seg
@@ -683,7 +689,15 @@ function _add_conformal_curve!(
             base.p0 + Point(-sin(base.α0), cos(base.α0)) * off,
             base.α0
         )
-        return _add_conformal_curve!(ctx, endpoints, off_turn, k, z, points_tree; kwargs...)
+        return _add_conformal_curve!(
+            ctx,
+            endpoints,
+            off_turn,
+            k,
+            z,
+            points_cache;
+            kwargs...
+        )
     end
     # General case (offset BSpline / variable offset). `bspline_approximation`
     # is NOT direction-symmetric: calling it on `seg` and on `Paths.reverse(seg)`
@@ -699,14 +713,14 @@ function _add_conformal_curve!(
             Float64(ustrip(STP_UNIT, getx(p))),
             Float64(ustrip(STP_UNIT, gety(p))),
             Float64(ustrip(STP_UNIT, z)),
-            points_tree
+            points_cache
         ) for p in newstarts
     ]
     starts = [endpoints[1], newpts...]
     stops = [newpts..., endpoints[2]]
     tags = Int32[]
     for (ep, sub) in zip([[s, e] for (s, e) in zip(starts, stops)], approx.segments)
-        t = _add_conformal_curve!(ctx, ep, sub, k, z, points_tree; kwargs...)
+        t = _add_conformal_curve!(ctx, ep, sub, k, z, points_cache; kwargs...)
         if t isa AbstractVector
             append!(tags, t)
         else
@@ -729,7 +743,7 @@ _add_conformal_curve!(
     seg::Paths.Segment,
     k::OpenCascade,
     z,
-    points_tree;
+    points_cache;
     kwargs...
 ) = throw(
     ArgumentError(
@@ -808,13 +822,13 @@ function render_conformal!(
     return _render_orchestrator!(
         sm,
         cs;
-        (emit!)=(els, meta, k; zmap, points_tree, kwargs...) -> _add_conformal!(
+        (emit!)=(els, meta, k; zmap, points_cache, kwargs...) -> _add_conformal!(
             context,
             els,
             meta,
             k;
             zmap=zmap,
-            points_tree=points_tree,
+            points_cache=points_cache,
             kwargs...
         ),
         (fragment!)=fragment_backstop ? _fragment_three_pass! : (_) -> nothing,

--- a/src/solidmodels/render.jl
+++ b/src/solidmodels/render.jl
@@ -1176,13 +1176,13 @@ function render!(
     return _render_orchestrator!(
         sm,
         cs;
-        (emit!)=(els, meta, k; zmap, points_tree, kwargs...) ->
+        (emit!)=(els, meta, k; zmap, points_cache, kwargs...) ->
             _add_to_current_solidmodel!(
                 els,
                 meta,
                 k;
                 zmap=zmap,
-                points_tree=points_tree,
+                points_cache=points_cache,
                 kwargs...
             ),
         (fragment!)=_fragment_three_pass!,
@@ -1211,7 +1211,7 @@ end
 
 # Shared orchestrator body called by both `render!` and `render_conformal!`.
 # The two entry points differ only in:
-#   - `emit!(els, meta, k; zmap, points_tree, kwargs...)`: how OCC entities are
+#   - `emit!(els, meta, k; zmap, points_cache, kwargs...)`: how OCC entities are
 #     added for a metadata group. Stock uses `_add_to_current_solidmodel!`;
 #     conformal wraps `_add_conformal!` closing over the caller's context.
 #   - `fragment!(sm)`: post-postrender fragment pass. Stock always runs the
@@ -1237,8 +1237,6 @@ function _render_orchestrator!(
     kwargs...
 ) where {T}
     gmsh.model.set_current(name(sm))
-    # Fresh model → previous render's live-point snapshot is stale.
-    _mark_points_stale!()
 
     if !isnothing(meshing_parameters)
         Base.depwarn("Using `MeshingParameters` is deprecated!", :render!, force=true)
@@ -1260,8 +1258,9 @@ function _render_orchestrator!(
     mesh_seen = Set{_MeshControlPointRecord}()
     mesh_points_by_group = _MeshControlPointOwners()
 
-    # Create RTree for avoiding duplicating points
-    points_tree = RTree{Float64, 3}(Int32)
+    # Point-dedup cache: R-tree of previously inserted OCC dim-0 entities,
+    # plus a set of live tags kept in sync with OCC's set via a stale flag.
+    points_cache = PointsCache()
 
     # Build set of used layer names for skip_unused_layers optimization
     used_names = if skip_unused_layers
@@ -1285,7 +1284,7 @@ function _render_orchestrator!(
 
         # Add to model using kernel via the strategy-specific emit function.
         group_dimtags_unflattened =
-            emit!(els, meta, kernel(sm); zmap=zmap, points_tree=points_tree, kwargs...)
+            emit!(els, meta, kernel(sm); zmap=zmap, points_cache=points_cache, kwargs...)
 
         group_dimtags = reduce(vcat, group_dimtags_unflattened, init=Tuple{Int32, Int32}[])
         # If group already exists, add to it
@@ -1516,13 +1515,41 @@ function _get_boundary_points(dts)
 end
 
 const POINT_MERGE_ATOL = 1e-9 # in STP_UNIT, i.e. atol=1e-6nm
-function _get_or_add_points!(k, pts_xy, z, points_tree; atol=POINT_MERGE_ATOL)
+
+"""
+    PointsCache
+
+Orchestrator-local state for point deduplication during a `render!` /
+`render_conformal!` pass. Bundles together:
+
+  - `tree` — an `RTree` of previously inserted OpenCASCADE dim-0 entities,
+    keyed by coordinate.
+  - `live` — the set of dim-0 tags known to still be live in OCC. Populated
+    on every insert.
+  - `stale` — set to `true` after any boolean op that can retag or delete
+    dim-0 entities (currently only `k.cut` inside
+    `_add_to_current_solidmodel!(::CurvilinearRegion)`), and reset to
+    `false` by `_refresh_live_points!` the next time a liveness check
+    needs to know.
+
+`_render_orchestrator!` creates one `PointsCache` per pass and threads it
+through the emit-callback into `_add_to_current_solidmodel!` /
+`_add_conformal!`.
+"""
+mutable struct PointsCache
+    tree::RTree{Float64, 3, SpatialIndexing.SpatialElem{Float64, 3, Nothing, Int32}}
+    live::Set{Int32}
+    stale::Bool
+end
+PointsCache() = PointsCache(RTree{Float64, 3}(Int32), Set{Int32}(), true)
+
+function _get_or_add_points!(k, pts_xy, z, points_cache; atol=POINT_MERGE_ATOL)
     return _get_or_add_point!.(
         k,
         getx.(pts_xy),
         gety.(pts_xy),
         z,
-        Ref(points_tree);
+        Ref(points_cache);
         atol=atol
     )
 end
@@ -1532,7 +1559,7 @@ function _get_or_add_point!(
     x::Length,
     y::Length,
     z::Length,
-    points_tree;
+    points_cache;
     atol=POINT_MERGE_ATOL
 )
     return _get_or_add_point!(
@@ -1540,7 +1567,7 @@ function _get_or_add_point!(
         float(ustrip(STP_UNIT, x)),
         float(ustrip(STP_UNIT, y)),
         float(ustrip(STP_UNIT, z)),
-        points_tree,
+        points_cache,
         atol=atol
     )
 end
@@ -1550,7 +1577,7 @@ function _get_or_add_point!(
     x::Float64,
     y::Float64,
     z::Float64,
-    points_tree::Nothing;
+    points_cache::Nothing;
     atol=POINT_MERGE_ATOL
 )
     return k.add_point(x, y, z)
@@ -1561,7 +1588,7 @@ function _get_or_add_point!(
     x::Float64,
     y::Float64,
     z::Float64,
-    points_tree::RTree;
+    points_cache::PointsCache;
     atol=POINT_MERGE_ATOL
 )
     return k.add_point(x, y, z)
@@ -1572,26 +1599,32 @@ function _get_or_add_point!(
     x::Float64,
     y::Float64,
     z::Float64,
-    points_tree::RTree;
+    points_cache::PointsCache;
     atol=POINT_MERGE_ATOL
 )
     reg =
         SpatialIndexing.Rect((x - atol, y - atol, z - atol), (x + atol, y + atol, z + atol))
     while true
-        pts = SpatialIndexing.contained_in(points_tree, reg)
+        pts = SpatialIndexing.contained_in(points_cache.tree, reg)
         if isempty(pts)
             tag = k.add_point(x, y, z)
-            insert!(points_tree, SpatialIndexing.Point((x, y, z)), tag)
-            push!(POINT_MERGE_LIVE, tag)
+            insert!(points_cache.tree, SpatialIndexing.Point((x, y, z)), tag)
+            push!(points_cache.live, tag)
             return tag
         end
         # If multiple candidate points fall in the tolerance box, tie-break
         # deterministically by (distance, tag) — R-tree iteration order is
         # not guaranteed deterministic across builds/versions, so we can't
         # rely on `first(pts)` alone.
-        best_elem = first(pts)
-        best_d2 = _point_d2(x, y, z, best_elem.mbr.low)
-        for pt in pts
+        E = eltype(pts)
+        best_elem = nothing
+        best_d2 = Inf
+        for pt::E in pts
+            if isnothing(best_elem)
+                best_elem = pt
+                best_d2 = _point_d2(x, y, z, best_elem.mbr.low)
+                continue
+            end
             d2 = _point_d2(x, y, z, pt.mbr.low)
             if (d2 < best_d2) || (d2 == best_d2 && pt.val < best_elem.val)
                 best_d2 = d2
@@ -1601,10 +1634,10 @@ function _get_or_add_point!(
         # Verify the tag still refers to a live OpenCASCADE dim-0 entity.
         # Boolean ops (e.g. `k.cut`) can retag or delete entities after we
         # inserted them; if the tag is stale we drop it and retry.
-        if _is_live_point(k, best_elem.val)
+        if _is_live_point(k, points_cache, best_elem.val)
             return best_elem.val
         end
-        delete!(points_tree, best_elem.mbr)
+        delete!(points_cache.tree, best_elem.mbr)
     end
 end
 
@@ -1616,28 +1649,19 @@ end
     return dx * dx + dy * dy + dz * dz
 end
 
-# Snapshot of OpenCASCADE dim-0 entity tags known to be live. Populated on
-# every `_get_or_add_point!` insert. Marked stale by any boolean op that can
-# delete/retag entities (currently `k.cut` in `_add_to_current_solidmodel!`);
-# a subsequent `_is_live_point` call refreshes from `k.get_entities(0)`.
-const POINT_MERGE_LIVE = Set{Int32}()
-const POINT_MERGE_STALE = Base.RefValue(true)
-
-function _refresh_live_points!(k)
-    empty!(POINT_MERGE_LIVE)
-    union!(POINT_MERGE_LIVE, Iterators.map(last, k.get_entities(0)))
-    POINT_MERGE_STALE[] = false
+function _refresh_live_points!(k, cache::PointsCache)
+    empty!(cache.live)
+    union!(cache.live, Iterators.map(last, k.get_entities(0)))
+    cache.stale = false
     return nothing
 end
 
-function _mark_points_stale!()
-    POINT_MERGE_STALE[] = true
-    return nothing
-end
+_mark_points_stale!(cache::PointsCache) = (cache.stale = true; nothing)
+_mark_points_stale!(::Nothing) = nothing
 
-function _is_live_point(k, tag)
-    POINT_MERGE_STALE[] && _refresh_live_points!(k)
-    return tag in POINT_MERGE_LIVE
+function _is_live_point(k, cache::PointsCache, tag)
+    cache.stale && _refresh_live_points!(k, cache)
+    return tag in cache.live
 end
 
 # Add primitives to solid model
@@ -1646,13 +1670,13 @@ function _add_to_current_solidmodel!(
     m::Meta,
     k;
     zmap=(_) -> zero(T),
-    points_tree=nothing,
+    points_cache=nothing,
     atol=DeviceLayout.onenanometer(T),
     kwargs...
 ) where {T}
     z = zmap(m) # map from m using kwargs
     # Add as curve loop to get point deduplication
-    loop = _add_loop!(CurvilinearPolygon(points(poly)), k, z; points_tree, atol)
+    loop = _add_loop!(CurvilinearPolygon(points(poly)), k, z; points_cache, atol)
     surf = k.add_plane_surface([loop])
 
     return (Int32(2), surf)
@@ -1663,9 +1687,9 @@ _add_to_current_solidmodel!(
     m::Meta,
     k;
     zmap=(_) -> zero(T),
-    points_tree=nothing,
+    points_cache=nothing,
     kwargs...
-) = _add_to_current_solidmodel!(CurvilinearRegion(x), m, k; zmap, points_tree, kwargs...)
+) = _add_to_current_solidmodel!(CurvilinearRegion(x), m, k; zmap, points_cache, kwargs...)
 
 # GmshNative flattens curvilinear primitives in `to_primitives`, so this sink is
 # OpenCascade-only in normal rendering.
@@ -1674,13 +1698,13 @@ function _add_to_current_solidmodel!(
     m::Meta,
     k;
     zmap=(_) -> zero(T),
-    points_tree=nothing,
+    points_cache=nothing,
     atol=DeviceLayout.onenanometer(T),
     kwargs...
 ) where {T}
     z = zmap(m) # map from m using kwargs
-    outer_loop = _add_loop!(surf.exterior, k, z; points_tree, atol)
-    hole_loops = _add_loop!.(surf.holes, k, z; points_tree, atol)
+    outer_loop = _add_loop!(surf.exterior, k, z; points_cache, atol)
+    hole_loops = _add_loop!.(surf.holes, k, z; points_cache, atol)
 
     surftag = k.add_plane_surface([outer_loop])
     if !isempty(hole_loops)
@@ -1688,8 +1712,8 @@ function _add_to_current_solidmodel!(
         out_dim_tags, _ = k.cut([(2, surftag)], [(2, x) for x ∈ holes])
         surftag = out_dim_tags[1][2]
         # `k.cut` may have retagged or deleted dim-0 entities referenced by
-        # `points_tree`; force the next liveness probe to refresh.
-        _mark_points_stale!()
+        # `points_cache`; force the next liveness probe to refresh.
+        _mark_points_stale!(points_cache)
     end
     return (Int32(2), surftag)
 end
@@ -1699,13 +1723,13 @@ function _add_to_current_solidmodel!(
     m::Meta,
     k;
     zmap=(_) -> zero(T),
-    points_tree=nothing,
+    points_cache=nothing,
     atol=DeviceLayout.onenanometer(T),
     kwargs...
 ) where {T}
     z = zmap(m)
-    p0 = _get_or_add_point!(k, getx(line.p0), gety(line.p0), z, points_tree)
-    p1 = _get_or_add_point!(k, getx(line.p1), gety(line.p1), z, points_tree)
+    p0 = _get_or_add_point!(k, getx(line.p0), gety(line.p0), z, points_cache)
+    p1 = _get_or_add_point!(k, getx(line.p1), gety(line.p1), z, points_cache)
     linetag = k.add_line(p0, p1)
     return (Int32(1), linetag)
 end
@@ -1715,10 +1739,10 @@ function _add_loop!(
     cl::CurvilinearPolygon,
     k,
     z;
-    points_tree=nothing,
+    points_cache=nothing,
     atol=DeviceLayout.onenanometer(coordinatetype(cl))
 )
-    pts = _get_or_add_points!(k, points(cl), z, points_tree)
+    pts = _get_or_add_points!(k, points(cl), z, points_cache)
     endpoint_pairs = zip(pts, circshift(pts, -1))
     curves = map(enumerate(endpoint_pairs)) do (i, endpoints)
         curve_idx = findfirst(isequal(i), cl.curve_start_idx)

--- a/src/solidmodels/render.jl
+++ b/src/solidmodels/render.jl
@@ -1575,22 +1575,61 @@ function _get_or_add_point!(
 )
     reg =
         SpatialIndexing.Rect((x - atol, y - atol, z - atol), (x + atol, y + atol, z + atol))
-    if isempty(points_tree, reg)
-        tag = k.add_point(x, y, z)
-        insert!(points_tree, SpatialIndexing.Point((x, y, z)), tag)
-        return tag
+    while true
+        pts = SpatialIndexing.contained_in(points_tree, reg)
+        if isempty(pts)
+            tag = k.add_point(x, y, z)
+            insert!(points_tree, SpatialIndexing.Point((x, y, z)), tag)
+            return tag
+        end
+        # If more than one previously-inserted point falls within the
+        # tolerance box (can happen with a coarse `atol` or where two
+        # boundaries land within one nm of each other), pick the closest —
+        # avoids `only()` throwing on multi-candidate collisions and gives a
+        # deterministic tie-break.
+        best_elem = first(pts)
+        best_d2 = _point_d2(x, y, z, best_elem.mbr.low)
+        for pt in pts
+            d2 = _point_d2(x, y, z, pt.mbr.low)
+            if d2 < best_d2
+                best_d2 = d2
+                best_elem = pt
+            end
+        end
+        # Verify the tag is still a live OCC point. `k.cut` (called from
+        # `_add_to_current_solidmodel!(::CurvilinearRegion)`) can retag or
+        # delete points after we inserted them, leaving stale entries in the
+        # tree. If the tag is stale we drop it from the tree and retry — the
+        # retry either finds another live candidate in `reg` or falls through
+        # to a fresh `add_point`. This replaces an O(N) `k.get_entities(0)`
+        # scan on every collision with an O(1) OCC probe.
+        if _is_live_point(k, best_elem.val)
+            return best_elem.val
+        end
+        # Drop the stale entry so future queries don't keep hitting it.
+        # SpatialIndexing takes the MBR (a point-Rect) as the delete key.
+        delete!(points_tree, best_elem.mbr)
     end
-    pts = SpatialIndexing.contained_in(points_tree, reg)
-    tag = only(pts).val
-    current_points = k.get_entities(0)
-    if tag in last.(current_points)
-        return tag
+end
+
+# Squared distance from (x, y, z) to a SpatialIndexing point-Rect (low == high).
+@inline function _point_d2(x, y, z, c)
+    dx = x - c[1]
+    dy = y - c[2]
+    dz = z - c[3]
+    return dx * dx + dy * dy + dz * dz
+end
+
+# O(1) probe: does OCC still have a point with this tag? `getBoundingBox` on
+# a stale tag throws "Unknown OpenCASCADE point with tag N".
+function _is_live_point(k, tag)
+    try
+        k.getBoundingBox(0, tag)
+        return true
+    catch e
+        e isa ErrorException || rethrow(e)
+        return false
     end
-    # point must have gotten relabeled — can happen if you're trying to connect to a point that was on a hole
-    # just add the point again, don't bother with the tree
-    # (for some reason k.get_entities_in_bounding_box may not find the point either, even with a +/- 1nm box)
-    tag = k.add_point(x, y, z)
-    return tag
 end
 
 # Add primitives to solid model

--- a/src/solidmodels/render.jl
+++ b/src/solidmodels/render.jl
@@ -1237,6 +1237,8 @@ function _render_orchestrator!(
     kwargs...
 ) where {T}
     gmsh.model.set_current(name(sm))
+    # Fresh model → previous render's live-point snapshot is stale.
+    _mark_points_stale!()
 
     if !isnothing(meshing_parameters)
         Base.depwarn("Using `MeshingParameters` is deprecated!", :render!, force=true)
@@ -1580,34 +1582,28 @@ function _get_or_add_point!(
         if isempty(pts)
             tag = k.add_point(x, y, z)
             insert!(points_tree, SpatialIndexing.Point((x, y, z)), tag)
+            push!(POINT_MERGE_LIVE, tag)
             return tag
         end
-        # If more than one previously-inserted point falls within the
-        # tolerance box (can happen with a coarse `atol` or where two
-        # boundaries land within one nm of each other), pick the closest —
-        # avoids `only()` throwing on multi-candidate collisions and gives a
-        # deterministic tie-break.
+        # If multiple candidate points fall in the tolerance box, tie-break
+        # deterministically by (distance, tag) — R-tree iteration order is
+        # not guaranteed deterministic across builds/versions, so we can't
+        # rely on `first(pts)` alone.
         best_elem = first(pts)
         best_d2 = _point_d2(x, y, z, best_elem.mbr.low)
         for pt in pts
             d2 = _point_d2(x, y, z, pt.mbr.low)
-            if d2 < best_d2
+            if (d2 < best_d2) || (d2 == best_d2 && pt.val < best_elem.val)
                 best_d2 = d2
                 best_elem = pt
             end
         end
-        # Verify the tag is still a live OCC point. `k.cut` (called from
-        # `_add_to_current_solidmodel!(::CurvilinearRegion)`) can retag or
-        # delete points after we inserted them, leaving stale entries in the
-        # tree. If the tag is stale we drop it from the tree and retry — the
-        # retry either finds another live candidate in `reg` or falls through
-        # to a fresh `add_point`. This replaces an O(N) `k.get_entities(0)`
-        # scan on every collision with an O(1) OCC probe.
+        # Verify the tag still refers to a live OpenCASCADE dim-0 entity.
+        # Boolean ops (e.g. `k.cut`) can retag or delete entities after we
+        # inserted them; if the tag is stale we drop it and retry.
         if _is_live_point(k, best_elem.val)
             return best_elem.val
         end
-        # Drop the stale entry so future queries don't keep hitting it.
-        # SpatialIndexing takes the MBR (a point-Rect) as the delete key.
         delete!(points_tree, best_elem.mbr)
     end
 end
@@ -1620,16 +1616,28 @@ end
     return dx * dx + dy * dy + dz * dz
 end
 
-# O(1) probe: does OCC still have a point with this tag? `getBoundingBox` on
-# a stale tag throws "Unknown OpenCASCADE point with tag N".
+# Snapshot of OpenCASCADE dim-0 entity tags known to be live. Populated on
+# every `_get_or_add_point!` insert. Marked stale by any boolean op that can
+# delete/retag entities (currently `k.cut` in `_add_to_current_solidmodel!`);
+# a subsequent `_is_live_point` call refreshes from `k.get_entities(0)`.
+const POINT_MERGE_LIVE = Set{Int32}()
+const POINT_MERGE_STALE = Base.RefValue(true)
+
+function _refresh_live_points!(k)
+    empty!(POINT_MERGE_LIVE)
+    union!(POINT_MERGE_LIVE, Iterators.map(last, k.get_entities(0)))
+    POINT_MERGE_STALE[] = false
+    return nothing
+end
+
+function _mark_points_stale!()
+    POINT_MERGE_STALE[] = true
+    return nothing
+end
+
 function _is_live_point(k, tag)
-    try
-        k.getBoundingBox(0, tag)
-        return true
-    catch e
-        e isa ErrorException || rethrow(e)
-        return false
-    end
+    POINT_MERGE_STALE[] && _refresh_live_points!(k)
+    return tag in POINT_MERGE_LIVE
 end
 
 # Add primitives to solid model
@@ -1679,6 +1687,9 @@ function _add_to_current_solidmodel!(
         holes = [k.add_plane_surface([h]) for h ∈ hole_loops]
         out_dim_tags, _ = k.cut([(2, surftag)], [(2, x) for x ∈ holes])
         surftag = out_dim_tags[1][2]
+        # `k.cut` may have retagged or deleted dim-0 entities referenced by
+        # `points_tree`; force the next liveness probe to refresh.
+        _mark_points_stale!()
     end
     return (Int32(2), surftag)
 end

--- a/test/test_conformal_render.jl
+++ b/test/test_conformal_render.jl
@@ -49,7 +49,7 @@
         k = kernel(sm)
         ctx = ConformalRenderContext()
         import SpatialIndexing
-        points_tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+        points_cache = SolidModels.PointsCache()
 
         # Left rect: (0,0) → (10,0) → (10,10) → (0,10)
         left = CurvilinearPolygon(
@@ -70,8 +70,8 @@
             ]
         )
 
-        loop1 = add_conformal_loop!(ctx, left, k, 0.0μm; points_tree)
-        loop2 = add_conformal_loop!(ctx, right, k, 0.0μm; points_tree)
+        loop1 = add_conformal_loop!(ctx, left, k, 0.0μm; points_cache)
+        loop2 = add_conformal_loop!(ctx, right, k, 0.0μm; points_cache)
 
         # After the second loop, we should see at least one cache hit — the
         # shared edge (10,0)→(10,10) should reuse the tag from the first loop.
@@ -140,13 +140,13 @@
         k = kernel(sm)
         ctx = ConformalRenderContext()
         import SpatialIndexing
-        points_tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+        points_cache = SolidModels.PointsCache()
 
         R = 100.0μm
         pp = [Point(0.0μm, 0.0μm), Point(R, 0.0μm), Point(0.0μm, R)]
         turn = Paths.Turn(90°, R, α0=90°, p0=pp[2])
         cp = CurvilinearPolygon(pp, [turn], [2])
-        loop = add_conformal_loop!(ctx, cp, k, 0.0μm; points_tree)
+        loop = add_conformal_loop!(ctx, cp, k, 0.0μm; points_cache)
         @test loop isa Integer
         gmsh.finalize()
     end
@@ -157,13 +157,13 @@
         k = kernel(sm)
         ctx = ConformalRenderContext()
         import SpatialIndexing
-        points_tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+        points_cache = SolidModels.PointsCache()
 
         R = 50.0μm
         pp = [Point(0.0μm, 0.0μm), Point(R, 0.0μm), Point(-R, 0.0μm)]
         turn = Paths.Turn(180°, R, α0=90°, p0=pp[2])
         cp = CurvilinearPolygon(pp, [turn], [2])
-        loop = add_conformal_loop!(ctx, cp, k, 0.0μm; points_tree)
+        loop = add_conformal_loop!(ctx, cp, k, 0.0μm; points_cache)
         @test loop isa Integer
         gmsh.finalize()
     end
@@ -174,7 +174,7 @@
         k = kernel(sm)
         ctx = ConformalRenderContext()
         import SpatialIndexing
-        points_tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+        points_cache = SolidModels.PointsCache()
 
         pp = [
             Point(0.0μm, 0.0μm),
@@ -187,7 +187,7 @@
         t1 = Point(-1.0μm, 0.0μm)
         seg = Paths.BSpline(spline_pts, t0, t1)
         cp = CurvilinearPolygon(pp, [seg], [2])
-        loop = add_conformal_loop!(ctx, cp, k, 0.0μm; points_tree)
+        loop = add_conformal_loop!(ctx, cp, k, 0.0μm; points_cache)
         @test loop isa Integer
         gmsh.finalize()
     end
@@ -272,19 +272,19 @@
         k = kernel(sm)
         ctx = ConformalRenderContext()
         import SpatialIndexing
-        points_tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+        points_cache = SolidModels.PointsCache()
 
         R = 100.0μm
         pp = [Point(0.0μm, 0.0μm), Point(R, 0.0μm), Point(0.0μm, R)]
         turn = Paths.Turn(90°, R, α0=90°, p0=pp[2])
         cp_arc = CurvilinearPolygon(pp, [turn], [2])
-        add_conformal_loop!(ctx, cp_arc, k, 0.0μm; points_tree)
+        add_conformal_loop!(ctx, cp_arc, k, 0.0μm; points_cache)
 
         # Straight-edge polygon that shares the (pp[2], pp[3]) endpoints. It
         # would ordinarily be a chord, but the cache should return the arc tag.
         hits_before = ctx.stats[:hits]
         line_cp = CurvilinearPolygon(pp)  # no curve — pure line loop
-        add_conformal_loop!(ctx, line_cp, k, 0.0μm; points_tree)
+        add_conformal_loop!(ctx, line_cp, k, 0.0μm; points_cache)
         @test ctx.stats[:hits] > hits_before  # arc was reused for a line request
         gmsh.finalize()
     end
@@ -294,7 +294,7 @@
         k = kernel(sm)
         ctx = ConformalRenderContext()
         import SpatialIndexing
-        points_tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+        points_cache = SolidModels.PointsCache()
 
         pp = [
             Point(0.0μm, 0.0μm),
@@ -305,11 +305,11 @@
         spline_pts = [pp[2], Point(150.0μm, 50.0μm), pp[3]]
         seg = Paths.BSpline(spline_pts, Point(1.0μm, 0.0μm), Point(-1.0μm, 0.0μm))
         cp_spline = CurvilinearPolygon(pp, [seg], [2])
-        add_conformal_loop!(ctx, cp_spline, k, 0.0μm; points_tree)
+        add_conformal_loop!(ctx, cp_spline, k, 0.0μm; points_cache)
 
         hits_before = ctx.stats[:hits]
         line_cp = CurvilinearPolygon(pp)  # straight (pp[2], pp[3])
-        add_conformal_loop!(ctx, line_cp, k, 0.0μm; points_tree)
+        add_conformal_loop!(ctx, line_cp, k, 0.0μm; points_cache)
         # If the spline registered itself in endpoint_curve_index, the later
         # line request hits — otherwise a duplicate straight edge is created
         # and the shared boundary is non-conformal.
@@ -341,7 +341,7 @@
         k = kernel(sm)
         ctx = ConformalRenderContext()
         import SpatialIndexing
-        points_tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+        points_cache = SolidModels.PointsCache()
 
         R = 100.0μm
         pp = [Point(0.0μm, 0.0μm), Point(R, 0.0μm), Point(0.0μm, R)]
@@ -351,9 +351,9 @@
 
         misses_before = ctx.stats[:misses]
         arcs_before = ctx.stats[:arcs]
-        add_conformal_loop!(ctx, cp1, k, 0.0μm; points_tree)
+        add_conformal_loop!(ctx, cp1, k, 0.0μm; points_cache)
         arcs_after_first = ctx.stats[:arcs]
-        add_conformal_loop!(ctx, cp2, k, 0.0μm; points_tree)
+        add_conformal_loop!(ctx, cp2, k, 0.0μm; points_cache)
         # Second render created zero new arcs (all hits from the cache).
         @test ctx.stats[:arcs] == arcs_after_first
         # And at least one exact-key hit was recorded.
@@ -366,7 +366,7 @@
         k = kernel(sm)
         ctx = ConformalRenderContext()
         import SpatialIndexing
-        points_tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+        points_cache = SolidModels.PointsCache()
 
         pp = [
             Point(0.0μm, 0.0μm),
@@ -382,9 +382,9 @@
         cp1 = CurvilinearPolygon(pp, [seg], [2])
         cp2 = CurvilinearPolygon(pp, [seg], [2])
 
-        add_conformal_loop!(ctx, cp1, k, 0.0μm; points_tree)
+        add_conformal_loop!(ctx, cp1, k, 0.0μm; points_cache)
         splines_after_first = ctx.stats[:splines]
-        add_conformal_loop!(ctx, cp2, k, 0.0μm; points_tree)
+        add_conformal_loop!(ctx, cp2, k, 0.0μm; points_cache)
         @test ctx.stats[:splines] == splines_after_first
         @test ctx.stats[:hits] >= 1
         gmsh.finalize()
@@ -404,7 +404,7 @@
         ctx = ConformalRenderContext()
         import SpatialIndexing
         SolidModels = DeviceLayout.SolidModels
-        points_tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+        points_cache = SolidModels.PointsCache()
 
         # Endpoints on the x axis; centers above and below.
         p1 = SolidModels.ConformalRender._cached_point_relaxed!(
@@ -413,7 +413,7 @@
             -50.0,
             0.0,
             0.0,
-            points_tree
+            points_cache
         )
         p2 = SolidModels.ConformalRender._cached_point_relaxed!(
             k,
@@ -421,7 +421,7 @@
             50.0,
             0.0,
             0.0,
-            points_tree
+            points_cache
         )
         # Center above chord: bulges downward → midpoint below chord.
         c_above = SolidModels.ConformalRender._cached_point_strict!(
@@ -430,7 +430,7 @@
             0.0,
             80.0,
             0.0,
-            points_tree
+            points_cache
         )
         # Center below chord: bulges upward → midpoint above chord.
         c_below = SolidModels.ConformalRender._cached_point_strict!(
@@ -439,7 +439,7 @@
             0.0,
             -80.0,
             0.0,
-            points_tree
+            points_cache
         )
 
         rej_before = ctx.stats[:midpoint_rejections]
@@ -461,7 +461,7 @@
         k = kernel(sm)
         ctx = ConformalRenderContext()
         import SpatialIndexing
-        points_tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+        points_cache = SolidModels.PointsCache()
 
         a = Point(0.0μm, 0.0μm)
         b = Point(10.0μm, 0.0μm)
@@ -469,7 +469,7 @@
         # which would normally not appear here — just to hit the fallback.
         straight = Paths.Straight(10.0μm, a, 0.0°)
         cp = CurvilinearPolygon([a, b], [straight], [1])
-        @test_throws ArgumentError add_conformal_loop!(ctx, cp, k, 0.0μm; points_tree)
+        @test_throws ArgumentError add_conformal_loop!(ctx, cp, k, 0.0μm; points_cache)
         gmsh.finalize()
     end
 

--- a/test/test_solidmodel.jl
+++ b/test/test_solidmodel.jl
@@ -1920,4 +1920,87 @@ end
         @test length(tags) == nsurf
         @test area ≈ expected rtol = 1e-6
     end
+
+    @testset "_get_or_add_point! multi-candidate resolution" begin
+        # A caller that queries with a large `atol` can catch multiple
+        # previously-inserted points inside its tolerance box. The old
+        # implementation `only(pts)`-errored in that case; the new one
+        # returns the closest of the candidates.
+        import SpatialIndexing
+        sm = SolidModel("get_or_add_point_multi"; overwrite=true)
+        k = SolidModels.kernel(sm)
+        tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+        # Insert two points 0.1 µm apart at the tight default tolerance so the
+        # tree stores them as distinct entries.
+        t1 = SolidModels._get_or_add_point!(
+            k,
+            0.0,
+            0.0,
+            0.0,
+            tree;
+            atol=SolidModels.POINT_MERGE_ATOL
+        )
+        t2 = SolidModels._get_or_add_point!(
+            k,
+            0.1,
+            0.0,
+            0.0,
+            tree;
+            atol=SolidModels.POINT_MERGE_ATOL
+        )
+        @test t1 != t2
+        # Query at (0.02, 0, 0) with a wide atol that catches both — expect
+        # the closer one (t1, distance 0.02) rather than t2 (distance 0.08).
+        t_hit = SolidModels._get_or_add_point!(k, 0.02, 0.0, 0.0, tree; atol=1.0)
+        @test t_hit == t1
+        # Query at (0.08, 0, 0) with the same wide atol — expect t2.
+        t_hit2 = SolidModels._get_or_add_point!(k, 0.08, 0.0, 0.0, tree; atol=1.0)
+        @test t_hit2 == t2
+        SolidModels.gmsh.finalize()
+    end
+
+    @testset "_get_or_add_point! recovers from stale RTree tag" begin
+        # `k.cut` can retag or delete points after they were inserted into the
+        # points_tree. A subsequent lookup that finds a stale tag must fall
+        # back to a fresh `add_point` and drop the stale entry from the tree.
+        import SpatialIndexing
+        sm = SolidModel("get_or_add_point_stale"; overwrite=true)
+        k = SolidModels.kernel(sm)
+        tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+        stale = SolidModels._get_or_add_point!(
+            k,
+            3.0,
+            4.0,
+            0.0,
+            tree;
+            atol=SolidModels.POINT_MERGE_ATOL
+        )
+        # Simulate `k.cut` removing the point without notifying the tree.
+        k.remove([(0, stale)])
+        # A follow-up query on the same coordinates must NOT return the stale
+        # tag; it must synthesize a fresh point.
+        fresh = SolidModels._get_or_add_point!(
+            k,
+            3.0,
+            4.0,
+            0.0,
+            tree;
+            atol=SolidModels.POINT_MERGE_ATOL
+        )
+        @test fresh != stale
+        # The fresh point should be live (bounding box query succeeds).
+        @test try
+            k.getBoundingBox(0, fresh)
+            true
+        catch
+            false
+        end
+        # And the stale entry should have been dropped from the tree so
+        # future queries don't re-encounter it.
+        reg = SpatialIndexing.Rect((2.9, 3.9, -0.1), (3.1, 4.1, 0.1))
+        remaining = SpatialIndexing.contained_in(tree, reg)
+        @test length(remaining) == 1
+        @test first(remaining).val == fresh
+        SolidModels.gmsh.finalize()
+    end
 end

--- a/test/test_solidmodel.jl
+++ b/test/test_solidmodel.jl
@@ -1975,10 +1975,19 @@ end
             tree;
             atol=SolidModels.POINT_MERGE_ATOL
         )
-        # Simulate `k.cut` removing the point without notifying the tree.
+        # Simulate `k.cut` removing the point without notifying the tree —
+        # the RTree still holds the (now-stale) mapping to `stale`.
         k.remove([(0, stale)])
-        # A follow-up query on the same coordinates must NOT return the stale
-        # tag; it must synthesize a fresh point.
+        @test try
+            k.getBoundingBox(0, stale)
+            false
+        catch
+            true
+        end
+        # A follow-up query on the same coordinates must return a LIVE tag —
+        # `_get_or_add_point!` should detect that the cached candidate is
+        # stale and synthesize a fresh point. (OCC may recycle the freed tag
+        # value, so we assert liveness rather than tag inequality.)
         fresh = SolidModels._get_or_add_point!(
             k,
             3.0,
@@ -1987,20 +1996,18 @@ end
             tree;
             atol=SolidModels.POINT_MERGE_ATOL
         )
-        @test fresh != stale
-        # The fresh point should be live (bounding box query succeeds).
         @test try
             k.getBoundingBox(0, fresh)
             true
         catch
             false
         end
-        # And the stale entry should have been dropped from the tree so
-        # future queries don't re-encounter it.
+        # And the tree should now hold exactly one entry for this coordinate,
+        # pointing at the live tag (the stale entry was dropped and replaced).
         reg = SpatialIndexing.Rect((2.9, 3.9, -0.1), (3.1, 4.1, 0.1))
-        remaining = SpatialIndexing.contained_in(tree, reg)
+        remaining = collect(SpatialIndexing.contained_in(tree, reg))
         @test length(remaining) == 1
-        @test first(remaining).val == fresh
+        @test remaining[1].val == fresh
         SolidModels.gmsh.finalize()
     end
 end

--- a/test/test_solidmodel.jl
+++ b/test/test_solidmodel.jl
@@ -1926,13 +1926,13 @@ end
         import SpatialIndexing
         sm = SolidModel("get_or_add_point_multi"; overwrite=true)
         k = SolidModels.kernel(sm)
-        tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+        cache = SolidModels.PointsCache()
         t1 = SolidModels._get_or_add_point!(
             k,
             0.0,
             0.0,
             0.0,
-            tree;
+            cache;
             atol=SolidModels.POINT_MERGE_ATOL
         )
         t2 = SolidModels._get_or_add_point!(
@@ -1940,14 +1940,14 @@ end
             0.1,
             0.0,
             0.0,
-            tree;
+            cache;
             atol=SolidModels.POINT_MERGE_ATOL
         )
         @test t1 != t2
         # (0.02, 0, 0) with wide atol catches both; closer is t1.
-        @test SolidModels._get_or_add_point!(k, 0.02, 0.0, 0.0, tree; atol=1.0) == t1
+        @test SolidModels._get_or_add_point!(k, 0.02, 0.0, 0.0, cache; atol=1.0) == t1
         # (0.08, 0, 0) with the same wide atol — closer is t2.
-        @test SolidModels._get_or_add_point!(k, 0.08, 0.0, 0.0, tree; atol=1.0) == t2
+        @test SolidModels._get_or_add_point!(k, 0.08, 0.0, 0.0, cache; atol=1.0) == t2
         SolidModels.gmsh.finalize()
     end
 
@@ -1958,14 +1958,14 @@ end
         import SpatialIndexing
         sm = SolidModel("get_or_add_point_tie"; overwrite=true)
         k = SolidModels.kernel(sm)
-        tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+        cache = SolidModels.PointsCache()
         # Symmetric pair around the origin.
         t_neg = SolidModels._get_or_add_point!(
             k,
             -0.1,
             0.0,
             0.0,
-            tree;
+            cache;
             atol=SolidModels.POINT_MERGE_ATOL
         )
         t_pos = SolidModels._get_or_add_point!(
@@ -1973,30 +1973,30 @@ end
             0.1,
             0.0,
             0.0,
-            tree;
+            cache;
             atol=SolidModels.POINT_MERGE_ATOL
         )
         @test t_neg < t_pos  # insertion order gives ascending tags
         # Query at exact midpoint — both candidates equidistant. Must
         # return the lower tag deterministically.
-        @test SolidModels._get_or_add_point!(k, 0.0, 0.0, 0.0, tree; atol=1.0) == t_neg
+        @test SolidModels._get_or_add_point!(k, 0.0, 0.0, 0.0, cache; atol=1.0) == t_neg
         SolidModels.gmsh.finalize()
     end
 
     @testset "_get_or_add_point! recovers from stale RTree tag" begin
         # `k.cut` can retag or delete points after they were inserted into the
-        # points_tree. A subsequent lookup that finds a stale tag must fall
+        # points_cache. A subsequent lookup that finds a stale tag must fall
         # back to a fresh `add_point` and drop the stale entry from the tree.
         import SpatialIndexing
         sm = SolidModel("get_or_add_point_stale"; overwrite=true)
         k = SolidModels.kernel(sm)
-        tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+        cache = SolidModels.PointsCache()
         stale = SolidModels._get_or_add_point!(
             k,
             3.0,
             4.0,
             0.0,
-            tree;
+            cache;
             atol=SolidModels.POINT_MERGE_ATOL
         )
         # Simulate `k.cut` removing the point — the RTree still holds the
@@ -2004,7 +2004,7 @@ end
         # marked stale exactly the way `_add_to_current_solidmodel!` does
         # after a real `k.cut`.
         k.remove([(0, stale)])
-        SolidModels._mark_points_stale!()
+        SolidModels._mark_points_stale!(cache)
         @test try
             k.getBoundingBox(0, stale)
             false
@@ -2020,7 +2020,7 @@ end
             3.0,
             4.0,
             0.0,
-            tree;
+            cache;
             atol=SolidModels.POINT_MERGE_ATOL
         )
         @test try
@@ -2032,7 +2032,7 @@ end
         # And the tree should now hold exactly one entry for this coordinate,
         # pointing at the live tag (the stale entry was dropped and replaced).
         reg = SpatialIndexing.Rect((2.9, 3.9, -0.1), (3.1, 4.1, 0.1))
-        remaining = collect(SpatialIndexing.contained_in(tree, reg))
+        remaining = collect(SpatialIndexing.contained_in(cache.tree, reg))
         @test length(remaining) == 1
         @test remaining[1].val == fresh
         SolidModels.gmsh.finalize()

--- a/test/test_solidmodel.jl
+++ b/test/test_solidmodel.jl
@@ -1922,16 +1922,11 @@ end
     end
 
     @testset "_get_or_add_point! multi-candidate resolution" begin
-        # A caller that queries with a large `atol` can catch multiple
-        # previously-inserted points inside its tolerance box. The old
-        # implementation `only(pts)`-errored in that case; the new one
-        # returns the closest of the candidates.
+        # With multiple candidates in the tolerance box, return the closest.
         import SpatialIndexing
         sm = SolidModel("get_or_add_point_multi"; overwrite=true)
         k = SolidModels.kernel(sm)
         tree = SpatialIndexing.RTree{Float64, 3}(Int32)
-        # Insert two points 0.1 µm apart at the tight default tolerance so the
-        # tree stores them as distinct entries.
         t1 = SolidModels._get_or_add_point!(
             k,
             0.0,
@@ -1949,13 +1944,42 @@ end
             atol=SolidModels.POINT_MERGE_ATOL
         )
         @test t1 != t2
-        # Query at (0.02, 0, 0) with a wide atol that catches both — expect
-        # the closer one (t1, distance 0.02) rather than t2 (distance 0.08).
-        t_hit = SolidModels._get_or_add_point!(k, 0.02, 0.0, 0.0, tree; atol=1.0)
-        @test t_hit == t1
-        # Query at (0.08, 0, 0) with the same wide atol — expect t2.
-        t_hit2 = SolidModels._get_or_add_point!(k, 0.08, 0.0, 0.0, tree; atol=1.0)
-        @test t_hit2 == t2
+        # (0.02, 0, 0) with wide atol catches both; closer is t1.
+        @test SolidModels._get_or_add_point!(k, 0.02, 0.0, 0.0, tree; atol=1.0) == t1
+        # (0.08, 0, 0) with the same wide atol — closer is t2.
+        @test SolidModels._get_or_add_point!(k, 0.08, 0.0, 0.0, tree; atol=1.0) == t2
+        SolidModels.gmsh.finalize()
+    end
+
+    @testset "_get_or_add_point! equidistant tie-break by lower tag" begin
+        # If two inserted points are exactly equidistant from the query,
+        # R-tree iteration order is not guaranteed deterministic — the
+        # returned tag must be the lower one.
+        import SpatialIndexing
+        sm = SolidModel("get_or_add_point_tie"; overwrite=true)
+        k = SolidModels.kernel(sm)
+        tree = SpatialIndexing.RTree{Float64, 3}(Int32)
+        # Symmetric pair around the origin.
+        t_neg = SolidModels._get_or_add_point!(
+            k,
+            -0.1,
+            0.0,
+            0.0,
+            tree;
+            atol=SolidModels.POINT_MERGE_ATOL
+        )
+        t_pos = SolidModels._get_or_add_point!(
+            k,
+            0.1,
+            0.0,
+            0.0,
+            tree;
+            atol=SolidModels.POINT_MERGE_ATOL
+        )
+        @test t_neg < t_pos  # insertion order gives ascending tags
+        # Query at exact midpoint — both candidates equidistant. Must
+        # return the lower tag deterministically.
+        @test SolidModels._get_or_add_point!(k, 0.0, 0.0, 0.0, tree; atol=1.0) == t_neg
         SolidModels.gmsh.finalize()
     end
 
@@ -1975,9 +1999,12 @@ end
             tree;
             atol=SolidModels.POINT_MERGE_ATOL
         )
-        # Simulate `k.cut` removing the point without notifying the tree —
-        # the RTree still holds the (now-stale) mapping to `stale`.
+        # Simulate `k.cut` removing the point — the RTree still holds the
+        # (now-stale) mapping to `stale`, and the live-point snapshot is
+        # marked stale exactly the way `_add_to_current_solidmodel!` does
+        # after a real `k.cut`.
         k.remove([(0, stale)])
+        SolidModels._mark_points_stale!()
         @test try
             k.getBoundingBox(0, stale)
             false


### PR DESCRIPTION
Follows up on @gpeairs's comment in #260 (2026-08-07): _"another patch of yours that didn't make it here touched `_get_or_add_point!`, avoiding the O(N^2) sweep over points and relaxing the `only` call to allow for multiple merge candidates. Does it make sense to upstream that?"_ — this ships both.

## Changes

1. **Closest-of-many picker on multi-candidate collisions.** Replace `tag = only(pts).val` with a squared-distance scan across `pts`. Callers that query with a wider `atol` than the tightest inserted spacing (e.g. rendering pipelines that use a relaxed 2 nm vertex-merge tolerance while inserting arc centers at strict tolerance) can catch >1 candidate; the old code errored, the new one returns the closest.

2. **O(1) stale-tag probe instead of the O(N) `k.get_entities(0)` scan.** The check that catches a stale RTree tag after `k.cut` retagged/deleted the underlying OCC point is now `k.getBoundingBox(0, tag)` in a `try` block — throws for a stale tag, returns for a live one. On stale, the entry is dropped from the RTree so the next query doesn't hit it again.

## Benchmark

Micro-benchmark at N=10,000 points (hot cache-hit path — the loop `_add_loop!` runs during a full-chip render):

|          | Before  | After  | Speedup |
|----------|---------|--------|---------|
| Insert   | 4.69 µs | 4.60 µs | ~1× (unchanged) |
| Cache hit | 105.25 µs | 12.08 µs | **~8.7×** |

At production scale (a chip render inserts ~40 k points and re-queries each many times through shared boundaries) this is the difference between the point-lookup path being a bottleneck and being negligible.

## Correctness

Two new testsets under `test/test_solidmodel.jl`:

- `_get_or_add_point! multi-candidate resolution` — inserts two points 0.1 µm apart, queries with a wide `atol=1.0` that catches both, asserts the closer one is returned in both directions.
- `_get_or_add_point! recovers from stale RTree tag` — inserts a point, calls `k.remove([(0, tag)])` to simulate a `k.cut` that took it out from under the tree, asserts the next query returns a fresh tag and the stale entry is dropped.

`Pkg.test` locally: 595/595 pass (was 553; +7 new assertions across the two testsets).

Formatter clean (`scripts/format.jl check`).
