### PR TITLE
Add graphics bbox, metadata_filter, dpi, backgrounds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-CHANGELOG.md merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format of this changelog is based on
 ### Fixed
 
   - Graphics export now preserves aspect ratio when only `width` or `height` is supplied, rather than
-    capping width-only output at 288 pixels high. Reference bounding boxes render again, and GDS layers
+    capping width-only output at 288 pixels high. If neither is supplied, the maximum dimension is capped at 4 inches. Reference bounding boxes render again, and GDS layers
     above 255 receive palette colors instead of all falling back to black.
   - Path termination and `SimpleNoRender` halos now use constant-offset edges instead of the generic
     functional-offset fallback. The rendered discretization of these halos on curves may change but 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ The format of this changelog is based on
 
   - Mesh control-point sets that resolve to the same `(h, α)` no longer overwrite one another
     when the default grading parameter is applied.
+  - Cairo graphics export accepts a layout-coordinate `bbox` viewport, a `metadata_filter` passed
+    through to `flatten`, configurable `dpi`, and transparent, white, black, or RGB(A) backgrounds.
+    `layercolors` may use exact `GDSMeta` keys to distinguish datatypes on the same GDS layer.
+
+### Fixed
+
+  - Graphics export now preserves aspect ratio when only `width` or `height` is supplied, rather than
+    capping width-only output at 288 pixels high. Reference bounding boxes render again, and GDS layers
+    above 255 receive palette colors instead of all falling back to black.
   - Path termination and `SimpleNoRender` halos now use constant-offset edges instead of the generic
     functional-offset fallback. The rendered discretization of these halos on curves may change but 
     will be geometrically equivalent within tolerance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format of this changelog is based on
   - Mesh control-point sets that resolve to the same `(h, α)` no longer overwrite one another
     when the default grading parameter is applied.
   - Cairo graphics export accepts a layout-coordinate `bbox` viewport, a `metadata_filter` passed
+  - Graphics export accepts a layout-coordinate `bbox` viewport, a `metadata_filter` passed
     through to `flatten`, configurable `dpi`, and transparent, white, black, or RGB(A) backgrounds.
     `layercolors` may use exact `GDSMeta` keys to distinguish datatypes on the same GDS layer.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,18 +14,14 @@ The format of this changelog is based on
     For `extrude_z!` postrender operations, generated perimeter and curvature controls are
     repeated along the extrusion.
     Pass `curvature_sizing=false` to `render!` or `render_conformal!` to retain perimeter-only sizing.
-
-### Fixed
-
-  - Mesh control-point sets that resolve to the same `(h, α)` no longer overwrite one another
-    when the default grading parameter is applied.
-  - Cairo graphics export accepts a layout-coordinate `bbox` viewport, a `metadata_filter` passed
   - Graphics export accepts a layout-coordinate `bbox` viewport, a `metadata_filter` passed
     through to `flatten`, configurable `dpi`, and transparent, white, black, or RGB(A) backgrounds.
     `layercolors` may use exact `GDSMeta` keys to distinguish datatypes on the same GDS layer.
 
 ### Fixed
 
+  - Mesh control-point sets that resolve to the same `(h, α)` no longer overwrite one another
+    when the default grading parameter is applied.
   - Graphics export now preserves aspect ratio when only `width` or `height` is supplied, rather than
     capping width-only output at 288 pixels high. If neither is supplied, the maximum dimension is capped at 4 inches. Reference bounding boxes render again, and GDS layers
     above 255 receive palette colors instead of all falling back to black.

