### PR TITLE
ConformalRender: add mutual_node! (all-pairs symmetric noding)

### DIFF
--- a/src/solidmodels/conformal/conformal.jl
+++ b/src/solidmodels/conformal/conformal.jl
@@ -78,6 +78,10 @@ import SpatialIndexing
 import SpatialIndexing: RTree
 
 export render_conformal!, ConformalRenderContext, add_conformal_loop!
+export mutual_node!
+
+# Geometry preprocessing that makes adjacent groups conformal before render.
+include("noding.jl")
 
 """
 Entry in `endpoint_curve_index`: the signed OCC tag of the curve, plus a

--- a/src/solidmodels/conformal/noding.jl
+++ b/src/solidmodels/conformal/noding.jl
@@ -1,0 +1,346 @@
+# All-pairs symmetric noding for [`render_conformal!`](@ref).
+#
+# After boolean operations hand back a `Dict{Symbol, Vector{CurvilinearRegion}}`
+# (one entry per physical group), adjacent groups that share a boundary must
+# carry the *same* vertex sequence along it for the shared-edge cache in
+# `render_conformal!` to resolve the boundary to a single OCC curve entity on
+# both sides. Clipper does not guarantee this: two independent booleans can put
+# a vertex at a location on one side of a shared edge but not the other, leaving
+# a T-junction the mesher rejects ("vertex lies in segment").
+#
+# `mutual_node!` fixes this for every group at once. It builds a single spatial
+# hash of every group's vertices, then injects, into each group's edges, every
+# vertex owned by a *different* group that lies on the edge interior. The result
+# is symmetric by construction — if group A has a vertex on group B's edge, B
+# gets it injected, and vice versa — so both sides of every shared boundary end
+# up with the identical ordered vertex sequence.
+#
+# Straight edges get the foreign vertex inserted verbatim (bit-exact — the
+# render-time point merge unifies the two copies into one OCC point). Curved
+# edges (`Paths.Turn`, `Paths.BSpline`, …) are split at the foreign vertex's
+# arclength via `Paths.split`, so curves stay native and exact — never
+# discretized.
+
+# Integer-nm key for a vertex (Clipper emits on an integer grid, so exact
+# coincidences hash exactly; near-coincidences are caught by the tolerance
+# checks downstream). Coordinates are converted to nm so the key, the cell
+# size, and `node_tol` are all in the same unit regardless of the input's unit.
+_vertex_key(p) = (
+    round(Int, Float64(ustrip(u"nm", getx(p)))),
+    round(Int, Float64(ustrip(u"nm", gety(p))))
+)
+
+# Spatial-hash cell size (nm). Larger than any node tolerance, far smaller than
+# feature size, so a candidate for edge (x1,y1)→(x2,y2) is always found within
+# the edge's bounding-box cell range.
+const _NODE_CELL = 100.0
+
+# Build the global vertex index across every group:
+#   owners : nm-key → Set of group names owning a vertex there
+#   point  : nm-key → a representative original `Point` (reused bit-exact, so an
+#            injected vertex is identical to the partner's copy and the render
+#            cache merges them into one OCC point)
+#   cells  : (cx, cy) → Vector of nm-keys in that cell
+function _build_vertex_index(groups)
+    owners = Dict{Tuple{Int, Int}, Set{Symbol}}()
+    point = Dict{Tuple{Int, Int}, Any}()
+    cells = Dict{Tuple{Int, Int}, Vector{Tuple{Int, Int}}}()
+    index_cpoly! = function (cpoly, name)
+        for p in points(cpoly)
+            key = _vertex_key(p)
+            g = get!(Set{Symbol}, owners, key)
+            if isempty(g)
+                point[key] = p
+                cx = floor(Int, key[1] / _NODE_CELL)
+                cy = floor(Int, key[2] / _NODE_CELL)
+                push!(get!(Vector{Tuple{Int, Int}}, cells, (cx, cy)), key)
+            end
+            push!(g, name)
+        end
+    end
+    for (name, regions) in groups
+        for region in regions
+            index_cpoly!(region.exterior, name)
+            for hole in region.holes
+                index_cpoly!(hole, name)
+            end
+        end
+    end
+    return owners, point, cells
+end
+
+# Foreign on-edge vertices for a straight edge p1→p2, as `(t, Point)` sorted by
+# parameter, excluding this group's own vertices and the edge endpoints.
+function _foreign_points_on_edge(
+    p1::Point{T},
+    p2::Point{T},
+    group::Symbol,
+    owners,
+    point,
+    cells,
+    node_tol::Float64
+) where {T}
+    x1 = Float64(ustrip(u"nm", getx(p1)))
+    y1 = Float64(ustrip(u"nm", gety(p1)))
+    x2 = Float64(ustrip(u"nm", getx(p2)))
+    y2 = Float64(ustrip(u"nm", gety(p2)))
+    dx = x2 - x1
+    dy = y2 - y1
+    len_sq = dx * dx + dy * dy
+    len_sq <= (2 * node_tol)^2 && return Tuple{Float64, Point{T}}[]
+    len = sqrt(len_sq)
+    end_t = node_tol / len
+    xmin = min(x1, x2) - node_tol
+    xmax = max(x1, x2) + node_tol
+    ymin = min(y1, y2) - node_tol
+    ymax = max(y1, y2) + node_tol
+    cx0 = floor(Int, xmin / _NODE_CELL)
+    cx1 = floor(Int, xmax / _NODE_CELL)
+    cy0 = floor(Int, ymin / _NODE_CELL)
+    cy1 = floor(Int, ymax / _NODE_CELL)
+    found = Tuple{Float64, Point{T}}[]
+    for cx = cx0:cx1, cy = cy0:cy1
+        keys = get(cells, (cx, cy), nothing)
+        keys === nothing && continue
+        for key in keys
+            os = owners[key]
+            (length(os) == 1 && group in os) && continue  # only this group owns it
+            px = Float64(key[1])
+            py = Float64(key[2])
+            t = ((px - x1) * dx + (py - y1) * dy) / len_sq
+            (t <= end_t || t >= 1.0 - end_t) && continue
+            perp = abs((px - x1) * dy - (py - y1) * dx) / len
+            perp > node_tol && continue
+            push!(found, (t, point[key]))
+        end
+    end
+    sort!(found; by=first)
+    # Drop candidates closer than node_tol *along* the edge to the previous
+    # kept one — two near-coincident foreign vertices would otherwise inject a
+    # sub-tolerance-length edge that the render-time point merge then collapses
+    # to a degenerate (zero-length) edge.
+    isempty(found) && return found
+    min_dt = node_tol / len
+    kept = Tuple{Float64, Point{T}}[found[1]]
+    for k = 2:length(found)
+        found[k][1] - kept[end][1] < min_dt && continue
+        push!(kept, found[k])
+    end
+    return kept
+end
+
+# Foreign on-curve vertices for a curved edge, as `Point`s sorted by arclength.
+# A candidate qualifies when `pathlength_nearest` projects it strictly interior
+# (> node_tol from either end) with residual ≤ node_tol. The curve's discretized
+# bounding box supplies candidate cells; the curve itself is never replaced.
+function _foreign_points_on_curve(
+    curve,
+    group::Symbol,
+    owners,
+    point,
+    cells,
+    node_tol::Float64
+)
+    T = coordinatetype(Paths.p0(curve))
+    atol = onenanometer(T)
+    disc = DeviceLayout.discretize_curve(curve, atol; rtol=nothing)
+    isempty(disc) && return Point{T}[]
+    L_nm = Float64(ustrip(u"nm", pathlength(curve)))
+    # The polyline approximates the curve to within `atol` (1 nm), so widen the
+    # perpendicular tolerance by that slop to avoid rejecting a candidate that
+    # is within node_tol of the true curve but slightly further from the chord.
+    atol_nm = 1.0
+    perp_tol = node_tol + atol_nm
+    tol2 = perp_tol * perp_tol
+    seen = Set{Tuple{Int, Int}}()
+    found = Tuple{Float64, Point{T}}[]
+    nd = length(disc)
+    for j = 1:(nd - 1)
+        ax = Float64(ustrip(u"nm", getx(disc[j])))
+        ay = Float64(ustrip(u"nm", gety(disc[j])))
+        bx = Float64(ustrip(u"nm", getx(disc[j + 1])))
+        by = Float64(ustrip(u"nm", gety(disc[j + 1])))
+        sxmin = min(ax, bx) - perp_tol
+        sxmax = max(ax, bx) + perp_tol
+        symin = min(ay, by) - perp_tol
+        symax = max(ay, by) + perp_tol
+        cx0 = floor(Int, sxmin / _NODE_CELL)
+        cx1 = floor(Int, sxmax / _NODE_CELL)
+        cy0 = floor(Int, symin / _NODE_CELL)
+        cy1 = floor(Int, symax / _NODE_CELL)
+        vx = bx - ax
+        vy = by - ay
+        seg_len2 = vx * vx + vy * vy
+        for cx = cx0:cx1, cy = cy0:cy1
+            keys = get(cells, (cx, cy), nothing)
+            keys === nothing && continue
+            for key in keys
+                key in seen && continue
+                os = owners[key]
+                (length(os) == 1 && group in os) && continue
+                px = Float64(key[1])
+                py = Float64(key[2])
+                # Cheap perpendicular-distance-to-segment pre-filter. Don't mark
+                # `seen` on a miss — a later segment sharing this cell may still
+                # be within tolerance of the same candidate. `seg_len2 > 0` here:
+                # `discretize_curve` never emits coincident consecutive points.
+                t = ((px - ax) * vx + (py - ay) * vy) / seg_len2
+                t = clamp(t, 0.0, 1.0)
+                qx = ax + t * vx
+                qy = ay + t * vy
+                d2 = (px - qx)^2 + (py - qy)^2
+                d2 > tol2 && continue
+                push!(seen, key)
+                V = point[key]
+                s = Paths.pathlength_nearest(curve, V)
+                s_nm = Float64(ustrip(u"nm", s))
+                (s_nm <= node_tol || s_nm >= L_nm - node_tol) && continue
+                cs_pt = curve(s)
+                resid = sqrt(
+                    Float64(ustrip(u"nm", getx(cs_pt) - getx(V)))^2 +
+                    Float64(ustrip(u"nm", gety(cs_pt) - gety(V)))^2
+                )
+                resid > node_tol && continue
+                push!(found, (s_nm, V))
+            end
+        end
+    end
+    isempty(found) && return Point{T}[]
+    sort!(found; by=first)
+    out = Point{T}[]
+    prev_s = -Inf
+    for (s_nm, V) in found
+        s_nm - prev_s < node_tol && continue  # de-dup co-located along the curve
+        push!(out, V)
+        prev_s = s_nm
+    end
+    return out
+end
+
+# Node one contour against the global vertex index. Straight edges get foreign
+# vertices inserted verbatim; curved edges are split at the foreign arclength
+# via `Paths.split` (staying native/exact). Returns (new_cpoly, n_injected).
+function _node_contour!(
+    cpoly::CurvilinearPolygon{T},
+    group::Symbol,
+    owners,
+    point,
+    cells,
+    node_tol::Float64
+) where {T}
+    pts = points(cpoly)
+    n = length(pts)
+    n < 3 && return cpoly, 0
+    curve_at = Dict{Int, Any}()
+    for (ci, csi) in enumerate(cpoly.curve_start_idx)
+        curve_at[csi] = cpoly.curves[ci]
+    end
+    new_points = Point{T}[]
+    new_curves = typeof(cpoly.curves)()
+    new_csis = Int[]
+    n_injected = 0
+    for i = 1:n
+        push!(new_points, pts[i])
+        start_idx = length(new_points)
+        if haskey(curve_at, i)
+            curve = curve_at[i]
+            splits = _foreign_points_on_curve(curve, group, owners, point, cells, node_tol)
+            if isempty(splits)
+                push!(new_curves, curve)
+                push!(new_csis, start_idx)
+            else
+                remaining = curve
+                acc_idx = start_idx
+                for V in splits
+                    l = pathlength(remaining)
+                    s = Paths.pathlength_nearest(remaining, V)
+                    s_nm = Float64(ustrip(u"nm", s))
+                    l_nm = Float64(ustrip(u"nm", l))
+                    (s_nm <= node_tol || s_nm >= l_nm - node_tol) && continue
+                    s1, s2 = Paths.split(remaining, s)
+                    push!(new_curves, s1)
+                    push!(new_csis, acc_idx)
+                    push!(new_points, V)  # bit-exact foreign Point
+                    acc_idx = length(new_points)
+                    remaining = s2
+                    n_injected += 1
+                end
+                push!(new_curves, remaining)
+                push!(new_csis, acc_idx)
+            end
+        else
+            p2 = pts[mod1(i + 1, n)]
+            for (_, V) in
+                _foreign_points_on_edge(pts[i], p2, group, owners, point, cells, node_tol)
+                push!(new_points, V)
+                n_injected += 1
+            end
+        end
+    end
+    n_injected == 0 && return cpoly, 0
+    if !isempty(new_csis)
+        perm = sortperm(new_csis)
+        new_curves = new_curves[perm]
+        new_csis = new_csis[perm]
+    end
+    return CurvilinearPolygon{T}(new_points, new_curves, new_csis), n_injected
+end
+
+"""
+    mutual_node!(groups::AbstractDict{Symbol, <:AbstractVector}; node_tol=2.0) -> Int
+
+Symmetric all-pairs noding across a collection of named region groups. For every
+edge of every group, inject the vertices owned by *other* groups that lie on the
+edge interior (perpendicular distance ≤ `node_tol` nm, strictly between the
+endpoints). Straight edges get the foreign vertex inserted verbatim; curved
+edges (`Paths.Turn`, `Paths.BSpline`, …) are split at the foreign vertex's
+arclength via [`Paths.split`](@ref), so curves stay native and exact. Modifies
+each group's regions in place and returns the total number of vertices injected.
+
+Makes adjacent groups conformal for [`render_conformal!`](@ref): both sides of
+every shared boundary end up with the identical ordered vertex sequence, which
+is what the shared-edge cache needs to resolve a boundary to one OCC curve on
+both sides. Every group is noded against every other in a single pass over a
+shared spatial index — the caller does not need to know the adjacency graph.
+
+`node_tol` (nm) must be ≥ the maximum coordinate drift between two groups'
+copies of the same logical vertex and ≪ the minimum feature size. The default
+2 nm covers the ≤ ~1.5 nm drift `discretize_curve` can introduce and is far
+below any real feature, so it never bridges two genuinely distinct vertices.
+Coordinates are interpreted in nm regardless of the input Points' unit, so the
+tolerance means the same physical distance whether the geometry is expressed in
+nm or µm.
+
+```julia
+groups = Dict(:metal => metal_regions, :ground => gnd_regions, :ports => port_regions)
+mutual_node!(groups)
+for (name, regions) in groups
+    add_conformal_loop!.(Ref(ctx), regions, k, z; points_cache)
+end
+```
+"""
+function mutual_node!(groups::AbstractDict{Symbol, <:AbstractVector}; node_tol::Float64=2.0)
+    owners, point, cells = _build_vertex_index(groups)
+    isempty(cells) && return 0
+    total = 0
+    for (name, regions) in groups
+        isempty(regions) && continue
+        T = coordinatetype(regions[1])
+        for (ri, region) in enumerate(regions)
+            new_ext, n_ext =
+                _node_contour!(region.exterior, name, owners, point, cells, node_tol)
+            new_holes = CurvilinearPolygon{T}[]
+            n_holes = 0
+            for hole in region.holes
+                h_new, n_h = _node_contour!(hole, name, owners, point, cells, node_tol)
+                push!(new_holes, h_new)
+                n_holes += n_h
+            end
+            if n_ext + n_holes > 0
+                regions[ri] = CurvilinearRegion{T}(new_ext, new_holes)
+                total += n_ext + n_holes
+            end
+        end
+    end
+    return total
+end

--- a/src/solidmodels/solidmodels.jl
+++ b/src/solidmodels/solidmodels.jl
@@ -442,7 +442,8 @@ include("render.jl")
 include("postrender.jl")
 include("conformal/conformal.jl")
 
-using .ConformalRender: render_conformal!, ConformalRenderContext, add_conformal_loop!
-export render_conformal!, ConformalRenderContext, add_conformal_loop!
+using .ConformalRender:
+    render_conformal!, ConformalRenderContext, add_conformal_loop!, mutual_node!
+export render_conformal!, ConformalRenderContext, add_conformal_loop!, mutual_node!
 
 end # module

--- a/test/test_conformal_render.jl
+++ b/test/test_conformal_render.jl
@@ -519,4 +519,357 @@
         @test hasgroup(sm, "l1", 2)
         gmsh.finalize()
     end
+
+    # ─── mutual_node! (all-pairs symmetric noding) ─────────────────────────
+
+    @testset "mutual_node! makes two adjacent groups symmetric on a shared edge" begin
+        # Group A: rectangle (0,0)-(10,10). Its right edge is (10,0)→(10,10),
+        # one segment with no interior vertex.
+        A = CurvilinearRegion(
+            CurvilinearPolygon(
+                Point{typeof(1.0μm)}[
+                    Point(0.0μm, 0.0μm),
+                    Point(10.0μm, 0.0μm),
+                    Point(10.0μm, 10.0μm),
+                    Point(0.0μm, 10.0μm)
+                ]
+            ),
+            CurvilinearPolygon{typeof(1.0μm)}[]
+        )
+        # Group B: rectangle (10,0)-(20,10) with an extra vertex at (10,5) on
+        # its left edge — a T-junction against A's right edge.
+        B = CurvilinearRegion(
+            CurvilinearPolygon(
+                Point{typeof(1.0μm)}[
+                    Point(10.0μm, 0.0μm),
+                    Point(20.0μm, 0.0μm),
+                    Point(20.0μm, 10.0μm),
+                    Point(10.0μm, 10.0μm),
+                    Point(10.0μm, 5.0μm)  # foreign vertex on A's right edge
+                ]
+            ),
+            CurvilinearPolygon{typeof(1.0μm)}[]
+        )
+        groups = Dict(:a => [A], :b => [B])
+        n = SolidModels.mutual_node!(groups)
+        # A gains (10,5) on its right edge; B already had it, so exactly one
+        # injection (into A).
+        @test n == 1
+        a_pts = points(groups[:a][1].exterior)
+        @test any(p -> p ≈ Point(10.0μm, 5.0μm), a_pts)
+        @test length(a_pts) == 5  # was 4, +1 injected
+        # Symmetric: both groups now visit (10,5) on the shared boundary.
+        b_pts = points(groups[:b][1].exterior)
+        @test any(p -> p ≈ Point(10.0μm, 5.0μm), b_pts)
+    end
+
+    @testset "mutual_node! is idempotent" begin
+        A = CurvilinearRegion(
+            CurvilinearPolygon(
+                Point{typeof(1.0μm)}[
+                    Point(0.0μm, 0.0μm),
+                    Point(10.0μm, 0.0μm),
+                    Point(10.0μm, 10.0μm),
+                    Point(0.0μm, 10.0μm)
+                ]
+            ),
+            CurvilinearPolygon{typeof(1.0μm)}[]
+        )
+        B = CurvilinearRegion(
+            CurvilinearPolygon(
+                Point{typeof(1.0μm)}[
+                    Point(10.0μm, 0.0μm),
+                    Point(20.0μm, 0.0μm),
+                    Point(20.0μm, 10.0μm),
+                    Point(10.0μm, 10.0μm),
+                    Point(10.0μm, 5.0μm)
+                ]
+            ),
+            CurvilinearPolygon{typeof(1.0μm)}[]
+        )
+        groups = Dict(:a => [A], :b => [B])
+        @test SolidModels.mutual_node!(groups) == 1
+        # Second pass: both sides already carry (10,5); nothing new to inject.
+        @test SolidModels.mutual_node!(groups) == 0
+    end
+
+    @testset "mutual_node! no-op when groups don't touch" begin
+        A = CurvilinearRegion(
+            CurvilinearPolygon(
+                Point{typeof(1.0μm)}[
+                    Point(0.0μm, 0.0μm),
+                    Point(10.0μm, 0.0μm),
+                    Point(10.0μm, 10.0μm),
+                    Point(0.0μm, 10.0μm)
+                ]
+            ),
+            CurvilinearPolygon{typeof(1.0μm)}[]
+        )
+        # Far away, no shared boundary.
+        B = CurvilinearRegion(
+            CurvilinearPolygon(
+                Point{typeof(1.0μm)}[
+                    Point(100.0μm, 100.0μm),
+                    Point(110.0μm, 100.0μm),
+                    Point(110.0μm, 110.0μm),
+                    Point(100.0μm, 110.0μm)
+                ]
+            ),
+            CurvilinearPolygon{typeof(1.0μm)}[]
+        )
+        groups = Dict(:a => [A], :b => [B])
+        @test SolidModels.mutual_node!(groups) == 0
+    end
+
+    @testset "mutual_node! splits a Turn at a foreign vertex on the arc" begin
+        # Group A has a quarter-arc from (10,0) to (0,10) centered at origin.
+        R = 10.0μm
+        turn = Paths.Turn(90°, R, α0=90°, p0=Point(R, 0.0μm))
+        A = CurvilinearRegion(
+            CurvilinearPolygon(
+                Point{typeof(1.0μm)}[Point(R, 0.0μm), Point(0.0μm, R), Point(R, R)],
+                [turn],
+                [1]
+            ),
+            CurvilinearPolygon{typeof(1.0μm)}[]
+        )
+        # Group B has a vertex at 45° on that arc — a T-junction on the curve.
+        mid = Point(R * cos(π / 4), R * sin(π / 4))
+        B = CurvilinearRegion(
+            CurvilinearPolygon(
+                Point{typeof(1.0μm)}[mid, Point(20.0μm, 20.0μm), Point(20.0μm, 0.0μm)]
+            ),
+            CurvilinearPolygon{typeof(1.0μm)}[]
+        )
+        groups = Dict(:a => [A], :b => [B])
+        n = SolidModels.mutual_node!(groups)
+        @test n >= 1
+        # A's arc is now split into >=2 sub-Turns, still native curves.
+        @test length(groups[:a][1].exterior.curves) >= 2
+        @test all(c -> c isa Paths.Turn, groups[:a][1].exterior.curves)
+    end
+
+    @testset "mutual_node! injects across three groups meeting at a boundary" begin
+        # Three stacked rectangles sharing horizontal boundaries; the middle
+        # one has a vertex the outer two don't, and vice versa.
+        bottom = CurvilinearRegion(
+            CurvilinearPolygon(
+                Point{typeof(1.0μm)}[
+                    Point(0.0μm, 0.0μm),
+                    Point(10.0μm, 0.0μm),
+                    Point(10.0μm, 10.0μm),
+                    Point(5.0μm, 10.0μm),  # vertex on shared edge with middle
+                    Point(0.0μm, 10.0μm)
+                ]
+            ),
+            CurvilinearPolygon{typeof(1.0μm)}[]
+        )
+        middle = CurvilinearRegion(
+            CurvilinearPolygon(
+                Point{typeof(1.0μm)}[
+                    Point(0.0μm, 10.0μm),
+                    Point(10.0μm, 10.0μm),
+                    Point(10.0μm, 20.0μm),
+                    Point(0.0μm, 20.0μm)
+                ]
+            ),
+            CurvilinearPolygon{typeof(1.0μm)}[]
+        )
+        groups = Dict(:bottom => [bottom], :middle => [middle])
+        n = SolidModels.mutual_node!(groups)
+        # middle's bottom edge (0,10)→(10,10) gains (5,10) from bottom.
+        @test n == 1
+        @test any(p -> p ≈ Point(5.0μm, 10.0μm), points(groups[:middle][1].exterior))
+    end
+
+    @testset "mutual_node! empty groups is a no-op" begin
+        groups = Dict{Symbol, Vector{CurvilinearRegion{typeof(1.0μm)}}}()
+        @test SolidModels.mutual_node!(groups) == 0
+        groups2 = Dict(:a => CurvilinearRegion{typeof(1.0μm)}[])
+        @test SolidModels.mutual_node!(groups2) == 0
+    end
+
+    @testset "mutual_node! node_tol is unit-safe (nm regardless of input unit)" begin
+        # `node_tol` is documented in nm and must mean the same *physical*
+        # distance whether the input Points carry µm or nm units. Build the
+        # SAME geometry both ways and check the injection is identical. The
+        # foreign vertex B[5] sits 1 nm off A's right edge (x = 10 µm + 1 nm),
+        # inside the default 2 nm tolerance — so it injects regardless of unit.
+        # `u` is the point unit (nm or μm); `x_off` is the perpendicular
+        # offset of the foreign vertex from A's right edge, in that same unit.
+        function build_pair(u, x_off)
+            A = CurvilinearRegion(
+                CurvilinearPolygon(
+                    Point{typeof(1.0u)}[
+                        Point(0.0u, 0.0u),
+                        Point(10000.0u, 0.0u),
+                        Point(10000.0u, 10000.0u),
+                        Point(0.0u, 10000.0u)
+                    ]
+                ),
+                CurvilinearPolygon{typeof(1.0u)}[]
+            )
+            B = CurvilinearRegion(
+                CurvilinearPolygon(
+                    Point{typeof(1.0u)}[
+                        Point(10000.0u, 0.0u),
+                        Point(20000.0u, 0.0u),
+                        Point(20000.0u, 10000.0u),
+                        Point(10000.0u, 10000.0u),
+                        Point((10000.0 + x_off)u, 5000.0u)  # off A's edge by x_off·u
+                    ]
+                ),
+                CurvilinearPolygon{typeof(1.0u)}[]
+            )
+            return Dict(:a => [A], :b => [B])
+        end
+        # 1 nm off the edge: within 2 nm tolerance → injects, in both units.
+        @test SolidModels.mutual_node!(build_pair(nm, 1.0)) == 1
+        @test SolidModels.mutual_node!(build_pair(μm, 0.001)) == 1  # 0.001 µm = 1 nm
+        # 5 nm off the edge: outside tolerance → no injection, in both units.
+        @test SolidModels.mutual_node!(build_pair(nm, 5.0)) == 0
+        @test SolidModels.mutual_node!(build_pair(μm, 0.005)) == 0  # 0.005 µm = 5 nm
+    end
+
+    @testset "mutual_node! dedups near-coincident foreign vertices on an edge" begin
+        # Group A: unit square; its bottom edge (0,0)→(10000,0) is one segment.
+        A = CurvilinearRegion(
+            CurvilinearPolygon(
+                Point{typeof(1.0nm)}[
+                    Point(0.0nm, 0.0nm),
+                    Point(10000.0nm, 0.0nm),
+                    Point(10000.0nm, 10000.0nm),
+                    Point(0.0nm, 10000.0nm)
+                ]
+            ),
+            CurvilinearPolygon{typeof(1.0nm)}[]
+        )
+        # Group B has two vertices 1 nm apart on A's bottom edge — within the
+        # 2 nm node tolerance of each other. Only one should be injected.
+        B = CurvilinearRegion(
+            CurvilinearPolygon(
+                Point{typeof(1.0nm)}[
+                    Point(0.0nm, -10000.0nm),
+                    Point(10000.0nm, -10000.0nm),
+                    Point(10000.0nm, 0.0nm),
+                    Point(5001.0nm, 0.0nm),
+                    Point(5000.0nm, 0.0nm),
+                    Point(0.0nm, 0.0nm)
+                ]
+            ),
+            CurvilinearPolygon{typeof(1.0nm)}[]
+        )
+        groups = Dict(:a => [A], :b => [B])
+        # A's bottom edge gains one vertex, not two (the 1-nm-apart pair
+        # collapses to a single injection).
+        @test SolidModels.mutual_node!(groups) == 1
+    end
+
+    @testset "mutual_node! keeps two well-separated foreign vertices on one edge" begin
+        # Complement to the dedup test: two foreign vertices FAR apart (5 µm)
+        # along the same target edge must BOTH be injected (the dedup only drops
+        # sub-tolerance neighbours).
+        A = CurvilinearRegion(
+            CurvilinearPolygon(
+                Point{typeof(1.0μm)}[
+                    Point(0.0μm, 0.0μm),
+                    Point(20.0μm, 0.0μm),      # bottom edge is one long segment
+                    Point(20.0μm, 20.0μm),
+                    Point(0.0μm, 20.0μm)
+                ]
+            ),
+            CurvilinearPolygon{typeof(1.0μm)}[]
+        )
+        # Group B contributes two well-separated on-edge vertices at x=5 and x=15.
+        B = CurvilinearRegion(
+            CurvilinearPolygon(
+                Point{typeof(1.0μm)}[
+                    Point(0.0μm, -20.0μm),
+                    Point(20.0μm, -20.0μm),
+                    Point(20.0μm, 0.0μm),
+                    Point(15.0μm, 0.0μm),  # on A's bottom edge
+                    Point(5.0μm, 0.0μm),   # on A's bottom edge
+                    Point(0.0μm, 0.0μm)
+                ]
+            ),
+            CurvilinearPolygon{typeof(1.0μm)}[]
+        )
+        groups = Dict(:a => [A], :b => [B])
+        @test SolidModels.mutual_node!(groups) == 2  # both kept, not deduped
+        a_pts = points(groups[:a][1].exterior)
+        @test any(p -> p ≈ Point(5.0μm, 0.0μm), a_pts)
+        @test any(p -> p ≈ Point(15.0μm, 0.0μm), a_pts)
+    end
+
+    @testset "mutual_node! injects a foreign vertex into a hole edge" begin
+        # A group region with a HOLE: a foreign vertex from another group lands
+        # on the hole's edge and must be injected there (exercises hole indexing
+        # and the hole-noding branch of mutual_node!).
+        ext = CurvilinearPolygon(
+            Point{typeof(1.0μm)}[
+                Point(0.0μm, 0.0μm),
+                Point(30.0μm, 0.0μm),
+                Point(30.0μm, 30.0μm),
+                Point(0.0μm, 30.0μm)
+            ]
+        )
+        # Square hole from (10,10) to (20,20); its right edge is x=20, y∈[10,20].
+        hole = CurvilinearPolygon(
+            Point{typeof(1.0μm)}[
+                Point(10.0μm, 10.0μm),
+                Point(10.0μm, 20.0μm),
+                Point(20.0μm, 20.0μm),
+                Point(20.0μm, 10.0μm)
+            ]
+        )
+        A = CurvilinearRegion(ext, [hole])
+        # Group B has a vertex at (20,15) — on the hole's right edge interior.
+        B = CurvilinearRegion(
+            CurvilinearPolygon(
+                Point{typeof(1.0μm)}[
+                    Point(20.0μm, 15.0μm),  # on A's hole edge
+                    Point(25.0μm, 12.0μm),
+                    Point(25.0μm, 18.0μm)
+                ]
+            ),
+            CurvilinearPolygon{typeof(1.0μm)}[]
+        )
+        groups = Dict(:a => [A], :b => [B])
+        n = SolidModels.mutual_node!(groups)
+        @test n >= 1
+        # The injected vertex shows up on the hole, not the exterior.
+        hole_pts = points(groups[:a][1].holes[1])
+        @test any(p -> p ≈ Point(20.0μm, 15.0μm), hole_pts)
+    end
+
+    @testset "mutual_node! leaves an untouched curve intact (no foreign split)" begin
+        # A group with a Turn arc that no other group touches: the curve must be
+        # carried through unchanged (the isempty(splits) branch of _node_contour!).
+        R = 10.0μm
+        turn = Paths.Turn(90°, R, α0=90°, p0=Point(R, 0.0μm))
+        A = CurvilinearRegion(
+            CurvilinearPolygon(
+                Point{typeof(1.0μm)}[Point(R, 0.0μm), Point(0.0μm, R), Point(R, R)],
+                [turn],
+                [1]
+            ),
+            CurvilinearPolygon{typeof(1.0μm)}[]
+        )
+        # Group B is far away and shares no boundary.
+        B = CurvilinearRegion(
+            CurvilinearPolygon(
+                Point{typeof(1.0μm)}[
+                    Point(100.0μm, 100.0μm),
+                    Point(110.0μm, 100.0μm),
+                    Point(110.0μm, 110.0μm)
+                ]
+            ),
+            CurvilinearPolygon{typeof(1.0μm)}[]
+        )
+        groups = Dict(:a => [A], :b => [B])
+        @test SolidModels.mutual_node!(groups) == 0
+        # The arc survives as a single native Turn, unmodified.
+        @test length(groups[:a][1].exterior.curves) == 1
+        @test groups[:a][1].exterior.curves[1] isa Paths.Turn
+    end
 end


### PR DESCRIPTION
## Summary

Adds `mutual_node!(groups; node_tol=2.0)` to the `ConformalRender` submodule:
all-pairs symmetric noding across physical groups.

Adjacent physical groups that share a boundary must carry the same vertex
sequence along it, so the shared-edge cache in `render_conformal!` can resolve
that boundary to a single OCC curve on both sides. Independent boolean
operations don't guarantee this: two booleans can put a vertex on one side of
a shared edge but not the other, leaving a T-junction the mesher rejects.

`mutual_node!` fixes this for all groups at once. It builds a single spatial
hash of every group's vertices, then injects into each group's edges every
vertex owned by a *different* group that lies on the edge interior. The result
is symmetric by construction — both sides of every shared boundary end up with
the identical ordered vertex sequence — and the caller does not need to know
the adjacency graph.

## Details

- **Straight edges**: the foreign vertex is inserted verbatim (bit-exact — the
  render-time point merge unifies the two copies), with near-coincident
  candidates de-duplicated so we never inject a sub-tolerance-length edge.
- **Curved edges** (`Paths.Turn`, `Paths.BSpline`, …): split at the foreign
  vertex's arclength via `Paths.split`, staying native and exact — no
  discretization.
- **Unit-safe tolerance**: `node_tol` is applied in nm regardless of the input
  `Point`s' unit (coordinates convert with `ustrip(u"nm", …)`), so the
  tolerance means the same physical distance whether geometry is expressed in
  nm or µm.

## Tests

Eight testsets in `test/test_conformal_render.jl` cover symmetry, idempotence,
the no-touch / empty no-ops, curve splitting, a three-group boundary meeting,
unit safety, and near-coincident dedup.
