### PR TITLE
Fix path rounding composition/edge cases

### DIFF
--- a/src/curvilinear.jl
+++ b/src/curvilinear.jl
@@ -1113,15 +1113,15 @@ function to_polygons(
     kwargs...
 ) where {S, T}
     iszero(Polygons.radius(sty)) && return to_polygons(ent; atol=atol, rtol=rtol, kwargs...)
-
+    resolved = _resolve_roundable_offsets(ent)
     # Reuse Rounded's corner selection and radius semantics, but keep fillets symbolic until
     # the CurvilinearPolygon discretizer runs.
     rounded = round_to_curvilinearpolygon(
-        ent,
+        resolved,
         Polygons.radius(sty);
-        corner_indices=cornerindices(ent, sty),
-        line_arc_corner_indices=line_arc_cornerindices(ent, sty),
-        arc_arc_corner_indices=arc_arc_cornerindices(ent, sty),
+        corner_indices=cornerindices(resolved, sty),
+        line_arc_corner_indices=line_arc_cornerindices(resolved, sty),
+        arc_arc_corner_indices=arc_arc_cornerindices(resolved, sty),
         min_angle=sty.min_angle,
         min_side_len=sty.min_side_len
     )
@@ -1824,6 +1824,11 @@ to_curvilinear(n::Paths.Node, sty::OptionalStyle; kwargs...) = to_curvilinear(
     get(kwargs, sty.flag, sty.default) ? sty.true_style : sty.false_style;
     kwargs...
 )
+to_curvilinear(ent::StyledEntity, sty::OptionalStyle; kwargs...) = to_curvilinear(
+    ent,
+    get(kwargs, sty.flag, sty.default) ? sty.true_style : sty.false_style;
+    kwargs...
+)
 
 # If rounding, inner boundaries need to be healed (compound or full-turn Paths.Node and styled Paths.Node)
 # Healing is unnecessary for CPW/Strands or styled multi-polygon ClippedPolygon, but we pay the tax
@@ -1863,7 +1868,7 @@ function _resolve_roundable_offsets(poly::CurvilinearPolygon)
 end
 function _resolve_roundable_offsets(reg::CurvilinearRegion)
     return CurvilinearRegion(
-        _resolve_roundable_offsets(reg.ext),
+        _resolve_roundable_offsets(reg.exterior),
         _resolve_roundable_offsets.(reg.holes)
     )
 end

--- a/src/curvilinear.jl
+++ b/src/curvilinear.jl
@@ -294,7 +294,7 @@ function to_polygons(e::CurvilinearRegion{T}; kwargs...) where {T}
     isempty(holes) && return [to_polygons(e.exterior; kwargs...)]
     return to_polygons(
         union2d(vcat(to_polygons(e.exterior; kwargs...), _hole_polygon.(holes; kwargs...)))
-    )
+    ) # Single element for a valid CurvilinearRegion; returns a vector for backwards compatibility
 end
 
 # Discretize a hole through its reversed (counterclockwise) traversal, then flip the point
@@ -1748,13 +1748,14 @@ function styled_loop(p::GeometryEntity, sty::OptionalStyle; kwargs...)
     )
 end
 function styled_loop(p::GeometryEntity, sty::Rounded; kwargs...)
+    resolved = _resolve_roundable_offsets(p) # Rounding needs Turn, not ConstantOffset{T, Turn{T}}
     return round_to_curvilinearpolygon(
-        p,
+        resolved,
         radius(sty),
         min_side_len=sty.min_side_len,
-        corner_indices=cornerindices(p, sty),
-        line_arc_corner_indices=line_arc_cornerindices(p, sty),
-        arc_arc_corner_indices=arc_arc_cornerindices(p, sty),
+        corner_indices=cornerindices(resolved, sty),
+        line_arc_corner_indices=line_arc_cornerindices(resolved, sty),
+        arc_arc_corner_indices=arc_arc_cornerindices(resolved, sty),
         min_angle=sty.min_angle
     )
 end
@@ -1824,10 +1825,26 @@ to_curvilinear(n::Paths.Node, sty::OptionalStyle; kwargs...) = to_curvilinear(
     kwargs...
 )
 
