### PR TITLE
Add split_t_junctions! as a 2D geometry post-render operation

### DIFF
--- a/src/DeviceLayout.jl
+++ b/src/DeviceLayout.jl
@@ -576,7 +576,7 @@ export Curvilinear,
 
 # After curvilinear.jl (rounding produces CurvilinearRegion) and cells.jl/render
 include("postrender.jl")
-export round_layer, round_layer!
+export round_layer, round_layer!, split_t_junctions!
 
 include("simple_shapes.jl")
 import .SimpleShapes:

--- a/src/postrender.jl
+++ b/src/postrender.jl
@@ -106,3 +106,275 @@ function _rounded_regions(cs::CoordinateSystem{S}, layer, sty) where {S}
     # rather than being discretized, and line-arc corners are rounded natively.
     return [to_curvilinear(r, sty) for r in union2d_curved(ents)]
 end
+
+#####
+##### T-junction splitting
+#####
+# When two shapes share a boundary but their vertices don't line up — one shape
+# has a vertex partway along an edge of the other — the pair forms a "T junction".
+# This causes two kinds of downstream trouble:
+#
+#   * For **GDS output**, snapping to the manufacturing grid can round the two
+#     sides of the shared boundary apart, opening a ~1 nm gap or overlap.
+#   * For **3D meshing**, a mesher (e.g. TetGen) rejects the input with a
+#     "vertex lies in segment" PLC error because the shared boundary isn't a
+#     1:1 edge correspondence.
+#
+# [`split_t_junctions!`](@ref) fixes both by injecting each foreign vertex that
+# lies on a target edge into that edge, restoring matching vertices on both
+# sides. Straight edges get the foreign point inserted directly; curved edges
+# (`Paths.Turn`) are split at the corresponding arclength with [`Paths.split`](@ref)
+# so the sub-curves stay exact arcs.
+
+# All tolerances below are lengths (in the coordinate type `T`), expressed as a
+# multiple of `onenanometer(T)` so the same code is correct for any unit. Defaults
+# are tied to the geometry tolerances they must stay consistent with:
+#   * `atol` (coincidence) defaults to 1 nm, matching the default rendering
+#     discretization tolerance and the GDS 1 nm grid: a foreign vertex within one
+#     grid step of an edge is treated as lying on it.
+# Angular guards use `rtol`, a *fraction of the segment length*, so a split is
+# only made when it lands strictly interior to the edge/arc (never within `rtol`
+# of an endpoint, where it would duplicate an existing vertex).
+
+# Collect every vertex (exterior + holes) of a region's curvilinear polygons into
+# `pts`, as `Point{T}`.
+function _collect_region_vertices!(
+    pts::Vector{Point{T}},
+    region::CurvilinearRegion{T}
+) where {T}
+    append!(pts, points(region.exterior))
+    for h in region.holes
+        append!(pts, points(h))
+    end
+    return pts
+end
+
+# Foreign points from `candidates` that lie on the arc of `turn`, excluding its
+# endpoints, sorted along the direction of travel. Uses the segment's own
+# `curvaturecenter` (unit-correct) and `pathlength_nearest`, so no manual
+# trigonometry or unit stripping is needed.
+function _points_on_turn(turn::Paths.Turn{T}, candidates, atol, rtol::Real) where {T}
+    center = Paths.curvaturecenter(turn)
+    r = abs(turn.r)
+    L = pathlength(turn)
+    on_arc = Tuple{T, Point{T}}[]  # (arclength, on-arc point)
+    for c in candidates
+        # Radial coincidence: is the candidate on the circle of this arc?
+        d = hypot(getx(c) - getx(center), gety(c) - gety(center))
+        abs(d - r) > atol && continue
+        # Arclength of the nearest on-arc point; skip if it's outside (0, L) or
+        # within rtol·L of either end (those are the existing arc endpoints).
+        s = pathlength_nearest(turn, c)
+        (s <= rtol * L || s >= (1 - rtol) * L) && continue
+        # Snap to the exact point ON the arc at that arclength (NOT the foreign
+        # `c`, which may be up to `atol` off-arc — using `c` would break the
+        # `CurvilinearPolygon` constructor's tight point/endpoint agreement).
+        push!(on_arc, (convert(T, s), turn(s)))
+    end
+    sort!(on_arc; by=first)  # by arclength = order of travel along the arc
+    return on_arc
+end
+
+# Foreign points from `candidates` that lie on the straight edge p1→p2, excluding
+# its endpoints, sorted along the edge. Returns the injected points as `Point{T}`.
+function _points_on_edge(p1::Point{T}, p2::Point{T}, candidates, atol, rtol::Real) where {T}
+    d = p2 - p1
+    len = hypot(getx(d), gety(d))
+    on_edge = Tuple{Float64, Point{T}}[]  # (parameter t∈(0,1), foreign point)
+    len <= atol && return on_edge  # degenerate edge
+    for c in candidates
+        rel = c - p1
+        # projection parameter t along the edge, as a unitless Float64
+        t = Float64((getx(rel) * getx(d) + gety(rel) * gety(d)) / len^2)
+        (t <= rtol || t >= 1 - rtol) && continue                # interior only
+        # Perpendicular distance from the edge line (a length).
+        cross = getx(rel) * gety(d) - gety(rel) * getx(d)       # length²
+        perp = abs(cross) / len
+        perp > atol && continue
+        push!(on_edge, (t, c))  # a straight-edge split reuses the foreign point verbatim
+    end
+    sort!(on_edge; by=first)
+    return on_edge
+end
+
+# Rebuild one `CurvilinearPolygon`, injecting foreign vertices onto its edges.
+# Returns the (possibly rebuilt) polygon and the number of vertices inserted.
+function _inject_edge_vertices(
+    cpoly::CurvilinearPolygon{T},
+    candidates;
+    atol,
+    rtol::Real
+) where {T}
+    pts = points(cpoly)
+    n = length(pts)
+    n < 3 && return cpoly, 0
+    curve_at = Dict(csi => i for (i, csi) in enumerate(cpoly.curve_start_idx))
+    new_points = Point{T}[]
+    new_curves = eltype(cpoly.curves)[]
+    new_csi = Int[]
+    inserted = 0
+    for i = 1:n
+        push!(new_points, pts[i])
+        if haskey(curve_at, i)
+            # Curved edge starting at vertex i.
+            seg = cpoly.curves[curve_at[i]]
+            if seg isa Paths.Turn
+                splits = _points_on_turn(seg, candidates, atol, rtol)
+                if isempty(splits)
+                    push!(new_curves, seg)
+                    push!(new_csi, length(new_points))
+                else
+                    # Split the turn successively at each interior arclength. Work
+                    # in remaining-arclength coordinates as the head is peeled off.
+                    remaining = seg
+                    consumed = zero(pathlength(seg))
+                    for (s, on_pt) in splits
+                        s_local = s - consumed
+                        sub1, sub2 = Paths.split(remaining, s_local)
+                        push!(new_curves, sub1)
+                        push!(new_csi, length(new_points))
+                        push!(new_points, on_pt)
+                        remaining = sub2
+                        consumed = s
+                        inserted += 1
+                    end
+                    push!(new_curves, remaining)
+                    push!(new_csi, length(new_points))
+                end
+            else
+                push!(new_curves, seg)
+                push!(new_csi, length(new_points))
+            end
+        else
+            # Straight edge pts[i] → pts[i+1].
+            p2 = pts[mod1(i + 1, n)]
+            for (_, c) in _points_on_edge(pts[i], p2, candidates, atol, rtol)
+                push!(new_points, c)
+                inserted += 1
+            end
+        end
+    end
+    inserted == 0 && return cpoly, 0
+    return CurvilinearPolygon{T}(new_points, new_curves, new_csi), inserted
+end
+
+"""
+    split_t_junctions!(targets, sources...; atol=onenanometer(T), rtol=1e-6) -> Int
+
+Inject every vertex of the `sources` that lies on an edge of `targets` into that
+edge, so that a boundary shared between the two groups has matching vertices on
+both sides. Modifies `targets` in place and returns the number of vertices
+inserted.
+
+`targets` and each of `sources` are iterables of [`CurvilinearRegion`](@ref).
+A T junction occurs where a `sources` vertex lands partway along a `targets`
+edge without a corresponding `targets` vertex there. This function eliminates
+those junctions:
+
+  - **Straight edges** get the foreign vertex inserted verbatim (the two copies,
+    one per side, coincide and are treated as the same point downstream).
+  - **Curved edges** (`Paths.Turn`) are split at the foreign vertex's arclength
+    with [`Paths.split`](@ref), so the resulting sub-arcs remain exact. The
+    injected vertex is the exact point on the arc at that arclength, not the
+    (possibly slightly off-arc) foreign vertex.
+
+Fixing T junctions avoids 1 nm gaps from manufacturing-grid snapping in GDS output
+and "vertex lies in segment" PLC errors when meshing a solid model.
+
+# Keywords
+
+  - `atol`: coincidence tolerance (a length). A foreign vertex within `atol` of a
+    target edge (perpendicular distance for straight edges, radial distance for
+    arcs) is considered to lie on it. Defaults to `onenanometer(T)`, matching the
+    default rendering discretization tolerance and the GDS 1 nm grid.
+  - `rtol`: relative endpoint guard, as a fraction of edge/arc length. Splits
+    within `rtol` of an endpoint are skipped, since those coincide with an
+    existing vertex. Defaults to `1e-6`.
+
+# Example
+
+```julia
+targets = union2d_curved(cs => :metal_negative) # Vector{<:CurvilinearRegion}
+sources = union2d_curved(cs => :metal_positive)
+split_t_junctions!(targets, sources)
+```
+
+A [`Polygon`](@ref)-vector method is also provided for GDS-style geometry.
+"""
+function split_t_junctions!(
+    targets::AbstractVector{CurvilinearRegion{T}},
+    sources...;
+    atol=onenanometer(T),
+    rtol::Real=1e-6
+) where {T}
+    isempty(targets) && return 0
+    candidates = Point{T}[]
+    for group in sources
+        for region in group
+            _collect_region_vertices!(candidates, region)
+        end
+    end
+    isempty(candidates) && return 0
+    total = 0
+    for (ri, region) in enumerate(targets)
+        new_ext, n_ext = _inject_edge_vertices(region.exterior, candidates; atol, rtol)
+        new_holes = CurvilinearPolygon{T}[]
+        n_holes = 0
+        for h in region.holes
+            new_h, n_h = _inject_edge_vertices(h, candidates; atol, rtol)
+            push!(new_holes, new_h)
+            n_holes += n_h
+        end
+        if n_ext + n_holes > 0
+            targets[ri] = CurvilinearRegion{T}(new_ext, new_holes)
+            total += n_ext + n_holes
+        end
+    end
+    return total
+end
+
+"""
+    split_t_junctions!(targets::AbstractVector{<:Polygon}, sources...; atol, rtol) -> Int
+
+`Polygon`-vector method of [`split_t_junctions!`](@ref): inject `sources` vertices
+that lie on `targets` polygon edges. Useful for eliminating T junctions in 2D
+layout geometry before GDS output (where grid snapping could otherwise open 1 nm
+gaps along a shared straight boundary). Modifies `targets` in place; returns the
+number of vertices inserted.
+"""
+function split_t_junctions!(
+    targets::AbstractVector{<:Polygon{T}},
+    sources...;
+    atol=onenanometer(T),
+    rtol::Real=1e-6
+) where {T}
+    isempty(targets) && return 0
+    candidates = Point{T}[]
+    for group in sources
+        for poly in group
+            append!(candidates, points(poly))
+        end
+    end
+    isempty(candidates) && return 0
+    total = 0
+    for (pi, poly) in enumerate(targets)
+        pts = points(poly)
+        n = length(pts)
+        n < 3 && continue
+        new_points = Point{T}[]
+        inserted = 0
+        for i = 1:n
+            push!(new_points, pts[i])
+            p2 = pts[mod1(i + 1, n)]
+            for (_, c) in _points_on_edge(pts[i], p2, candidates, atol, rtol)
+                push!(new_points, c)
+                inserted += 1
+            end
+        end
+        if inserted > 0
+            targets[pi] = Polygon{T}(new_points)
+            total += inserted
+        end
+    end
+    return total
+end

