### PR TITLE
Fix to_curvilinear Optional/Plain/Rounded style handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-j# Changelog
+# Changelog
 
 The format of this changelog is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
-# Changelog
+j# Changelog
 
 The format of this changelog is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
+
+### Fixed
+
+  - Curve recovery (`union2d_curved` and friends) preserves arcs from path nodes styled with
+    `Plain` or `OptionalStyle` (as produced by `not_simulated`/`only_simulated` and friends),
+    which previously fell back to discretization.
+  - The `Rounded` style now works on `Paths.Node` with `Straight` or `Turn` segments
 
 ## 1.18.0 (2026-08-24)
 
@@ -47,10 +54,6 @@ The format of this changelog is based on
     node list. Previously the removed node stayed reachable as `g.<id>`, and using it then
     failed obscurely — with a `MethodError` mentioning `Nothing`, or a `KeyError` whose key is
     the whole `ComponentNode` — instead of reporting that the node had been removed.
-  - Curve recovery (`union2d_curved` and friends) preserves arcs from path nodes styled with
-    `Plain` or `OptionalStyle` (as produced by `not_simulated`/`only_simulated` and friends),
-    which previously fell back to discretization.
-  - The `Rounded` style now works on `Paths.Node` with `Straight` or `Turn` segments
 
 ## 1.17.0 (2026-08-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ The format of this changelog is based on
     node list. Previously the removed node stayed reachable as `g.<id>`, and using it then
     failed obscurely — with a `MethodError` mentioning `Nothing`, or a `KeyError` whose key is
     the whole `ComponentNode` — instead of reporting that the node had been removed.
+  - Curve recovery (`union2d_curved` and friends) preserves arcs from path nodes styled with
+    `Plain` or `OptionalStyle` (as produced by `not_simulated`/`only_simulated` and friends),
+    which previously fell back to discretization.
 
 ## 1.17.0 (2026-08-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format of this changelog is based on
   - Curve recovery (`union2d_curved` and friends) preserves arcs from path nodes styled with
     `Plain` or `OptionalStyle` (as produced by `not_simulated`/`only_simulated` and friends),
     which previously fell back to discretization.
+  - The `Rounded` style now works on `Paths.Node` with `Straight` or `Turn` segments
 
 ## 1.17.0 (2026-08-10)
 

