### PR TITLE
Use constant offset for termination halo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ The format of this changelog is based on
 
 ### Fixed
 
-  - Path termination halos now use constant-offset edges instead of the generic
-    functional-offset fallback.
+  - Path termination and `SimpleNoRender` halos now use constant-offset edges instead of the generic
+    functional-offset fallback. The rendered discretization of these halos on curves may change but 
+    will be geometrically equivalent within tolerance.
 
 ## 1.17.0 (2026-08-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format of this changelog is based on
 
 ## Unreleased
 
+### Fixed
+
+  - Path termination halos now use constant-offset edges instead of the generic
+    functional-offset fallback.
+
 ## 1.17.0 (2026-08-10)
 
 ### Added

--- a/examples/SingleTransmon/SingleTransmon.jl
+++ b/examples/SingleTransmon/SingleTransmon.jl
@@ -72,6 +72,7 @@ function single_transmon(;
         jj_template=ExampleSimpleJunction(),
         name="qubit",
         cap_length,
+        island_rounding=1μm,
         cap_gap,
         cap_width
     )

--- a/examples/SingleTransmon/SingleTransmon.jl
+++ b/examples/SingleTransmon/SingleTransmon.jl
@@ -72,7 +72,6 @@ function single_transmon(;
         jj_template=ExampleSimpleJunction(),
         name="qubit",
         cap_length,
-        island_rounding=1μm,
         cap_gap,
         cap_width
     )

--- a/src/paths/paths.jl
+++ b/src/paths/paths.jl
@@ -1599,7 +1599,13 @@ function halo(sty::Union{TaperTrace, TaperCPW}, outer_delta, inner_delta=nothing
 end
 
 function halo(
-    sty::Union{SimpleTrace, SimpleCPW},
+    sty::Union{
+        SimpleTrace,
+        SimpleCPW,
+        TraceTermination,
+        CPWOpenTermination,
+        CPWShortTermination
+    },
     outer_delta,
     inner_delta=nothing;
     kwargs...

--- a/src/paths/paths.jl
+++ b/src/paths/paths.jl
@@ -1630,7 +1630,12 @@ function halo(sty::SimpleNoRender, outer_delta, inner_delta=nothing; kwargs...)
     return Paths.SimpleNoRender(sty.width + outer_delta) # Change extent for attachments
 end
 
-function halo(sty::Union{NoRender, NoRenderContinuous, NoRenderDiscrete}, outer_delta, inner_delta=nothing; kwargs...)
+function halo(
+    sty::Union{NoRender, NoRenderContinuous, NoRenderDiscrete},
+    outer_delta,
+    inner_delta=nothing;
+    kwargs...
+)
     return Paths.NoRender()
 end
 

--- a/src/paths/paths.jl
+++ b/src/paths/paths.jl
@@ -1627,14 +1627,12 @@ function halo(sty::Style, outer_delta, inner_delta=nothing; kwargs...)
     )
 end
 
-function halo(
+halo(
     sty::Union{NoRender, NoRenderContinuous, NoRenderDiscrete},
     outer_delta,
     inner_delta=nothing;
     kwargs...
-)
-    return Paths.NoRender()
-end
+) = sty
 
 # All compound styles should be taken style-by-style rather than falling back to generic
 function halo(sty::AbstractCompoundStyle, outer_delta, inner_delta=nothing; kwargs...)

--- a/src/paths/paths.jl
+++ b/src/paths/paths.jl
@@ -1604,7 +1604,8 @@ function halo(
         SimpleCPW,
         TraceTermination,
         CPWOpenTermination,
-        CPWShortTermination
+        CPWShortTermination,
+        SimpleNoRender
     },
     outer_delta,
     inner_delta=nothing;
@@ -1624,10 +1625,6 @@ function halo(sty::Style, outer_delta, inner_delta=nothing; kwargs...)
         t -> 2 * (extent(sty, t) + inner_delta),
         t -> outer_delta - inner_delta
     )