--- a/test/test_postrender.jl
+++ b/test/test_postrender.jl
@@ -193,3 +193,311 @@
         @test elements(cs)[only(idx)] isa CurvilinearRegion # stays symbolic
     end
 end
+
+@testitem "split_t_junctions!" setup = [CommonTestSetup] begin
+    import DeviceLayout: CurvilinearPolygon, CurvilinearRegion, coordinatetype
+
+    # A rectangle target with a bottom edge (0,0)→(10,0). Built for coordinate
+    # type T (via convert) so the same test runs across unit conventions.
+    pT(T, x, y) = convert(Point{T}, p(x * μm, y * μm))
+    rect_region(T) = CurvilinearRegion(
+        CurvilinearPolygon(
+            Point{T}[pT(T, 0, 0), pT(T, 10, 0), pT(T, 10, 10), pT(T, 0, 10)]
+        )
+    )
+    # A 90° arc region: quarter circle radius R (µm) centered at origin, (R,0)→(0,R).
+    arc_region(T, R=10) = begin
+        turn = Paths.Turn(90°, convert(T, R * μm); α0=90°, p0=pT(T, R, 0))
+        CurvilinearRegion(
+            CurvilinearPolygon(
+                Point{T}[pT(T, R, 0), pT(T, 0, R), pT(T, R, R)],
+                [turn],
+                [1]
+            )
+        )
+    end
+
+    @testset "injects a foreign vertex on a straight edge" begin
+        target = [rect_region(typeof(1.0μm))]
+        # Source triangle with a vertex exactly on the target's bottom edge at (5,0).
+        source = [
+            CurvilinearRegion(
+                CurvilinearPolygon(
+                    Point{typeof(1.0μm)}[
+                        p(4.0μm, -5.0μm),
+                        p(5.0μm, 0.0μm),
+                        p(6.0μm, -5.0μm)
+                    ]
+                )
+            )
+        ]
+        n = split_t_junctions!(target, source)
+        @test n == 1
+        @test length(points(target[1].exterior)) == 5
+        @test any(
+            q ->
+                isapprox(getx(q), 5.0μm; atol=1e-6μm) &&
+                    isapprox(gety(q), 0.0μm; atol=1e-6μm),
+            points(target[1].exterior)
+        )
+    end
+
+    @testset "no-op when no source vertex lies on a target edge" begin
+        target = [rect_region(typeof(1.0μm))]
+        source = [
+            CurvilinearRegion(
+                CurvilinearPolygon(
+                    Point{typeof(1.0μm)}[
+                        p(20.0μm, 20.0μm),
+                        p(25.0μm, 25.0μm),
+                        p(20.0μm, 25.0μm)
+                    ]
+                )
+            )
+        ]
+        @test split_t_junctions!(target, source) == 0
+        @test length(points(target[1].exterior)) == 4
+    end
+
+    @testset "no-op on empty target or empty sources" begin
+        empty_t = CurvilinearRegion{typeof(1.0μm)}[]
+        src = [
+            CurvilinearRegion(
+                CurvilinearPolygon(
+                    Point{typeof(1.0μm)}[p(0μm, 0μm), p(5μm, 5μm), p(0μm, 5μm)]
+                )
+            )
+        ]
+        @test split_t_junctions!(empty_t, src) == 0
+        @test split_t_junctions!([rect_region(typeof(1.0μm))]) == 0                # no sources
+        @test split_t_junctions!(
+            [rect_region(typeof(1.0μm))],
+            CurvilinearRegion{typeof(1.0μm)}[]
+        ) == 0                                                                     # empty source group
+    end
+
+    @testset "picks up vertices from source holes" begin
+        target = [rect_region(typeof(1.0μm))]
+        # Source exterior is far away; its HOLE has a vertex on the target's edge.
+        source = [
+            CurvilinearRegion(
+                CurvilinearPolygon(
+                    Point{typeof(1.0μm)}[
+                        p(100.0μm, 100.0μm),
+                        p(110.0μm, 100.0μm),
+                        p(110.0μm, 110.0μm),
+                        p(100.0μm, 110.0μm)
+                    ]
+                ),
+                [
+                    CurvilinearPolygon(
+                        Point{typeof(1.0μm)}[
+                            p(102.0μm, 102.0μm),
+                            p(5.0μm, 0.0μm),
+                            p(108.0μm, 102.0μm)
+                        ]
+                    )
+                ]
+            )
+        ]
+        @test split_t_junctions!(target, source) == 1
+    end
+
+    @testset "splits a Turn at a foreign on-arc point, using the EXACT arc point" begin
+        target = [arc_region(typeof(1.0μm))]
+        R = 10.0
+        # Foreign point near 45° on the arc, deliberately a hair OFF the circle
+        # (radius 10 + 0.5 nm) to check we snap to the exact on-arc point, not this.
+        off = (R + 5e-4)
+        src_pt = p((off * cospi(0.25))μm, (off * sinpi(0.25))μm)
+        source = [
+            CurvilinearRegion(
+                CurvilinearPolygon(
+                    Point{typeof(1.0μm)}[src_pt, p(20.0μm, 20.0μm), p(20.0μm, 0.0μm)]
+                )
+            )
+        ]
+        n = split_t_junctions!(target, source)
+        @test n == 1
+        @test length(target[1].exterior.curves) == 2   # arc split into two sub-Turns
+        # The injected vertex must lie EXACTLY on radius R (the true arc), not at the
+        # off-arc source radius — this is what keeps CurvilinearPolygon consistent.
+        injected = only(
+            filter(
+                q ->
+                    !any(
+                        o -> isapprox(getx(q), getx(o)) && isapprox(gety(q), gety(o)),
+                        (p(R * 1μm, 0.0μm), p(0.0μm, R * 1μm), p(R * 1μm, R * 1μm))
+                    ),
+                points(target[1].exterior)
+            )
+        )
+        r_injected = hypot(getx(injected), gety(injected))
+        @test isapprox(r_injected, R * 1μm; atol=1e-6μm)   # on the true arc
+        @test !isapprox(r_injected, off * 1μm; atol=1e-6μm) # NOT the off-arc source
+    end
+
+    @testset "splits multiple foreign points on one arc, ordered along travel" begin
+        target = [arc_region(typeof(1.0μm))]
+        R = 10.0
+        # Two on-arc points at 30° and 60°.
+        a = p((R * cospi(1 / 6))μm, (R * sinpi(1 / 6))μm)
+        b = p((R * cospi(1 / 3))μm, (R * sinpi(1 / 3))μm)
+        source = [
+            CurvilinearRegion(
+                CurvilinearPolygon(
+                    Point{typeof(1.0μm)}[a, b, p(20.0μm, 20.0μm), p(20.0μm, 0.0μm)]
+                )
+            )
+        ]
+        n = split_t_junctions!(target, source)
+        @test n == 2
+        @test length(target[1].exterior.curves) == 3   # arc split into three sub-Turns
+    end
+
+    @testset "orders points correctly on a clockwise arc (hole winding)" begin
+        # A CW arc (negative α) — the case where naive angle sorting reverses order.
+        # Two on-arc points must still be injected in travel order without error.
+        T = typeof(1.0μm)
+        R = 10.0μm
+        turn = Paths.Turn(-90°, R; α0=0°, p0=p(0.0μm, 0.0μm))
+        # endpoints of this CW quarter arc
+        e0 = turn(zero(pathlength(turn)))
+        e1 = turn(pathlength(turn))
+        target = [
+            CurvilinearRegion(
+                CurvilinearPolygon(Point{T}[e0, e1, p(getx(e1), gety(e0))], [turn], [1])
+            )
+        ]
+        c = Paths.curvaturecenter(turn)
+        pa = turn(pathlength(turn) * 0.3)   # two interior on-arc points
+        pb = turn(pathlength(turn) * 0.7)
+        source = [
+            CurvilinearRegion(
+                CurvilinearPolygon(Point{T}[pa, pb, p(getx(pa) + 1μm, gety(pa) - 1μm)])
+            )
+        ]
+        n = split_t_junctions!(target, source)
+        @test n == 2
+        @test length(target[1].exterior.curves) == 3
+    end
+
+    @testset "result is invariant across coordinate types (nm vs μm)" begin
+        # Same geometry in two coordinate conventions must inject the same number
+        # of vertices and land them at the same physical location.
+        function run(T)
+            target = [rect_region(T)]
+            source = [
+                CurvilinearRegion(
+                    CurvilinearPolygon(Point{T}[pT(T, 4, -5), pT(T, 5, 0), pT(T, 6, -5)])
+                )
+            ]
+            n = split_t_junctions!(target, source)
+            return n, points(target[1].exterior)
+        end
+        n_um, pts_um = run(typeof(1.0μm))
+        n_nm, pts_nm = run(typeof(1.0nm))
+        @test n_um == n_nm == 1
+        @test length(pts_um) == length(pts_nm) == 5
+        # The injected (5,0) vertex is at the same physical point regardless of units.
+        onedge(pts) = any(
+            q ->
+                isapprox(getx(q), 5.0μm; atol=1e-6μm) &&
+                    isapprox(gety(q), 0.0μm; atol=1e-6μm),
+            pts
+        )
+        @test onedge(pts_um)
+        @test onedge(pts_nm)
+    end
+
+    @testset "Polygon-vector method injects on straight edges (GDS gap fix)" begin
+        T = typeof(1.0μm)
+        target = [Polygon(Point{T}[p(0μm, 0μm), p(10μm, 0μm), p(10μm, 10μm), p(0μm, 10μm)])]
+        source = [Polygon(Point{T}[p(4μm, -5μm), p(5μm, 0μm), p(6μm, -5μm)])]
+        n = split_t_junctions!(target, source)
+        @test n == 1
+        @test length(points(target[1])) == 5
+        @test any(
+            q ->
+                isapprox(getx(q), 5.0μm; atol=1e-6μm) &&
+                    isapprox(gety(q), 0.0μm; atol=1e-6μm),
+            points(target[1])
+        )
+    end
+
+    @testset "leaves an arc untouched when no foreign point lies on it" begin
+        # A target carrying a Turn arc, with sources that share no boundary:
+        # the arc is carried through unchanged (the isempty(splits) branch).
+        target = [arc_region(typeof(1.0μm))]
+        source = [
+            CurvilinearRegion(
+                CurvilinearPolygon(
+                    Point{typeof(1.0μm)}[
+                        p(100.0μm, 100.0μm),
+                        p(110.0μm, 100.0μm),
+                        p(110.0μm, 110.0μm)
+                    ]
+                )
+            )
+        ]
+        @test split_t_junctions!(target, source) == 0
+        # The single Turn survives, unmodified.
+        @test length(target[1].exterior.curves) == 1
+        @test target[1].exterior.curves[1] isa Paths.Turn
+    end
+
+    @testset "carries a non-Turn (BSpline) curve through unchanged" begin
+        # split_t_junctions! only splits Turn arcs; a BSpline edge is passed
+        # through verbatim (the non-Turn else branch), even when a source vertex
+        # happens to sit near it.
+        T = typeof(1.0μm)
+        pp =
+            Point{T}[p(0.0μm, 0.0μm), p(10.0μm, 0.0μm), p(10.0μm, 10.0μm), p(0.0μm, 10.0μm)]
+        spline_pts = [pp[2], p(15.0μm, 5.0μm), pp[3]]
+        seg = Paths.BSpline(spline_pts, p(1.0μm, 0.0μm), p(-1.0μm, 0.0μm))
+        target = [CurvilinearRegion(CurvilinearPolygon(pp, [seg], [2]))]
+        # A source vertex on the straight bottom edge (0,0)→(10,0) at x=5.
+        source = [
+            CurvilinearRegion(
+                CurvilinearPolygon(
+                    Point{T}[p(4.0μm, -5.0μm), p(5.0μm, 0.0μm), p(6.0μm, -5.0μm)]
+                )
+            )
+        ]
+        n = split_t_junctions!(target, source)
+        @test n == 1                                   # the straight edge got the vertex
+        # The BSpline is still present and was NOT split.
+        @test count(c -> c isa Paths.BSpline, target[1].exterior.curves) == 1
+    end
+
+    @testset "injects into a TARGET region's hole edge" begin
+        # The target region has a hole; a source vertex lands on the hole's edge
+        # and must be injected there (the hole loop of split_t_junctions!).
+        T = typeof(1.0μm)
+        ext = CurvilinearPolygon(
+            Point{T}[p(0μm, 0μm), p(30μm, 0μm), p(30μm, 30μm), p(0μm, 30μm)]
+        )
+        # Square hole (10,10)-(20,20); right edge x=20, y∈[10,20].
+        hole = CurvilinearPolygon(
+            Point{T}[p(10μm, 10μm), p(10μm, 20μm), p(20μm, 20μm), p(20μm, 10μm)]
+        )
+        target = [CurvilinearRegion(ext, [hole])]
+        # Source has a vertex at (20,15) — interior to the hole's right edge.
+        source = [
+            CurvilinearRegion(
+                CurvilinearPolygon(
+                    Point{T}[p(20.0μm, 15.0μm), p(25.0μm, 12.0μm), p(25.0μm, 18.0μm)]
+                )
+            )
+        ]
+        n = split_t_junctions!(target, source)
+        @test n >= 1
+        # The injected vertex is on the hole, not the exterior.
+        @test any(
+            q ->
+                isapprox(getx(q), 20.0μm; atol=1e-6μm) &&
+                    isapprox(gety(q), 15.0μm; atol=1e-6μm),
+            points(target[1].holes[1])
+        )
+    end
+end


