### PR TITLE
Fix KeyError in _collect_mesh_control_points! for groups with no samples

### DIFF
--- a/src/solidmodels/render.jl
+++ b/src/solidmodels/render.jl
@@ -636,7 +636,12 @@ function _collect_mesh_control_points!(
         first_new = record_points ? length(get(mesh_control_points(), key, ())) + 1 : 1
         _sample_meshsize!(prims, h_float, α_float, Float64(z))
         if record_points
-            for point in (@view mesh_control_points()[key][first_new:end])
+            # `_sample_meshsize!` only creates `mesh_control_points()[key]` if it
+            # actually emitted a sample; primitives that produce none
+            # (e.g. sub-3-vertex loops) leave the key absent. Fall back to an
+            # empty view so recording is a no-op then.
+            new_points = get(mesh_control_points(), key, SVector{3, Float64}[])
+            for point in (@view new_points[first_new:end])
                 record = (point[1], point[2], point[3], h_float, α_float)
                 !isnothing(mesh_seen) && push!(mesh_seen, record)
                 !isnothing(mesh_points) && push!(mesh_points, record)

--- a/test/test_size_fields.jl
+++ b/test/test_size_fields.jl
@@ -35,6 +35,26 @@
     )
     @test isempty(SolidModels.mesh_control_points())
 
+    # Regression: when a positive-`h` group's primitives emit NO samples (e.g. a
+    # sub-3-vertex polygon), the `(h, α)` bucket is never created. Recording
+    # (`mesh_seen`/`mesh_points` non-nothing) must not index a missing key — it
+    # previously threw `KeyError((h, α))`. This is the recording path
+    # `_render_orchestrator!` uses, so it must be a safe no-op here.
+    SolidModels.clear_mesh_control_points!()
+    seen = Set{NTuple{5, Float64}}()
+    collected = Set{NTuple{5, Float64}}()
+    SolidModels._collect_mesh_control_points!(
+        [Polygon([Point(0μm, 0μm), Point(1μm, 0μm)])],  # 2 vertices → no samples
+        75.0,
+        -1.0,
+        0.0;
+        curvature_sizing=false,
+        mesh_seen=seen,
+        mesh_points=collected
+    )
+    @test isempty(collected)
+    @test isempty(seen)
+
     circle_cs = CoordinateSystem("circle_size_fields", nm)
     render!(circle_cs, Circle(Point(3μm, 4μm), 2μm), SemanticMeta(:circle))
     render!(circle_cs, Circle(Point(3μm, 4μm), 2μm), SemanticMeta(:circle_copy))


### PR DESCRIPTION
## Summary

`_collect_mesh_control_points!` — shared by all `SolidModel` rendering (both
stock `render!` and the conformal path) — throws `KeyError((h, α))` when a
positive-`h` group's primitives produce **no** mesh control samples. This
happens for legitimate inputs:

- a sub-3-vertex loop (a degenerate/collapsed polygon), or
- a group where every edge is shorter than the sampling length.

`_sample_meshsize!` only creates the `mesh_control_points()[key]` bucket when
it actually emits a sample, but the recording branch indexed that key
directly, so an empty group crashed the render.

## Fix

Fall back to an empty view via `get(mesh_control_points(), key, SVector{3,Float64}[])`
so recording is a no-op when no points were produced.

## Test

Regression test at the `_collect_mesh_control_points!` level (in
`test/test_size_fields.jl`): a 2-vertex polygon under a positive `h` with
recording enabled — threw `KeyError((75.0, -1.0))` before, passes now.
