### PR TITLE
Fixes to API methods with zero coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ The format of this changelog is based on
   - Path termination and `SimpleNoRender` halos now use constant-offset edges instead of the generic
     functional-offset fallback. The rendered discretization of these halos on curves may change but 
     will be geometrically equivalent within tolerance.
+  - `SolidModels.revolve!` now accepts unitful axis points and directions, converting point
+    coordinates to the solid-model unit and direction components to a common unit. Unitless
+    points and directions remain supported.
   - `SolidModels.dimtags` applied to a vector of physical groups now returns a flat vector of
     `(dimension, tag)` tuples, as its docstring specifies, instead of a vector of per-group
     vectors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ The format of this changelog is based on
   - Path termination and `SimpleNoRender` halos now use constant-offset edges instead of the generic
     functional-offset fallback. The rendered discretization of these halos on curves may change but 
     will be geometrically equivalent within tolerance.
+  - `SolidModels.dimtags` applied to a vector of physical groups now returns a flat vector of
+    `(dimension, tag)` tuples, as its docstring specifies, instead of a vector of per-group
+    vectors.
+  - `SolidModels.remove_group!` applied to a collection of group names now returns a flat
+    (empty) dimtag vector, so it can be used as a postrender operation. Previously it returned
+    a vector of vectors and raised a `BoundsError` when the postrender machinery assigned the
+    result to a physical group.
 
 ## 1.17.0 (2026-08-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format of this changelog is based on
 
 ## Unreleased
 
+### Fixed
+
+  - `addstyle!(d::StyleDict, s::GeometryEntityStyle, node::Clipper.PolyNode)` no longer throws
+    an `UndefVarError`. This documented form of `addstyle!` referred to an undefined name in
+    its body, so it never worked; the equivalent `d[node] = s` spelling was unaffected.
+  - `rem_node!` now removes the node from a `SchematicGraph`'s name lookup as well as from its
+    node list. Previously the removed node stayed reachable as `g.<id>`, and using it then
+    failed obscurely — with a `MethodError` mentioning `Nothing`, or a `KeyError` whose key is
+    the whole `ComponentNode` — instead of reporting that the node had been removed.
+
 ## 1.16.1 (2026-07-28)
 
 ### Fixed

--- a/src/polygons.jl
+++ b/src/polygons.jl
@@ -1552,7 +1552,7 @@ end
 addstyle!(d::StyleDict, s::GeometryEntityStyle, indices::Int...) =
     addstyle!(d, s, [indices...])
 addstyle!(d::StyleDict, s::GeometryEntityStyle, node::Clipper.PolyNode) =
-    addstyle!(d, s, getkey(n))
+    addstyle!(d, s, getkey(node))
 
 # Accessors for a StyleDict
 Base.getindex(d::StyleDict, indices::Vector{Int}) = get(d.styles, indices, d.default)

--- a/src/schematics/schematics.jl
+++ b/src/schematics/schematics.jl
@@ -168,7 +168,9 @@ add_node!(g::SchematicGraph, n::ComponentNode; base_id=n.id, kwargs...) =
 function rem_node!(g::SchematicGraph, n::ComponentNode)
     idx = indexof(n, g)
     rem_vertex!(g.graph, idx)
-    delete!(g.node_dict, n.id)
+    # `node_dict` is keyed by `Symbol`, as `add_node!` inserts it; deleting with the node's
+    # `String` id would be a silent no-op, leaving the removed node reachable as `g.<id>`.
+    delete!(g.node_dict, Symbol(n.id))
     # Tricky indexing external data structure with vertices
     g.nodes[idx] = last(g.nodes) # Internally rem_vertex swaps with last vertex and pops
     pop!(g.nodes)

--- a/src/solidmodels/postrender.jl
+++ b/src/solidmodels/postrender.jl
@@ -162,14 +162,17 @@ end
     revolve!(sm::SolidModel, groupname, groupdim, x, y, z, ax, ay, az, θ)
 
 Extrude the entities in `g` using a rotation of `θ` radians around the axis of revolution