--- a/src/curvilinear.jl
+++ b/src/curvilinear.jl
@@ -1804,9 +1804,12 @@ to_curvilinear(ent::CurvilinearPolygon, sty; kwargs...) = styled_loop(ent, sty; 
 # styles pass through. Without this method a `MeshSized` path node falls to the generic
 # `to_polygons` fallback and silently discretizes its arcs. Zero-length continuous-style
 # nodes (as left around `attach!`/`launch!`) expand to nothing, matching `_normalize_curved_clip_arg`.
+# The styles are listed explicitly rather than accepting any style, because `pathtopolys`
+# ignores the style: styles that do change geometry (`Rounded`, `ToTolerance`) must keep
+# falling back to `to_polygons`, which honors them.
 function to_curvilinear(
     n::Paths.Node{T},
-    ::Union{MeshSized, WithDirection};
+    ::Union{MeshSized, WithDirection, Plain};
     kwargs...
 ) where {T}
     iszero(pathlength(n.seg)) &&
@@ -1814,6 +1817,13 @@ function to_curvilinear(
         return CurvilinearPolygon{T}[]
     return pathtopolys(n; kwargs...)
 end
+# `OptionalStyle` selects one of its two branches, either of which may be geometry-transparent,
+# so resolve the flag first rather than treating the wrapper itself as opaque.
+to_curvilinear(n::Paths.Node, sty::OptionalStyle; kwargs...) = to_curvilinear(
+    n,
+    get(kwargs, sty.flag, sty.default) ? sty.true_style : sty.false_style;
+    kwargs...
+)
 to_curvilinear(ent::ClippedPolygon, sty; kwargs...) =
     to_curvilinear(ent, StyleDict(sty); kwargs...)
 to_curvilinear(ent::CurvilinearRegion, sty; kwargs...) =

--- a/src/curvilinear.jl
+++ b/src/curvilinear.jl
@@ -1804,9 +1804,8 @@ to_curvilinear(ent::CurvilinearPolygon, sty; kwargs...) = styled_loop(ent, sty; 
 # styles pass through. Without this method a `MeshSized` path node falls to the generic
 # `to_polygons` fallback and silently discretizes its arcs. Zero-length continuous-style
 # nodes (as left around `attach!`/`launch!`) expand to nothing, matching `_normalize_curved_clip_arg`.
-# The styles are listed explicitly rather than accepting any style, because `pathtopolys`
-# ignores the style: styles that do change geometry (`Rounded`, `ToTolerance`) must keep
-# falling back to `to_polygons`, which honors them.
+# Geometry-changing styles must specialize or fall back to `to_polygons`: `Rounded` applies rounding,
+# `ToTolerance` applies tolerance control through the `to_polygons` fallback
 function to_curvilinear(
     n::Paths.Node{T},
     ::Union{MeshSized, WithDirection, Plain};
@@ -1824,6 +1823,31 @@ to_curvilinear(n::Paths.Node, sty::OptionalStyle; kwargs...) = to_curvilinear(
     get(kwargs, sty.flag, sty.default) ? sty.true_style : sty.false_style;
     kwargs...
 )
+
+function to_curvilinear(n::Paths.Node, sty::Rounded; kwargs...)
+    polys = pathtopolys(n; kwargs...)
+    resolved = _resolve_roundable_offsets(polys)
+    return to_curvilinear(resolved, sty; kwargs...)
+end
+
+_is_roundable_offset(::Paths.ConstantOffset{T, Paths.Turn{T}}) where {T} = true
+_is_roundable_offset(seg) = false
+_resolve_roundable_offset(seg::Paths.ConstantOffset{T, Paths.Turn{T}}) where {T} =
+    Paths.resolve_offset(seg)
+_resolve_roundable_offset(seg) = seg
+function _resolve_roundable_offsets(polys::Vector{<:GeometryEntity})
+    return _resolve_roundable_offsets.(polys)
+end
+_resolve_roundable_offsets(poly::Polygon) = poly
+function _resolve_roundable_offsets(poly::CurvilinearPolygon)
+    !(any(_is_roundable_offset.(poly.curves))) && return poly
+    return CurvilinearPolygon(
+        poly.p,
+        [_resolve_roundable_offset(k) for k in poly.curves],
+        poly.curve_start_idx
+    )
+end
+
 to_curvilinear(ent::ClippedPolygon, sty; kwargs...) =
     to_curvilinear(ent, StyleDict(sty); kwargs...)
 to_curvilinear(ent::CurvilinearRegion, sty; kwargs...) =

--- a/src/polygons.jl
+++ b/src/polygons.jl
@@ -174,7 +174,7 @@ copy(e::Ellipse) = Ellipse(e.center, e.radii, e.angle)
 Construct an Ellipse with major and minor radii equal to `r` at `center` (or origin if not provided).
 
 The result satisfies [`iscircle`](@ref Polygons.iscircle), so it discretizes with the constant-curvature
-fast path and participates in curve recovery (see [`recover_curves`](@ref)) as an exact
+fast path and participates in curve recovery (see [`recover_curves`](@ref DeviceLayout.Curvilinear.recover_curves)) as an exact
 four-arc representation.
 """
 Circle(center::Point{T}, r::T) where {T} = Ellipse(center, (r, r), 0.0°)

--- a/src/postrender.jl
+++ b/src/postrender.jl
@@ -21,8 +21,8 @@ For `CoordinateSystem` input, the union preserves curves already present in the 
 (arcs from paths, `Rounded` entities, circles, ...) using [`union2d_curved`](@ref), and
 corners between straight edges and arcs are rounded natively. Curve recovery is currently
 all-or-nothing: an input curve cut by the union falls back to a polyline, as described in
-[`recover_curves`](@ref). For `Cell` input, elements are already plain polygons, which are
-unioned with [`union2d`](@ref), then converted to rounded `CurvilinearRegion`s.
+[`Curvilinear.recover_curves`](@ref). For `Cell` input, elements are already plain polygons,
+which are unioned with [`union2d`](@ref), then converted to rounded `CurvilinearRegion`s.
 
 # Keyword arguments
 

--- a/test/test_curve_recovery.jl
+++ b/test/test_curve_recovery.jl
@@ -649,6 +649,20 @@ end
     pa0 = Path()
     straight!(pa0, 0μm, Paths.Trace(5μm))
     @test isempty(_normalize_curved_clip_arg(MeshSized(1μm)(pa0[1])))
+
+    # `Plain` and `OptionalStyle` are geometry-transparent too. `not_simulated` resolves to
+    # `Plain` by default, so a curved path node marked not-simulated must keep its arcs.
+    not_simulated = DeviceLayout.SchematicDrivenLayout.not_simulated
+    for node in (DeviceLayout.Plain()(pa[1]), not_simulated(pa[1]))
+        node_out = union2d_curved(node)
+        @test length(node_out) == 1
+        @test length(node_out[1].exterior.curves) == 2
+        @test isempty(to_polygons(xor2d(node_out, pathtopolys(pa))))
+    end
+    # The flag selects the branch: with `simulation=true`, not_simulated renders nothing.
+    ns = not_simulated(pa[1])
+    @test isempty(to_curvilinear(ns.ent, ns.sty; simulation=true))
+    @test length(to_curvilinear(ns.ent, ns.sty; simulation=false).curves) == 2
 end
 
 @testitem "Curve recovery — warn once on silent curve loss" setup = [CommonTestSetup] begin

--- a/test/test_curve_recovery.jl
+++ b/test/test_curve_recovery.jl
@@ -679,8 +679,8 @@ end
 
     # No effect on BSplines or variable width Turn
     pa2 = Path()
-    bspline!(pa2, [Point(1mm, 1mm)], 0°, Paths.Trace(2μm))
-    @test to_polygons(to_curvilinear(pa2[1], Rounded(1μm))) == to_polygons(pa2[1])
+    bspline!(pa2, [Point(1mm, 1mm)], 0°, Paths.CPW(2μm, 2μm))
+    @test to_polygons.(to_curvilinear(pa2[1], Rounded(1μm))) == to_polygons(pa2[1])
 
     pa3 = Path()
     turn!(pa3, 90°, 50μm, Paths.TaperTrace(5μm, 6μm))

--- a/test/test_curve_recovery.jl
+++ b/test/test_curve_recovery.jl
@@ -664,14 +664,18 @@ end
     @test isempty(to_curvilinear(ns.ent, ns.sty; simulation=true))
     @test length(to_curvilinear(ns.ent, ns.sty; simulation=false).curves) == 2
 
+    # Rounding
     rounded_node = to_curvilinear(pa[1], Rounded(2μm))
     @test length(rounded_node.curves) == 6
 
     # Works for Straight
     pa1 = Path()
-    straight!(pa1, 2μm, Paths.Trace(2μm))
-    @test Polygons.area(to_polygons(to_curvilinear(pa1[1], Rounded(1μm)))) ≈ pi * (1μm)^2 atol =
-        (2pi * 1μm * 1nm)
+    straight!(pa1, 2μm, Paths.CPW(2μm, 2μm))
+    @test sum(Polygons.area.(to_polygons.(to_curvilinear(pa1[1], Rounded(1μm))))) ≈
+          2 * pi * (1μm)^2 atol = (2 * 2pi * 1μm * 1nm)
+    opt_rnd = OptionalStyle(Rounded(1μm), :test)
+    @test sum(Polygons.area.(to_polygons.(to_curvilinear(pa1[1], opt_rnd)))) ≈
+          2 * pi * (1μm)^2 atol = (2 * 2pi * 1μm * 1nm)
 
     # No effect on BSplines or variable width Turn
     pa2 = Path()

--- a/test/test_curve_recovery.jl
+++ b/test/test_curve_recovery.jl
@@ -663,6 +663,24 @@ end
     ns = not_simulated(pa[1])
     @test isempty(to_curvilinear(ns.ent, ns.sty; simulation=true))
     @test length(to_curvilinear(ns.ent, ns.sty; simulation=false).curves) == 2
+
+    rounded_node = to_curvilinear(pa[1], Rounded(2μm))
+    @test length(rounded_node.curves) == 6
+
+    # Works for Straight
+    pa1 = Path()
+    straight!(pa1, 2μm, Paths.Trace(2μm))
+    @test Polygons.area(to_polygons(to_curvilinear(pa1[1], Rounded(1μm)))) ≈ pi * (1μm)^2 atol =
+        (2pi * 1μm * 1nm)
+
+    # No effect on BSplines or variable width Turn
+    pa2 = Path()
+    bspline!(pa2, [Point(1mm, 1mm)], 0°, Paths.Trace(2μm))
+    @test to_polygons(to_curvilinear(pa2[1], Rounded(1μm))) == to_polygons(pa2[1])
+
+    pa3 = Path()
+    turn!(pa3, 90°, 50μm, Paths.TaperTrace(5μm, 6μm))
+    @test to_polygons(to_curvilinear(pa3[1], Rounded(1μm))) == to_polygons(pa3[1])
 end
 
 @testitem "Curve recovery — warn once on silent curve loss" setup = [CommonTestSetup] begin


### PR DESCRIPTION
Previously these all fell back to being discretized. Optional should resolve to its style based on its flag, Plain should just pass through, and Rounded should attempt rounding. Rounding requires that ConstantOffset Turns be resolved to Turns so that the rounding engine can handle them.