### PR DESCRIPTION
## Summary

Adds `split_t_junctions!(targets, sources...; atol, rtol)` as a general 2D
geometry post-render operation in `src/postrender.jl`, exported from
`DeviceLayout`.

It injects every vertex of `sources` that lies on an edge of `targets` into
that edge, so a boundary shared between two groups carries matching vertices on
both sides. This serves two purposes:

- **GDS output**: closes ~1 nm gaps that appear when a shared boundary is
  snapped to the manufacturing grid on one side but not the other.
- **Solid-model meshing**: eliminates the "vertex lies in segment" PLC errors a
  mesher raises when a T-junction is left in the input.

## Details

- **Straight edges** get the foreign vertex inserted verbatim (the two copies,
  one per side, coincide and are treated as the same point downstream).
- **Curved edges** (`Paths.Turn`) are split at the foreign vertex's arclength
  with `Paths.split`, so sub-arcs stay exact. The injected vertex is the exact
  on-arc point at that arclength, not the (possibly slightly off-arc) source
  vertex.
- A `Polygon`-vector method is provided alongside the `CurvilinearRegion` one.
- Tolerances are two named, unit-correct keywords: `atol` (a length, default
  `onenanometer(T)`, tied to the render/GDS 1 nm grid) and `rtol` (relative
  endpoint guard, default `1e-6`). Arc geometry uses the segment's own
  `curvaturecenter` and `pathlength_nearest` — no manual trigonometry, no
  `ustrip`, nothing coordinate-type-specific.

## Tests

`test/test_postrender.jl` covers straight-edge injection, no-op cases,
hole-source, exact-on-arc single/multiple injection, clockwise-arc ordering, a
cross-coordinate-type invariance check (identical output for nm- and µm-based
coordinates), and the `Polygon`-vector method.

## Note on scope

This is the rework of the earlier revision of this PR, which also contained
`split_pinches`. Per review, this PR is now scoped to `split_t_junctions!`
only; `split_pinches` moves to its own PR (it is preprocessing specific to
conformal rendering, whereas `split_t_junctions!` is a general 2D operation
useful for GDS output too).