-through `(x, y, z)` in the direction `(ax, ay, az)`.
+through `(x, y, z)` in the direction `(ax, ay, az)`. The point and direction may each
+be unitful or unitless.
 
 When the mesh is extruded the angle should be strictly smaller than 2π.
 
 Return the resulting entities as a vector of `(dimension, entity_tag)` `Tuple`s.
 """
 function revolve!(g::AbstractPhysicalGroup, x, y, z, ax, ay, az, θ)
-    outdimtags = kernel(g).revolve(dimtags(g), x, y, z, ax, ay, az, θ)
+    point = x isa Length ? ustrip.(STP_UNIT, (x, y, z)) : (x, y, z)
+    axis = ustrip.(unit(ax), (ax, ay, az))
+    outdimtags = kernel(g).revolve(dimtags(g), point..., axis..., θ)
     return outdimtags
 end
 function revolve!(sm::SolidModel, groupname, groupdim, args...)

--- a/src/solidmodels/postrender.jl
+++ b/src/solidmodels/postrender.jl
@@ -1011,7 +1011,7 @@ function remove_group!(
 end
 
 remove_group!(sm::SolidModel, group, dim; kwargs...) =
-    remove_group!.(sm, group, dim; kwargs...)
+    reduce(vcat, remove_group!.(sm, group, dim; kwargs...); init=Tuple{Int32, Int32}[])
 
 function remove_group!(group::PhysicalGroup; recursive=true, remove_entities=true)
     if remove_entities

--- a/src/solidmodels/solidmodels.jl
+++ b/src/solidmodels/solidmodels.jl
@@ -85,7 +85,7 @@ import DeviceLayout.Polygons:
     radius
 import DeviceLayout.Curvilinear:
     islinear, round_to_curvilinearpolygon, to_curvilinear, styled_loop
-import Unitful: μm, mm, ustrip, °, uconvert, Length
+import Unitful: μm, mm, ustrip, °, uconvert, Length, unit
 import FileIO: File
 
 import SpatialIndexing

--- a/src/solidmodels/solidmodels.jl
+++ b/src/solidmodels/solidmodels.jl
@@ -242,7 +242,8 @@ end
 Return the `(dimension, integer tag)` tuples for `SolidModel` entities in `pg`.
 """
 dimtags(pg::AbstractPhysicalGroup) = [(pg.dim, tag) for tag in entitytags(pg)]
-dimtags(groups::Vector{<:AbstractPhysicalGroup}) = vcat(dimtags.(groups))
+dimtags(groups::Vector{<:AbstractPhysicalGroup}) =
+    reduce(vcat, dimtags.(groups); init=Tuple{Int32, Int32}[])
 
 name(pg::PhysicalGroup) = pg.name
 

--- a/test/test_schematicdriven.jl
+++ b/test/test_schematicdriven.jl
@@ -231,6 +231,22 @@
         SchematicDrivenLayout.matching_hooks(t1::TestComponent, ::TestComponent) =
             SchematicDrivenLayout.matching_hooks(t1, Spacer())
 
+        # `rem_node!` drops the node from `nodes` and from the name lookup. `node_dict` is
+        # keyed by `Symbol`, as `add_node!` inserts it, so deleting with the node's `String`
+        # id deletes nothing: the removed node stays reachable as `g.<id>` and every later
+        # use of it fails obscurely, since `indexof` then returns `nothing`.
+        @testset "Remove" begin
+            g3 = SchematicGraph("test_remove")
+            keep = add_node!(g3, template)
+            drop = add_node!(g3, bq)
+            @test Symbol(drop.id) in keys(g3.node_dict)
+            @test rem_node!(g3, drop) === drop
+            @test nodes(g3) == [keep]
+            @test !(Symbol(drop.id) in keys(g3.node_dict))
+            @test Symbol(keep.id) in keys(g3.node_dict)
+            @test getproperty(g3, Symbol(keep.id)) === keep
+        end
+
         @testset "Replace" begin
             append_x(tc, p) =
                 TestComponent(name=(tc.name * "$(ustrip(mm, p.x))"), hooks=tc.hooks)

--- a/test/test_shapes.jl
+++ b/test/test_shapes.jl
@@ -145,6 +145,18 @@
     @test d2[[1, 1]].min_angle == Polygons.Rounded(0.25μm).min_angle
     @test d2[[1, 1]].p0 == Polygons.Rounded(0.25μm).p0
 
+    # `addstyle!` is documented for all three location forms, and the `PolyNode` form must
+    # agree with the `setindex!` spelling above, which routes through it.
+    d3 = StyleDict()
+    Polygons.addstyle!(d3, Polygons.Rounded(0.25μm), rd1[1, 1])
+    @test to_polygons(DeviceLayout.styled(rd1, d3)) == to_polygons(rds)
+    d3 = StyleDict()
+    Polygons.addstyle!(d3, Polygons.Rounded(0.25μm), 1, 1)
+    @test to_polygons(DeviceLayout.styled(rd1, d3)) == to_polygons(rds)
+    d3 = StyleDict()
+    Polygons.addstyle!(d3, Polygons.Rounded(0.25μm), [1, 1])
+    @test to_polygons(DeviceLayout.styled(rd1, d3)) == to_polygons(rds)
+
     # Apply a Rounding style specified by target points
     sty = Polygons.Rounded(2.0μm, p0=[Point(1.0μm, 1.0μm), Point(-1.0μm, -1.0μm)])
     r = centered(Rectangle(2.0μm, 2.0μm))