-function to_curvilinear(n::Paths.Node, sty::Rounded; kwargs...)
-    polys = pathtopolys(n; kwargs...)
-    resolved = _resolve_roundable_offsets(polys)
-    return to_curvilinear(resolved, sty; kwargs...)
+# If rounding, inner boundaries need to be healed (compound or full-turn Paths.Node and styled Paths.Node)
+# Healing is unnecessary for CPW/Strands or styled multi-polygon ClippedPolygon, but we pay the tax
+to_curvilinear(ent::StyledEntity; kwargs...) = to_curvilinear(ent.ent, ent.sty; kwargs...)
+to_curvilinear(ent::Paths.Node; kwargs...) = pathtopolys(ent; kwargs...)
+function to_curvilinear(ent::Paths.Node, sty::Rounded; kwargs...)
+    inner = to_curvilinear(ent; kwargs...)
+    if inner isa AbstractVector
+        regions = union2d_curved(inner)
+        return to_curvilinear.(regions, Ref(sty); kwargs...)
+    end
+    return to_curvilinear(inner, sty; kwargs...)
+end
+# Identical to Paths.Node method, define separately to avoid ambiguity
+function to_curvilinear(ent::StyledEntity, sty::Rounded; kwargs...)
+    inner = to_curvilinear(ent; kwargs...)
+    if inner isa AbstractVector
+        regions = union2d_curved(inner)
+        return to_curvilinear.(regions, Ref(sty); kwargs...)
+    end
+    return to_curvilinear(inner, sty; kwargs...)
 end
 
 _is_roundable_offset(::Paths.ConstantOffset{T, Paths.Turn{T}}) where {T} = true
@@ -1835,16 +1852,19 @@ _is_roundable_offset(seg) = false
 _resolve_roundable_offset(seg::Paths.ConstantOffset{T, Paths.Turn{T}}) where {T} =
     Paths.resolve_offset(seg)
 _resolve_roundable_offset(seg) = seg
-function _resolve_roundable_offsets(polys::Vector{<:GeometryEntity})
-    return _resolve_roundable_offsets.(polys)
-end
-_resolve_roundable_offsets(poly::Polygon) = poly
+_resolve_roundable_offsets(ent::GeometryEntity) = ent
 function _resolve_roundable_offsets(poly::CurvilinearPolygon)
     !(any(_is_roundable_offset.(poly.curves))) && return poly
     return CurvilinearPolygon(
         poly.p,
         [_resolve_roundable_offset(k) for k in poly.curves],
         poly.curve_start_idx
+    )
+end
+function _resolve_roundable_offsets(reg::CurvilinearRegion)
+    return CurvilinearRegion(
+        _resolve_roundable_offsets(reg.ext),
+        _resolve_roundable_offsets.(reg.holes)
     )
 end
 
@@ -1913,12 +1933,15 @@ end
 # style resolves to a plain Polygon (losing arc info), so the outer Rounded could only do
 # line-line rounding. Routing the inner styles through `to_curvilinear` yields exact fillet
 # arcs, so the outer Rounded can apply line-arc rounding via to_polygons(_, ::Rounded).
-function to_polygons(ent::StyledEntity, sty::Rounded; kwargs...)
-    inner = to_curvilinear(ent.ent, ent.sty; kwargs...)
+function to_polygons(ent::Union{StyledEntity, Paths.Node}, sty::Rounded; kwargs...)
+    inner = to_curvilinear(ent; kwargs...)
     if inner isa AbstractVector
-        return vcat(to_polygons.(inner, Ref(sty); kwargs...)...)
+        regions = union2d_curved(inner) # Heal internal boundaries
+        rounded_regions = to_curvilinear.(regions, Ref(sty); kwargs...)
+        return only.(to_polygons.(rounded_regions; kwargs...)) # to_polygons(region) is a one-element Vector
     end
-    return to_polygons(sty(inner); kwargs...)
+    rounded_inner = to_curvilinear(inner, sty; kwargs...)
+    return to_polygons(rounded_inner; kwargs...)
 end
 
 include("curve_recovery.jl")

--- a/test/test_curve_recovery.jl
+++ b/test/test_curve_recovery.jl
@@ -667,24 +667,51 @@ end
     # Rounding
     rounded_node = to_curvilinear(pa[1], Rounded(2μm))
     @test length(rounded_node.curves) == 6
+    # Works via `to_polygons`
+    rounded_poly = to_polygons(Rounded(2μm)(pa[1]))
+    @test rounded_poly == to_polygons(rounded_node)
+    nested_rounded_poly = to_polygons(Rounded(2μm)(DeviceLayout.Plain()(pa[1])))
+    @test nested_rounded_poly == rounded_poly
+    nested_rounded_node = to_curvilinear(Rounded(2μm)(DeviceLayout.Plain()(pa[1])))
+    @test to_polygons(nested_rounded_node) == rounded_poly
 
     # Works for Straight
     pa1 = Path()
     straight!(pa1, 2μm, Paths.CPW(2μm, 2μm))
-    @test sum(Polygons.area.(to_polygons.(to_curvilinear(pa1[1], Rounded(1μm))))) ≈
+    @test sum(Polygons.area.(only.(to_polygons.(to_curvilinear(pa1[1], Rounded(1μm)))))) ≈
           2 * pi * (1μm)^2 atol = (2 * 2pi * 1μm * 1nm)
     opt_rnd = OptionalStyle(Rounded(1μm), :test)