-end
-
-function halo(sty::SimpleNoRender, outer_delta, inner_delta=nothing; kwargs...)
-    return Paths.SimpleNoRender(sty.width + outer_delta) # Change extent for attachments
 end
 
 function halo(

--- a/src/paths/paths.jl
+++ b/src/paths/paths.jl
@@ -1626,6 +1626,14 @@ function halo(sty::Style, outer_delta, inner_delta=nothing; kwargs...)
     )
 end
 
+function halo(sty::SimpleNoRender, outer_delta, inner_delta=nothing; kwargs...)
+    return Paths.SimpleNoRender(sty.width + outer_delta) # Change extent for attachments
+end
+
+function halo(sty::Union{NoRender, NoRenderContinuous, NoRenderDiscrete}, outer_delta, inner_delta=nothing; kwargs...)
+    return Paths.NoRender()
+end
+
 # All compound styles should be taken style-by-style rather than falling back to generic
 function halo(sty::AbstractCompoundStyle, outer_delta, inner_delta=nothing; kwargs...)
     newsty = copy(sty)

--- a/src/render/cpw.jl
+++ b/src/render/cpw.jl
@@ -1,33 +1,21 @@
-"""
-    cpw_points(f, s, scaler=identity)
-
-Return an anonymous function of `(t, sgn1, sgn2)` that returns points in the cross-section
-of the CPW defined by curve `f` and style `s`. `sgn1` and `sgn2` must be 1 or -1 and
-determine which point is returned.
-
-From left to right facing the direction of the curve, you can return the points defining
-the cross section as `f(t, 1, 1), f(t, 1, -1), f(t, -1, -1), f(t, -1, 1)`.
-"""
-function cpw_points(f, s, scaler=identity)
-    return (t, sgn1::Int, sgn2::Int) -> begin
-        if !(abs2(sgn1) == abs2(sgn2) == 1)
-            throw(ArgumentError("sgn1 and sgn2 must be 1 or -1"))
-        end
-        tng = Paths.ForwardDiff.derivative(f, t)
-        perp = sgn1 * Point(-tng.y, tng.x)
-
-        tt = scaler(t)
-        offset = (Paths.gap(s, tt) + Paths.trace(s, tt)) / 2
-        return f(t) + perp * ((sgn2 * Paths.gap(s, tt) / 2 + offset) / norm(perp))
-    end
+# Return the four corners of a straight CPW cross section in the order
+# right outer, right inner, left inner, left outer.
+function _cpw_corners(f::Paths.Straight, s, t)
+    center = f(t)
+    normal = Point(-sin(Paths.α0(f)), cos(Paths.α0(f)))
+    inner = Paths.trace(s) / 2
+    outer = inner + Paths.gap(s)
+    return [
+        center - outer * normal,
+        center - inner * normal,
+        center + inner * normal,
+        center + outer * normal
+    ]
 end
 
 function to_polygons(f::Paths.Straight{T}, s::Paths.SimpleCPW; kwargs...) where {T}
-    g = cpw_points(f, s)
+    c0 = _cpw_corners(f, s, zero(T))
+    c1 = _cpw_corners(f, s, pathlength(f))
 
-    t = StaticArrays.@SVector [zero(T), pathlength(f)]
-    ppts = [g.(t, 1, -1); @view g.(t, 1, 1)[end:-1:1]]
-    mpts = [g.(t, -1, 1); @view g.(t, -1, -1)[end:-1:1]]
-
-    return [Polygon(ppts), Polygon(mpts)]
+    return [Polygon([c0[3], c1[3], c1[4], c0[4]]), Polygon([c0[1], c1[1], c1[2], c0[2]])]
 end

--- a/src/render/cpw.jl
+++ b/src/render/cpw.jl
@@ -5,12 +5,12 @@ function _cpw_corners(f::Paths.Straight, s, t)
     normal = Point(-sin(Paths.α0(f)), cos(Paths.α0(f)))
     inner = Paths.trace(s) / 2
     outer = inner + Paths.gap(s)
-    return [
+    return (
         center - outer * normal,
         center - inner * normal,
         center + inner * normal,
         center + outer * normal
-    ]
+    )
 end
 
 function to_polygons(f::Paths.Straight{T}, s::Paths.SimpleCPW; kwargs...) where {T}