--- a/test/test_solidmodel.jl
+++ b/test/test_solidmodel.jl
@@ -373,6 +373,52 @@
           SolidModels.fragment_geom!(sm, "test_bdy", "test_bdy", 1, 1)
     @test SolidModels.hasgroup(sm, "test_bdy", 1)
 
+    # The collection-accepting forms of `dimtags` and `remove_group!` return a flat dimtag vector
+    @testset "Collection forms return flat dimtags" begin
+        cs_c = CoordinateSystem("collections", nm)
+        place!(cs_c, Rectangle(10μm, 10μm), SemanticMeta(:a))
+        place!(cs_c, Rectangle(4μm, 4μm) + Point(20μm, 0μm), SemanticMeta(:b))
+
+        # dimtags
+        sm_c = SolidModel("collections"; overwrite=true)
+        render!(sm_c, cs_c; skip_postrender=true)
+        ga, gb = sm_c["a", 2], sm_c["b", 2]
+        @test !isempty(SolidModels.dimtags(ga))
+        @test !isempty(SolidModels.dimtags(gb))
+        @test SolidModels.dimtags([ga, gb]) ==
+              vcat(SolidModels.dimtags(ga), SolidModels.dimtags(gb))
+        @test eltype(SolidModels.dimtags([ga, gb])) <: Tuple
+        @test isempty(SolidModels.dimtags(typeof(ga)[]))
+        @test eltype(SolidModels.dimtags(typeof(ga)[])) <: Tuple
+
+        # remove_group!
+        @test isempty(SolidModels.remove_group!(sm_c, ["a", "b"], 2; remove_entities=false))
+        @test eltype(SolidModels.remove_group!(sm_c, String[], 2; remove_entities=false)) <:
+              Tuple
+        @test !SolidModels.hasgroup(sm_c, "a", 2)
+        @test !SolidModels.hasgroup(sm_c, "b", 2)
+
+        # ...and through the postrender protocol
+        sm_v = SolidModel("collections_vec"; overwrite=true)
+        @test_nowarn render!(
+            sm_v,
+            cs_c;
+            postrender_ops=[("gone", SolidModels.remove_group!, (["a", "b"], 2))]
+        )
+        @test !SolidModels.hasgroup(sm_v, "a", 2)
+        @test !SolidModels.hasgroup(sm_v, "b", 2)
+
+        # scalar control
+        sm_s = SolidModel("collections_scalar"; overwrite=true)
+        @test_nowarn render!(
+            sm_s,
+            cs_c;
+            postrender_ops=[("gone", SolidModels.remove_group!, ("a", 2))]
+        )
+        @test !SolidModels.hasgroup(sm_s, "a", 2)
+        @test SolidModels.hasgroup(sm_s, "b", 2)
+    end
+
     # Simple keyhole polygon - one square from another
     r1 = difference2d(centered(Rectangle(4μm, 4μm)), centered(Rectangle(3μm, 3μm)))
     r2 = difference2d(centered(Rectangle(2μm, 2μm)), centered(Rectangle(1μm, 1μm)))

--- a/test/test_solidmodel.jl
+++ b/test/test_solidmodel.jl
@@ -373,6 +373,24 @@
           SolidModels.fragment_geom!(sm, "test_bdy", "test_bdy", 1, 1)
     @test SolidModels.hasgroup(sm, "test_bdy", 1)
 
+    @testset "Revolve unit handling" begin
+        function revolved_bounds(name, point, axis)
+            cs_r = CoordinateSystem(name, nm)
+            place!(cs_r, Rectangle(10μm, 5μm) + Point(20μm, 10μm), SemanticMeta(:surface))
+            sm_r = SolidModel(name; overwrite=true)
+            render!(sm_r, cs_r; skip_postrender=true)
+            result = SolidModels.revolve!(sm_r["surface", 2], point..., axis..., π / 3)
+            @test count(dt -> first(dt) == 3, result) == 1
+            SolidModels._synchronize!(sm_r)
+            return SolidModels.bounds3d(filter(dt -> first(dt) == 3, result))
+        end
+
+        unitful_bounds =
+            revolved_bounds("revolve_unitful", (0.001mm, 2μm, 3000nm), (1mm, 1μm, 1nm))
+        unitless_bounds = revolved_bounds("revolve_unitless", (1, 2, 3), (1, 1e-3, 1e-6))
+        @test all(isapprox.(unitful_bounds, unitless_bounds))
+    end
+
     # The collection-accepting forms of `dimtags` and `remove_group!` return a flat dimtag vector
     @testset "Collection forms return flat dimtags" begin
         cs_c = CoordinateSystem("collections", nm)


### PR DESCRIPTION
- `addstyle!(..., ::PolyNode)` was always broken, now fixed
- `rem_node!` used a string instead of Symbol key to remove a node from the graph's node dictionary, leaking an unusable record of the deleted node
- `remove_group!` and `dimtags` SolidModel methods now give correct flat output for collection arguments
- Revolve now handles units correctly