--- a/docs/src/concepts/render.md
+++ b/docs/src/concepts/render.md
@@ -91,9 +91,8 @@ and so on. You can save a cell to a graphics file by, e.g. `save("/path/to/file.
   - `height`: Output height, with the same unitless-pixel or physical-length behavior as
     `width`. If `width` is omitted, it is chosen to preserve the aspect ratio. Supplying both
     dimensions uses them exactly.
-  - `dpi`: Resolution used to convert physical `width` and `height` values to pixels, and for
-    the default four-inch width. It does not rescale unitless pixel dimensions. The default is
-    72.
+  - `dpi`: Resolution used to convert physical `width` and `height` values to pixels, including
+    the default four-inch maximum dimension. It does not rescale unitless pixel dimensions. The default is 72. For vector outputs, physical dimensions are scaled.
   - `bbox`: A [`Rectangle`](@ref) in layout coordinates to use as the viewport. Geometry outside
     the rectangle is clipped by the graphics surface.
   - `metadata_filter`: A predicate passed to [`flatten`](@ref) to select metadata before

--- a/docs/src/concepts/render.md
+++ b/docs/src/concepts/render.md
@@ -85,13 +85,37 @@ cells into SVG, PDF, and EPS vector graphics formats, or into the PNG raster gra
 format. This enables patterns to be displayed in web browsers, publications, presentations,
 and so on. You can save a cell to a graphics file by, e.g. `save("/path/to/file.svg", mycell)`. Possible keyword arguments include:
 
-  - `width`: Specifies the width parameter. A unitless number will give the width in pixels,
-    72dpi. You can also give a length in any unit using a `Unitful.Quantity`, e.g. `u"4inch"` if
-    you had previously done `using Unitful`.
-  - `height`: Specifies the height parameter. A unitless number will give the width in pixels,
-    72dpi. You can also give a length in any unit using a `Unitful.Quantity`. The aspect ratio
-    of the output is always preserved so specify either `width` or `height`.
-  - `layercolors`: Should be a dictionary with `Int` keys for layers and RGBA tuples as values.
-    For example, (1.0, 0.0, 0.0, 0.5) is red with 50% opacity.
-  - `bboxes`: Specifies whether to draw bounding boxes around the bounds of cell arrays or
-    cell references (true/false).
+  - `width`: Output width. A unitless number gives pixels. A `Unitful.Quantity`, such as
+    `u"4inch"`, is converted to pixels using `dpi`. If `height` is omitted, it is chosen to
+    preserve the rendered region's aspect ratio.
+  - `height`: Output height, with the same unitless-pixel or physical-length behavior as
+    `width`. If `width` is omitted, it is chosen to preserve the aspect ratio. Supplying both
+    dimensions uses them exactly.
+  - `dpi`: Resolution used to convert physical `width` and `height` values to pixels, and for
+    the default four-inch width. It does not rescale unitless pixel dimensions. The default is
+    72.
+  - `bbox`: A [`Rectangle`](@ref) in layout coordinates to use as the viewport. Geometry outside
+    the rectangle is clipped by the graphics surface.
+  - `metadata_filter`: A predicate passed to [`flatten`](@ref) to select metadata before
+    drawing. For example, `layer_inclusion([GDSMeta(1, 0)], [])` renders only that GDS layer
+    and datatype.
+  - `layercolors`: A dictionary mapping either exact `GDSMeta` values or integer GDS layer
+    numbers to RGBA tuples. Exact metadata keys allow datatypes on one layer to have different
+    colors. For example, `(1.0, 0.0, 0.0, 0.5)` is red with 50% opacity.
+  - `background`: `:transparent` (the default), `:white`, `:black`, `nothing`, or an RGB(A)
+    tuple with components between zero and one.
+  - `bboxes`: Whether to draw yellow bounding boxes around top-level cell arrays or cell
+    references (`true`/`false`).
+
+For example, this produces a high-resolution white-background crop containing only one layer:
+
+```julia
+save(
+    "junction_crop.png",
+    cell;
+    width=1200,
+    bbox=Rectangle(Point(400μm, 200μm), Point(500μm, 300μm)),
+    metadata_filter=layer_inclusion(GDSMeta(5, 0), []),
+    background=:white
+)
+```

--- a/src/backends/graphics.jl
+++ b/src/backends/graphics.jl
@@ -4,7 +4,15 @@ import Unitful: Length, inch, ustrip
 import Cairo
 
 import DeviceLayout:
-    bounds, datatype, default_meta_map, element_metadata, gdslayer, load, save, to_polygons
+    bounds,
+    datatype,
+    default_meta_map,
+    element_metadata,
+    gdslayer,
+    load,
+    refs,
+    save,
+    to_polygons
 import DeviceLayout: CoordinateSystem, GeometryEntity
 using ..Points
 using ..Transformations
@@ -74,17 +82,59 @@ lcolor(l) = lcolor(l, get_color_scheme())
 # Initialize layercolors with the preferred scheme
 const layercolors = Dict([(i => lcolor(i)) for i = 0:255]...)
 
-function fillcolor(options, layer)
-    haskey(options, :layercolors) &&
-        haskey(options[:layercolors], layer) &&
-        return options[:layercolors][layer]
-    haskey(layercolors, layer) && return layercolors[layer]
-    return (0.0, 0.0, 0.0, 0.5)
+function fillcolor(options, meta)
+    layer = gdslayer(meta)
+    if haskey(options, :layercolors)
+        colors = options[:layercolors]
+        haskey(colors, meta) && return colors[meta]
+        haskey(colors, layer) && return colors[layer]
+    end
+    color_index = mod(layer + 31 * datatype(meta), length(layercolors))
+    return layercolors[color_index]
 end
 
-lscale(x::Length)  = round(NoUnits((x |> inch) * 72 / inch))
-lscale(x::Integer) = x
-lscale(x::Real)    = Int(round(x))
+lscale(x::Length, dpi)  = round(Int, NoUnits((x |> inch) * dpi / inch))
+lscale(x::Integer, dpi) = x
+lscale(x::Real, dpi)    = Int(round(x))
+
+function canvas_size(options, w, h)
+    dpi = get(options, :dpi, 72)
+    dpi isa Real && dpi > 0 || throw(ArgumentError("dpi must be a positive number"))
+    has_width = haskey(options, :width)
+    has_height = haskey(options, :height)
+    default_size = lscale(4inch, dpi)
+    if has_width && has_height
+        return lscale(options[:width], dpi), lscale(options[:height], dpi)
+    elseif has_width
+        w1 = lscale(options[:width], dpi)
+        return w1, iszero(w) || iszero(h) ? w1 : Int(ceil(w1 * h / w))
+    elseif has_height
+        h1 = lscale(options[:height], dpi)
+        return iszero(w) || iszero(h) ? h1 : Int(ceil(h1 * w / h)), h1
+    end
+    return (
+        default_size,
+        iszero(w) || iszero(h) ? default_size : Int(ceil(default_size * h / w))
+    )
+end
+
+function background_color(background)
+    isnothing(background) && return (0.0, 0.0, 0.0, 0.0)
+    background === :transparent && return (0.0, 0.0, 0.0, 0.0)
+    background === :white && return (1.0, 1.0, 1.0, 1.0)
+    background === :black && return (0.0, 0.0, 0.0, 1.0)
+    if background isa Tuple && length(background) in (3, 4)
+        all(x -> x isa Real && 0 <= x <= 1, background) ||
+            throw(ArgumentError("background color components must be between 0 and 1"))
+        length(background) == 3 && return (background..., 1.0)
+        return background
+    end
+    throw(
+        ArgumentError(
+            "background must be :transparent, :white, :black, nothing, or an RGB(A) tuple"
+        )
+    )
+end
 
 MIMETypes = Union{
     MIME"image/png",
@@ -98,15 +148,20 @@ function Base.show(
     geom::Union{Cell{T}, CoordinateSystem{T}};
     options...
 ) where {T}
-    c0 = flatten(geom)
     opt = Dict{Symbol, Any}(options)
-    bnd = bounds(c0)
+    c0 = flatten(geom; metadata_filter=get(opt, :metadata_filter, nothing))
+    viewport = get(opt, :bbox, nothing)
+    if !isnothing(viewport) && !(viewport isa Rectangle)
+        throw(ArgumentError("bbox must be a Rectangle or nothing"))
+    end
+    bnd = isnothing(viewport) ? bounds(c0) : convert(Rectangle{T}, viewport)
     w, h = width(ustrip(bnd)), height(ustrip(bnd))
-    w1 = haskey(opt, :width) ? lscale(opt[:width]) : 4 * 72
-    h1 =
-        haskey(opt, :height) ? lscale(opt[:height]) :
-        (iszero(w) ? 4 * 72 : min(4 * 72, Int(ceil(w1 * h / w))))
-    bboxes = haskey(opt, :bboxes) ? opt[:bboxes] : false
+    !isnothing(viewport) &&
+        (w <= 0 || h <= 0) &&
+        throw(ArgumentError("bbox must have positive width and height"))
+    w1, h1 = canvas_size(opt, w, h)
+    w1 > 0 && h1 > 0 || throw(ArgumentError("render dimensions must be positive"))
+    bboxes = get(opt, :bboxes, false)
 
     surf = if mime isa MIME"image/png"
         Cairo.CairoARGBSurface(w1, h1)
@@ -121,23 +176,21 @@ function Base.show(
     end
 
     ctx = Cairo.CairoContext(surf)
-    if mime isa MIME"image/png"
-        # Transparent background
-        Cairo.set_source_rgba(ctx, 0.0, 0.0, 0.0, 0.0)
-        Cairo.rectangle(ctx, 0, 0, w1, h1)
-        Cairo.fill(ctx)
-    end
+    Cairo.set_source_rgba(ctx, background_color(get(opt, :background, :transparent))...)
+    Cairo.rectangle(ctx, 0, 0, w1, h1)
+    Cairo.fill(ctx)
 
-    ly = collect(gdslayers(c0))
+    metas = default_meta_map.(element_metadata(c0))
+    unique_metas = sort(unique(metas), by=meta -> (gdslayer(meta), datatype(meta)))
     trans = Translation(-bnd.ll.x, bnd.ur.y) ∘ XReflection()
 
-    sf = min(w1 / w, h1 / h)
+    sf = iszero(w) || iszero(h) ? 1.0 : min(w1 / w, h1 / h)
     Cairo.scale(ctx, sf, sf)
 
-    for l in sort(ly)
+    for meta in unique_metas
         Cairo.save(ctx)
-        Cairo.set_source_rgba(ctx, fillcolor(options, l)...)
-        for el in c0.elements[gdslayer.(default_meta_map.(element_metadata(c0))) .== l]
+        Cairo.set_source_rgba(ctx, fillcolor(opt, meta)...)
+        for el in c0.elements[metas .== meta]
             tel = trans(el)
             poly!(ctx, tel)
             render_text!(ctx, tel, sf)
@@ -149,7 +202,7 @@ function Base.show(
     if c0 isa Cell
         Cairo.save(ctx)
         for (t, meta) in zip(c0.texts, c0.text_metadata)
-            Cairo.set_source_rgba(ctx, fillcolor(options, gdslayer(meta))...)
+            Cairo.set_source_rgba(ctx, fillcolor(opt, default_meta_map(meta))...)
             render_text!(ctx, trans(t), sf)
         end
         Cairo.fill(ctx)
@@ -157,19 +210,15 @@ function Base.show(
     end
 
     if bboxes
-        for ref in c0.refs
+        for ref in refs(geom)
             Cairo.save(ctx)
             r = convert(Rectangle{T}, bounds(ref))
             Cairo.set_line_width(ctx, 0.5)
             Cairo.set_source_rgb(ctx, 1, 1, 0)
             Cairo.set_dash(ctx, [1.0, 1.0])
-            Cairo.rectangle(
-                ctx,
-                trans(ustrip(r.ll)).x,
-                trans(ustrip(r.ur)).y,
-                ustrip(width(r)),
-                ustrip(height(r))
-            )
+            ll = ustrip(trans(r.ll))
+            ur = ustrip(trans(r.ur))
+            Cairo.rectangle(ctx, ll.x, ur.y, ustrip(width(r)), ustrip(height(r)))
             Cairo.stroke(ctx)
             Cairo.restore(ctx)
         end

--- a/src/backends/graphics.jl
+++ b/src/backends/graphics.jl
@@ -7,7 +7,9 @@ import DeviceLayout:
     bounds,
     datatype,
     default_meta_map,
+    elements,
     element_metadata,
+    findbox,
     gdslayer,
     load,
     refs,
@@ -90,7 +92,7 @@ function fillcolor(options, meta)
         haskey(colors, layer) && return colors[layer]
     end
     color_index = mod(layer + 31 * datatype(meta), length(layercolors))
-    return layercolors[color_index]
+    return get(layercolors, color_index, (0.0, 0.0, 0.0, 0.5)) # Fallback in case `layercolors` was given non-consecutive keys
 end
 
 lscale(x::Length, dpi)  = round(Int, NoUnits((x |> inch) * dpi / inch))
@@ -112,9 +114,16 @@ function canvas_size(options, w, h)
         h1 = lscale(options[:height], dpi)
         return iszero(w) || iszero(h) ? h1 : Int(ceil(h1 * w / h)), h1
     end
+    # Fallback to default with max dimension capped at default_size, preserving aspect ratio
+    if w > h
+        return (
+            default_size,
+            iszero(w) || iszero(h) ? default_size : Int(ceil(default_size * h / w))
+        )
+    end
     return (
-        default_size,
-        iszero(w) || iszero(h) ? default_size : Int(ceil(default_size * h / w))
+        iszero(w) || iszero(h) ? default_size : Int(ceil(default_size * w / h)),
+        default_size
     )
 end
 
@@ -180,17 +189,19 @@ function Base.show(
     Cairo.rectangle(ctx, 0, 0, w1, h1)
     Cairo.fill(ctx)
 
-    metas = default_meta_map.(element_metadata(c0))
-    unique_metas = sort(unique(metas), by=meta -> (gdslayer(meta), datatype(meta)))
     trans = Translation(-bnd.ll.x, bnd.ur.y) ∘ XReflection()
 
     sf = iszero(w) || iszero(h) ? 1.0 : min(w1 / w, h1 / h)
     Cairo.scale(ctx, sf, sf)
 
+    view_idx = findbox(bnd, elements(c0); intersects=true)
+    view_elements = elements(c0)[view_idx]
+    view_metas = default_meta_map.(element_metadata(c0)[view_idx])
+    unique_metas = sort(unique(view_metas), by=meta -> (gdslayer(meta), datatype(meta)))
     for meta in unique_metas
         Cairo.save(ctx)
         Cairo.set_source_rgba(ctx, fillcolor(opt, meta)...)
-        for el in c0.elements[metas .== meta]
+        for el in view_elements[view_metas .== meta]
             tel = trans(el)
             poly!(ctx, tel)
             render_text!(ctx, tel, sf)

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -1213,6 +1213,14 @@ end
             background=:white
         )
         @test occursin("fill=\"rgb(100%, 100%, 100%)\"", read(path, String))
+        save(
+            path,
+            layered;
+            width=100,
+            bbox=Rectangle(Point(-10μm, -10μm), Point(40μm, 20μm)),
+            background=(0.5, 0.5, 0.5, 1.0)
+        )
+        @test occursin("fill=\"rgb(50%, 50%, 50%)\"", read(path, String))
 
         referenced = Cell("referenced", nm)
         addref!(referenced, s1, Point(0μm, 0μm))
@@ -1228,6 +1236,9 @@ end
             Dict{Symbol, Any}(:layercolors => Dict(GDSMeta(300, 2) => (1, 0, 0, 1))),
             GDSMeta(300, 2)
         ) == (1, 0, 0, 1)
+        @test eltype(
+            DeviceLayout.Graphics.canvas_size(Dict(:width => 4.6, :height => 4.6), 1, 1)
+        ) <: Integer
         @test_throws ArgumentError DeviceLayout.Graphics.canvas_size(
             Dict{Symbol, Any}(:dpi => 0),
             1,
@@ -1239,6 +1250,12 @@ end
             MIME"image/svg+xml"(),
             layered;
             bbox=Rectangle(0μm, 10μm)
+        )
+        @test_throws ArgumentError show(
+            IOBuffer(),
+            MIME"image/svg+xml"(),
+            layered;
+            bbox=(0μm, 10μm)
         )
 
         # Non-Cell straight to graphics

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -1156,6 +1156,91 @@ end
         save(path, s1, width=72 * 4)
         rm(path, force=true)
 
+        png_dimensions(path) = begin
+            bytes = read(path)
+            bigendian_uint32(range) =
+                foldl(range; init=UInt32(0)) do value, byte
+                    return (value << 8) | byte
+                end
+            return Int(bigendian_uint32(bytes[17:20])), Int(bigendian_uint32(bytes[21:24]))
+        end
+
+        wide = Cell("wide", nm)
+        render!(wide, Rectangle(20μm, 10μm), GDSMeta(1, 0))
+        path = joinpath(tdir, "wide.png")
+        save(path, wide; width=800)
+        @test png_dimensions(path) == (800, 400)
+        save(path, wide; height=100)
+        @test png_dimensions(path) == (200, 100)
+        save(path, wide; dpi=144)
+        @test png_dimensions(path) == (576, 288)
+        save(path, wide; width=100, bbox=Rectangle(10μm, 10μm))
+        @test png_dimensions(path) == (100, 100)
+        path = joinpath(tdir, "cross_unit_bbox.svg")
+        save(
+            path,
+            wide;
+            width=100,
+            bbox=Rectangle(10μm, 10μm),
+            layercolors=Dict(1 => (1.0, 0.0, 0.0, 1.0))
+        )
+        @test occursin("rgb(100%, 0%, 0%)", read(path, String))
+        rm(path, force=true)
+
+        layered = Cell("layered", nm)
+        render!(layered, Rectangle(10μm, 10μm), GDSMeta(1, 0))
+        render!(layered, Rectangle(Point(20μm, 0μm), Point(30μm, 10μm)), GDSMeta(2, 0))
+        path = joinpath(tdir, "filtered.svg")
+        save(
+            path,
+            layered;
+            width=100,
+            metadata_filter=layer_inclusion(GDSMeta(2, 0), []),
+            layercolors=Dict(
+                GDSMeta(1, 0) => (1.0, 0.0, 0.0, 1.0),
+                GDSMeta(2, 0) => (0.0, 1.0, 0.0, 1.0)
+            )
+        )
+        filtered_svg = read(path, String)
+        @test occursin("rgb(0%, 100%, 0%)", filtered_svg)
+        @test !occursin("rgb(100%, 0%, 0%)", filtered_svg)
+
+        save(
+            path,
+            layered;
+            width=100,
+            bbox=Rectangle(Point(-10μm, -10μm), Point(40μm, 20μm)),
+            background=:white
+        )
+        @test occursin("fill=\"rgb(100%, 100%, 100%)\"", read(path, String))
+
+        referenced = Cell("referenced", nm)
+        addref!(referenced, s1, Point(0μm, 0μm))
+        save(path, referenced; width=100, bboxes=true)
+        @test occursin("stroke=\"rgb(100%, 100%, 0%)\"", read(path, String))
+        rm(path, force=true)
+
+        @test DeviceLayout.Graphics.fillcolor(Dict{Symbol, Any}(), GDSMeta(300, 0)) !=
+              (0.0, 0.0, 0.0, 0.5)
+        @test DeviceLayout.Graphics.fillcolor(Dict{Symbol, Any}(), GDSMeta(1, 0)) !=
+              DeviceLayout.Graphics.fillcolor(Dict{Symbol, Any}(), GDSMeta(1, 1))
+        @test DeviceLayout.Graphics.fillcolor(
+            Dict{Symbol, Any}(:layercolors => Dict(GDSMeta(300, 2) => (1, 0, 0, 1))),
+            GDSMeta(300, 2)
+        ) == (1, 0, 0, 1)
+        @test_throws ArgumentError DeviceLayout.Graphics.canvas_size(
+            Dict{Symbol, Any}(:dpi => 0),
+            1,
+            1
+        )
+        @test_throws ArgumentError DeviceLayout.Graphics.background_color(:blue)
+        @test_throws ArgumentError show(
+            IOBuffer(),
+            MIME"image/svg+xml"(),
+            layered;
+            bbox=Rectangle(0μm, 10μm)
+        )
+
         # Non-Cell straight to graphics
         cs1 = CoordinateSystem("test", nm)
         r1 = Rectangle(10μm, 10μm)

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -1187,6 +1187,12 @@ end
         @test occursin("rgb(100%, 0%, 0%)", read(path, String))
         rm(path, force=true)
 
+        tall = Cell("tall", nm)
+        render!(tall, Rectangle(10μm, 20μm), GDSMeta(1, 0))
+        path = joinpath(tdir, "tall.png")
+        save(path, tall; dpi=144)
+        @test png_dimensions(path) == (288, 576)
+
         layered = Cell("layered", nm)
         render!(layered, Rectangle(10μm, 10μm), GDSMeta(1, 0))
         render!(layered, Rectangle(Point(20μm, 0μm), Point(30μm, 10μm)), GDSMeta(2, 0))


### PR DESCRIPTION
Add several keyword arguments to graphics-format `save` to make graphics export more useful:

- `bbox`: Restrict the viewport to a given rectangle
- `metadata_filter`: Same function keyword argument as `flatten` -- a `Meta -> Bool` filter like those produced by `layer_inclusion` to select layers to include/exclude
- `dpi`: Configurable dpi
- `layercolors`: Can now use exact GDSMeta keys to set different colors for same gdslayer, different datatype

Also fixes aspect ratio / height capping when only `width` or `height` is supplied, as well as the `bboxes` control for rendering cell bounding boxes. GDS layers above 255 now cycle back through palette colors.

A follow up will add a `save_render` wrapper that also exports a "manifest" with metadata about the exported image.