--- a/src/render/termination.jl
+++ b/src/render/termination.jl
@@ -48,9 +48,8 @@ function __poly(f::Paths.Straight{T}, s::Paths.CPWOpenTermination) where {T}
         end
         return Polygon(pts)
     else
-        ctr_initial = _cpw_corners(f, s, t1 - tr)
-        ctr_final = _cpw_corners(f, s, tr)
         pts = if s.initial
+            ctr_initial = _cpw_corners(f, s, t1 - tr)
             [
                 c1[1], # start at corner 1 (see diagram)
                 c1[2],
@@ -62,6 +61,7 @@ function __poly(f::Paths.Straight{T}, s::Paths.CPWOpenTermination) where {T}
                 c0[1]
             ]
         else
+            ctr_final = _cpw_corners(f, s, tr)
             [
                 c0[4], # start at corner 1 (see diagram)
                 c0[3],
@@ -122,10 +122,10 @@ function __poly(f::Paths.Straight{T}, s::Paths.CPWShortTermination) where {T}
     c0 = _cpw_corners(f, s, t0)
     c1 = _cpw_corners(f, s, t1)
     poly1 = Polygon([
-        c0[3],
+        c0[3], # for path with α=0°, start at corner 1 (see diagram)
         c1[3],
         c1[4],
-        c0[4] # for path with α=0°, start at corner 1 (see diagram)
+        c0[4]
     ])
 
     poly2 = Polygon([c0[1], c1[1], c1[2], c0[2]])

--- a/src/render/termination.jl
+++ b/src/render/termination.jl
@@ -23,52 +23,54 @@
 # corresponding to 2 and 5.
 
 function __poly(f::Paths.Straight{T}, s::Paths.CPWOpenTermination) where {T}
-    g = cpw_points(f, s)
-
     t0, tr, t1 = zero(T), s.rounding, pathlength(f)
+    c0 = _cpw_corners(f, s, t0)
+    c1 = _cpw_corners(f, s, t1)
     if iszero(tr)
         pts = if s.initial
             [
-                g(t1, -1, 1),  # start at corner 1 (see diagram)
-                g(t1, -1, -1),
-                g(t1, 1, -1),  # omitting corners 3, 4
-                g(t1, 1, 1),
-                g(t0, 1, 1),
-                g(t0, -1, 1)
+                c1[1], # start at corner 1 (see diagram)
+                c1[2],
+                c1[3], # omitting corners 3, 4
+                c1[4],
+                c0[4],
+                c0[1]
             ]
         else
             [
-                g(t0, 1, 1),   # start at corner 1 (see diagram)
-                g(t0, 1, -1),
-                g(t0, -1, -1), # omitting corners 3, 4
-                g(t0, -1, 1),
-                g(t1, -1, 1),
-                g(t1, 1, 1)
+                c0[4], # start at corner 1 (see diagram)
+                c0[3],
+                c0[2], # omitting corners 3, 4
+                c0[1],
+                c1[1],
+                c1[4]
             ]
         end
         return Polygon(pts)
     else
+        ctr_initial = _cpw_corners(f, s, t1 - tr)
+        ctr_final = _cpw_corners(f, s, tr)
         pts = if s.initial
             [
-                g(t1, -1, 1),  # start at corner 1 (see diagram)
-                g(t1, -1, -1),
-                g(t1 - tr, -1, -1),
-                g(t1 - tr, 1, -1),
-                g(t1, 1, -1),
-                g(t1, 1, 1),
-                g(t0, 1, 1),
-                g(t0, -1, 1)
+                c1[1], # start at corner 1 (see diagram)
+                c1[2],
+                ctr_initial[2],
+                ctr_initial[3],
+                c1[3],
+                c1[4],
+                c0[4],
+                c0[1]
             ]
         else
             [
-                g(t0, 1, 1),   # start at corner 1 (see diagram)
-                g(t0, 1, -1),
-                g(tr, 1, -1),
-                g(tr, -1, -1),
-                g(t0, -1, -1),
-                g(t0, -1, 1),
-                g(t1, -1, 1),
-                g(t1, 1, 1)
+                c0[4], # start at corner 1 (see diagram)
+                c0[3],
+                ctr_final[3],
+                ctr_final[2],
+                c0[2],
+                c0[1],
+                c1[1],
+                c1[4]
             ]
         end
 
@@ -112,21 +114,21 @@ end
 # 5--------6
 
 function __poly(f::Paths.Straight{T}, s::Paths.CPWShortTermination) where {T}
-    g = cpw_points(f, s)
-
     t0, tr, t1 = zero(T), s.rounding, pathlength(f)
     if !isapprox(tr, t1)
         throw(ArgumentError("Termination rounding ≠ termination path length."))
     end
 
+    c0 = _cpw_corners(f, s, t0)
+    c1 = _cpw_corners(f, s, t1)
     poly1 = Polygon([
-        g(t0, 1, -1),   # for path with α=0°, start at corner 1 (see diagram)
-        g(t1, 1, -1),
-        g(t1, 1, 1),
-        g(t0, 1, 1)
+        c0[3],
+        c1[3],
+        c1[4],
+        c0[4] # for path with α=0°, start at corner 1 (see diagram)
     ])
 
-    poly2 = Polygon([g(t0, -1, 1), g(t1, -1, 1), g(t1, -1, -1), g(t0, -1, -1)])
+    poly2 = Polygon([c0[1], c1[1], c1[2], c0[2]])
     iszero(tr) && return [poly1, poly2]
     round_idx = s.initial ? [1, 4] : [2, 3]
     round1 = Polygons.Rounded(tr; p0=points(poly1)[round_idx], min_side_len=zero(T))

--- a/test/test_entity.jl
+++ b/test/test_entity.jl
@@ -155,6 +155,67 @@
         @test halo(pth[1].sty, 20μm, 10μm) ==
               Paths.TaperCPW{typeof(1.0μm)}(30μm, 10μm, 40μm, 10μm, 10μm)
 
+        # Terminations have constant extent and should use the same simple halo styles as
+        # SimpleTrace/SimpleCPW rather than functional styles with general offsets.
+        termination_styles = (
+            Paths.TraceTermination(10μm, 2μm),
+            Paths.CPWOpenTermination(10μm, 6μm, 2μm),
+            Paths.CPWShortTermination(10μm, 6μm, 2μm)
+        )
+        outer_delta = 3μm
+        inner_delta = 1μm
+        for sty in termination_styles
+            ext = Paths.extent(sty)
+            @test halo(sty, outer_delta) == Paths.SimpleTrace(2 * (ext + outer_delta))
+            @test halo(sty, outer_delta, inner_delta) ==
+                  Paths.SimpleCPW(2 * (ext + inner_delta), outer_delta - inner_delta)
+        end
+
+        # On curved initial/final, open/short terminations, simple halo styles produce
+        # exact constant-offset edges. Endpoint extension remains path-level behavior.
+        for initial in (true, false), gap in (6μm, 0μm)
+            terminated_turn = Path(nm)
+            turn!(terminated_turn, 90°, 50μm, Paths.CPW(10μm, 6μm))
+            terminate!(terminated_turn; rounding=2μm, gap, initial)
+            termination_type =
+                iszero(gap) ? Paths.CPWShortTermination : Paths.CPWOpenTermination
+            termination_node = initial ? terminated_turn[1] : terminated_turn[end]
+            @test style(termination_node) isa termination_type
+
+            for inner in (nothing, inner_delta)
+                terminated_halo = if isnothing(inner)
+                    halo(terminated_turn, outer_delta)
+                else
+                    halo(terminated_turn, outer_delta, inner)
+                end
+                termination_halo_node =
+                    initial ? terminated_halo[2] : terminated_halo[end - 1]
+                expected_style = isnothing(inner) ? Paths.SimpleTrace : Paths.SimpleCPW
+                @test style(termination_halo_node) isa expected_style
+
+                initial_direction = Paths.α0(terminated_turn)
+                final_direction = Paths.α1(terminated_turn)
+                @test Paths.p0(terminated_halo) ≈
+                      Paths.p0(terminated_turn) -
+                      outer_delta * Point(cos(initial_direction), sin(initial_direction))
+                @test Paths.p1(terminated_halo) ≈
+                      Paths.p1(terminated_turn) +
+                      outer_delta * Point(cos(final_direction), sin(final_direction))
+
+                termination_halo_polys = pathtopolys(termination_halo_node)
+                halo_curves = reduce(
+                    vcat,
+                    [
+                        poly.curves for
+                        poly in termination_halo_polys if hasproperty(poly, :curves)
+                    ]
+                )
+                @test !isempty(halo_curves)
+                @test all(curve -> curve isa Paths.ConstantOffset, halo_curves)
+                @test !any(curve -> curve isa Paths.GeneralOffset, halo_curves)
+            end
+        end
+
         # A compound style is haloed substyle by substyle, so one starting with a
         # zero-extent substyle still gets a halo for its remaining substyles. Both
         # `AbstractCompoundStyle` subtypes must agree: `PeriodicStyle` here, and the

--- a/test/test_entity.jl
+++ b/test/test_entity.jl
@@ -227,9 +227,7 @@
         straight!(keepout_path, 10μm, Paths.SimpleNoRender(10μm, virtual=true))
         keepout_cs = CoordinateSystem(uniquename("keepout"), μm)
         place!(keepout_cs, keepout_path, SemanticMeta(:keepout))
-        keepout = elements(
-            flatten(Cell(halo(keepout_cs, 5μm), map_meta=(_) -> GDSMeta()))
-        )
+        keepout = elements(flatten(Cell(halo(keepout_cs, 5μm), map_meta=(_) -> GDSMeta())))
         @test only(gridpoints_in_polygon(keepout, [5μm], [0μm]))
 
         # A compound style is haloed substyle by substyle, so one starting with a

--- a/test/test_entity.jl
+++ b/test/test_entity.jl
@@ -216,6 +216,10 @@
             end
         end
 
+        # NoRender halos
+        @test Paths.extent(halo(Paths.SimpleNoRender(5μm), 5μm)) == 5μm
+        @test Paths.extent(halo(Paths.NoRender(), 5μm), 0μm) == 0μm
+
         # A compound style is haloed substyle by substyle, so one starting with a
         # zero-extent substyle still gets a halo for its remaining substyles. Both
         # `AbstractCompoundStyle` subtypes must agree: `PeriodicStyle` here, and the

--- a/test/test_entity.jl
+++ b/test/test_entity.jl
@@ -216,9 +216,21 @@
             end
         end
 
-        # NoRender halos
-        @test Paths.extent(halo(Paths.SimpleNoRender(5μm), 5μm)) == 5μm
+        # SimpleNoRender suppresses source geometry but its finite extent still represents
+        # a keepout. Its halo must therefore render, unlike the zero-extent NoRender styles.
+        simple_norender_halo = halo(Paths.SimpleNoRender(5μm), 5μm)
+        @test simple_norender_halo isa Paths.Trace
+        @test Paths.extent(simple_norender_halo, 0μm) == 7.5μm
         @test Paths.extent(halo(Paths.NoRender(), 5μm), 0μm) == 0μm
+
+        keepout_path = Path(μm)
+        straight!(keepout_path, 10μm, Paths.SimpleNoRender(10μm, virtual=true))
+        keepout_cs = CoordinateSystem(uniquename("keepout"), μm)
+        place!(keepout_cs, keepout_path, SemanticMeta(:keepout))
+        keepout = elements(
+            flatten(Cell(halo(keepout_cs, 5μm), map_meta=(_) -> GDSMeta()))
+        )
+        @test only(gridpoints_in_polygon(keepout, [5μm], [0μm]))
 
         # A compound style is haloed substyle by substyle, so one starting with a
         # zero-extent substyle still gets a halo for its remaining substyles. Both


### PR DESCRIPTION
Performance fix: Previously, termination (and SimpleNoRender) halos would use the generic fallback that creates a GeneralTrace/CPW style, which is relatively expensive to render. They now use constant-width Trace halos (or CPW if there's an inner delta).

Also fixed some unnecessary indirection in straight CPW rendering.