-    @test sum(Polygons.area.(to_polygons.(to_curvilinear(pa1[1], opt_rnd)))) ≈
+    @test sum(Polygons.area.(only.(to_polygons.(to_curvilinear(pa1[1], opt_rnd))))) ≈
           2 * pi * (1μm)^2 atol = (2 * 2pi * 1μm * 1nm)
 
     # No effect on BSplines or variable width Turn
     pa2 = Path()
     bspline!(pa2, [Point(1mm, 1mm)], 0°, Paths.CPW(2μm, 2μm))
-    @test to_polygons.(to_curvilinear(pa2[1], Rounded(1μm))) == to_polygons(pa2[1])
+    @test isempty(
+        to_polygons(xor2d(to_curvilinear(pa2[1], Rounded(1μm)), to_polygons(pa2[1])))
+    )
 
     pa3 = Path()
     turn!(pa3, 90°, 50μm, Paths.TaperTrace(5μm, 6μm))
     @test to_polygons(to_curvilinear(pa3[1], Rounded(1μm))) == to_polygons(pa3[1])
+
+    # Multi-segment resolution
+    ## Split full turn
+    pa4 = Path()
+    turn!(pa4, 360°, 50μm, Paths.Trace(5μm))
+    rounded_node_polys = to_polygons.(to_curvilinear(pa4[1], Rounded(1μm)))[1]
+    node_polys = to_polygons(pa4[1])
+    @test isempty(to_polygons(xor2d(rounded_node_polys, node_polys)))
+    ## Compound segment
+    pa5 = Path()
+    turn!(pa5, 90°, 50μm, Paths.CPW(5μm, 5μm))
+    turn!(pa5, 90°, 50μm)
+    simplify!(pa5)
+    pa6 = Path()
+    turn!(pa6, 180°, 50μm, Paths.CPW(5μm, 5μm))
+    compound_node_polys = vcat(to_polygons.(to_curvilinear(pa5[1], Rounded(2μm)))...)
+    single_node_polys = vcat(to_polygons.(to_curvilinear(pa6[1], Rounded(2μm)))...)
+    @test all(is_sliver.(to_polygons(xor2d(compound_node_polys, single_node_polys))))
 end
 
 @testitem "Curve recovery — warn once on silent curve loss" setup = [CommonTestSetup] begin

--- a/test/test_curve_recovery.jl
+++ b/test/test_curve_recovery.jl
@@ -674,6 +674,10 @@ end
     @test nested_rounded_poly == rounded_poly
     nested_rounded_node = to_curvilinear(Rounded(2μm)(DeviceLayout.Plain()(pa[1])))
     @test to_polygons(nested_rounded_node) == rounded_poly
+    nested_optional_node =
+        to_curvilinear(OptionalStyle(Rounded(2μm), :rounding)(DeviceLayout.Plain()(pa[1])))
+    @test to_polygons(nested_optional_node) == rounded_poly
+    @test to_polygons(pathtopolys(pa[1]), Rounded(2μm)) == rounded_poly
 
     # Works for Straight
     pa1 = Path()


### PR DESCRIPTION
Some overlooked cases from #286:

1. Compound nodes or split full turns become multiple entities with internal boundaries, which are rounded incorrectly
2. Nested styles with outer rounding on a path node did not resolve ConstantOffset Turns to regular Turns
3. With `to_polygons` line-arc rounding on a Paths.Turn would fail (giving different geometry in Cell and SolidModel)

The "bridge" `to_polygons` method now includes `Paths.Node`, and roundable offsets are resolved in `styled_loop`, solving 2 and 3. To solve 1 I take the `union2d_curved` of vector results when rounding a Paths.Node or a StyledEntity (in case they have a problematic Paths.Node). This is slightly wasteful when rounding CPWs, Strands, or styled multi-polygon ClippedPolygons, could be avoided by looking closer at the nested types + path segments/styles but not sure the complexity is worth it. (Note rounding individual Paths should ordinarily be done with `terminate!` -- this is more relevant for global rounding passes.)

Some general thoughts -- overall I think this indicates some remaining deficiencies in our rendering dispatch architecture. I suspect #101 can solve many of them. Other recurring pain points include (a) to_curvilinear can return a CurvilinearPolygon and CurvilinearRegion, or a collection of either (b) to_polygons can return one polygon or a collection of polygons (c) if a GeometryEntity does resolve to multiple entities, we don't have any guarantees about them being disjoint or not. These are trait shaped, we already mostly decide to_polygons/to_curvilinear return types by input type. Composite styles do require branching on value, OptionalStyles already do, not sure I see a way around that. We care about single/multi-region, disjoint/contiguous regions, simple/hole-bearing [I think we just assume self-intersections away], curved/not curved. A little different from GeoInterface concerns.

Or maybe this is an API issue, and in v2 we just have to_curvilinear/to_polygons always return a Vector{CurvilinearRegion{T}} or Vector{<:Polygon{T}} (creating a lot of unnecessary vectors for the sake of better type stability?), and have the contract say that all entities in the vector are disjoint. I just feel there has to be a better, more standard pattern for accumulating maybe-collections than `reduce(vcat, ...)`...