### PR TITLE
ConformalRender: add split_pinches for self-touching contours

### DIFF
--- a/src/solidmodels/conformal/conformal.jl
+++ b/src/solidmodels/conformal/conformal.jl
@@ -78,6 +78,9 @@ import SpatialIndexing
 import SpatialIndexing: RTree
 
 export render_conformal!, ConformalRenderContext, add_conformal_loop!
+export split_pinches, find_pinch_points
+
+include("preprocess.jl")
 
 """
 Entry in `endpoint_curve_index`: the signed OCC tag of the curve, plus a

--- a/src/solidmodels/conformal/preprocess.jl
+++ b/src/solidmodels/conformal/preprocess.jl
@@ -1,0 +1,191 @@
+# Geometry preprocessing for [`render_conformal!`](@ref).
+#
+# After boolean operations (e.g. [`union2d_curved`](@ref)) hand back a
+# `Vector{CurvilinearRegion}` (or `Dict{Symbol,Vector{CurvilinearRegion}}` if
+# multiple layers were computed together), a self-touching contour can make OCC
+# or the mesher reject the geometry: Clipper's union can produce polygons where
+# two non-adjacent vertices coincide — a zero-width neck or figure-8 — which OCC
+# rejects with "Curve loop is not closed". [`split_pinches`](@ref) detects these
+# and splits them into simple sub-polygons.
+#
+# It operates on `CurvilinearRegion` (or `Vector{CurvilinearRegion}`) and
+# preserves native curve segments (`Paths.Turn`, `Paths.BSpline`) — arcs are
+# carried through to each sub-polygon by remapping curve indices rather than
+# discretized.
+
+"""
+    find_pinch_points(pts; atol_nm=2.0) -> Vector{Tuple{Int,Int}}
+
+Return `(i, j)` index pairs where non-adjacent contour vertices coincide
+within `atol_nm`. Uses a hash grid for O(n) detection. Adjacent vertices
+(including the wraparound pair) are excluded — those are joined by a real
+edge, not a pinch.
+
+`atol_nm` should match the point-merge tolerance used at render time (see
+[`ConformalRenderContext`](@ref)'s `vertex_merge_atol`), so pinch detection
+predicts OCC's behaviour after the two vertices merge.
+"""
+function find_pinch_points(pts; atol_nm::Float64=2.0)
+    n = length(pts)
+    n < 4 && return Tuple{Int, Int}[]
+    cell = max(atol_nm, 1.0)
+    # `cell`, `tol2`, and `atol_nm` are all in nm, so coordinates must be too —
+    # strip to nm explicitly rather than to the Point's storage unit, so the
+    # tolerance is the same physical distance whether the input is nm- or
+    # µm-based (µm coordinates stripped bare would be 1000× too close together).
+    coords =
+        [(Float64(ustrip(u"nm", getx(p))), Float64(ustrip(u"nm", gety(p)))) for p in pts]
+    grid = Dict{Tuple{Int, Int}, Vector{Int}}()
+    pinches = Tuple{Int, Int}[]
+    tol2 = atol_nm * atol_nm
+    for i = 1:n
+        x, y = coords[i]
+        ci = (floor(Int, x / cell), floor(Int, y / cell))
+        for dcx = -1:1, dcy = -1:1
+            for j in get(grid, (ci[1] + dcx, ci[2] + dcy), Int[])
+                # j < i (only earlier points are in the grid). Skip adjacency.
+                (j == i - 1 || (j == 1 && i == n)) && continue
+                xj, yj = coords[j]
+                dx = x - xj
+                dy = y - yj
+                dx * dx + dy * dy <= tol2 && push!(pinches, (j, i))
+            end
+        end
+        push!(get!(Vector{Int}, grid, ci), i)
+    end
+    return pinches
+end
+
+# Split a contour at a pinch (vertices i and j coincide, i < j) into two
+# simple loops. Each lobe keeps exactly one copy of the pinch point.
+function _split_at_pinch(cpoly::CurvilinearPolygon, i::Int, j::Int)
+    pts = points(cpoly)
+    curves = cpoly.curves
+    csis = cpoly.curve_start_idx
+    n = length(pts)
+    idx1 = collect(i:(j - 1))
+    idx2 = vcat(collect(j:n), collect(1:(i - 1)))
+    pts1 = pts[idx1]
+    pts2 = pts[idx2]
+    pos1 = Dict(k => p for (p, k) in enumerate(idx1))
+    pos2 = Dict(k => p for (p, k) in enumerate(idx2))
+    curves1 = typeof(curves)()
+    curves2 = typeof(curves)()
+    csis1 = Int[]
+    csis2 = Int[]
+    for (ci, csi) in enumerate(csis)
+        if haskey(pos1, csi)
+            push!(curves1, curves[ci])
+            push!(csis1, pos1[csi])
+        elseif haskey(pos2, csi)
+            push!(curves2, curves[ci])
+            push!(csis2, pos2[csi])
+        end
+    end
+    return CurvilinearPolygon(pts1, curves1, csis1),
+    CurvilinearPolygon(pts2, curves2, csis2)
+end
+
+# Repeatedly split a contour at its first remaining pinch until no pinches
+# remain. Drop sub-loops with < 3 vertices — those are zero-area slivers
+# produced when several collinear pinches carve off a 2-point piece.
+function _split_cpoly_at_pinches(cpoly::CurvilinearPolygon)
+    results = typeof(cpoly)[]
+    queue = typeof(cpoly)[cpoly]
+    while !isempty(queue)
+        cp = popfirst!(queue)
+        length(points(cp)) < 3 && continue
+        pinches = find_pinch_points(points(cp))
+        if isempty(pinches)
+            push!(results, cp)
+        else
+            cp1, cp2 = _split_at_pinch(cp, pinches[1]...)
+            push!(queue, cp1)
+            push!(queue, cp2)
+        end
+    end
+    return results
+end
+
+# Ray-cast point-in-polygon. Coordinates are stripped to nm (matching the
+# `px`/`py` the caller passes), so the test is unit-invariant.
+function _point_in_poly(px::Float64, py::Float64, poly_pts)
+    n = length(poly_pts)
+    inside = false
+    j = n
+    for i = 1:n
+        xi = Float64(ustrip(u"nm", getx(poly_pts[i])))
+        yi = Float64(ustrip(u"nm", gety(poly_pts[i])))
+        xj = Float64(ustrip(u"nm", getx(poly_pts[j])))
+        yj = Float64(ustrip(u"nm", gety(poly_pts[j])))
+        if ((yi > py) != (yj > py)) && (px < (xj - xi) * (py - yi) / (yj - yi) + xi)
+            inside = !inside
+        end
+        j = i
+    end
+    return inside
+end
+
+function _split_all_pinches(region::CurvilinearRegion)
+    ext_pieces = _split_cpoly_at_pinches(region.exterior)
+    simple_holes = eltype(region.holes)[]
+    for h in region.holes
+        append!(simple_holes, _split_cpoly_at_pinches(h))
+    end
+    if length(ext_pieces) == 1
+        return [CurvilinearRegion(ext_pieces[1], simple_holes)]
+    end
+    # Multiple exterior pieces — assign each hole to the piece that contains
+    # it. Sort pieces largest-first so a representative-vertex test resolves
+    # nesting sanely.
+    order = sortperm(ext_pieces; by=cp -> length(points(cp)), rev=true)
+    ext_pieces = ext_pieces[order]
+    hole_buckets = [eltype(region.holes)[] for _ in ext_pieces]
+    for h in simple_holes
+        hp = points(h)
+        isempty(hp) && continue
+        hx = Float64(ustrip(u"nm", getx(hp[1])))
+        hy = Float64(ustrip(u"nm", gety(hp[1])))
+        assigned = false
+        for (pi, ext) in enumerate(ext_pieces)
+            if _point_in_poly(hx, hy, points(ext))
+                push!(hole_buckets[pi], h)
+                assigned = true
+                break
+            end
+        end
+        assigned || push!(hole_buckets[1], h)
+    end
+    return [
+        CurvilinearRegion(ext_pieces[pi], hole_buckets[pi]) for pi in eachindex(ext_pieces)
+    ]
+end
+
+"""
+    split_pinches(regions::Vector{<:CurvilinearRegion}) -> Vector{CurvilinearRegion}
+
+Split every self-touching region (on the exterior AND every hole) into simple
+sub-regions. A region is left untouched only if neither its exterior nor any
+hole has a pinch. Returns an expanded vector.
+
+Pinches are detected at a 2 nm tolerance (matching the default
+`ConformalRenderContext` `vertex_merge_atol`). Sub-loops with fewer than
+three vertices are dropped — those are zero-area slivers.
+
+Curves (`Paths.Turn`, `Paths.BSpline`, `Paths.OffsetSegment`) are preserved
+by remapping `curve_start_idx` to the new vertex indices within each lobe.
+"""
+function split_pinches(regions)
+    result = CurvilinearRegion[]
+    for r in regions
+        clean =
+            isempty(find_pinch_points(points(r.exterior))) &&
+            all(h -> isempty(find_pinch_points(points(h))), r.holes)
+        if clean
+            push!(result, r)
+        else
+            append!(result, _split_all_pinches(r))
+        end
+    end
+    return result
+end

--- a/src/solidmodels/solidmodels.jl
+++ b/src/solidmodels/solidmodels.jl
@@ -442,7 +442,13 @@ include("render.jl")
 include("postrender.jl")
 include("conformal/conformal.jl")
 
-using .ConformalRender: render_conformal!, ConformalRenderContext, add_conformal_loop!
+using .ConformalRender:
+    render_conformal!,
+    ConformalRenderContext,
+    add_conformal_loop!,
+    split_pinches,
+    find_pinch_points
 export render_conformal!, ConformalRenderContext, add_conformal_loop!
+export split_pinches, find_pinch_points
 
 end # module

--- a/test/test_conformal_render.jl
+++ b/test/test_conformal_render.jl
@@ -14,7 +14,9 @@
         LineSegment,
         straight!,
         turn!,
-        bspline!
+        bspline!,
+        union2d,
+        to_polygons
     using DeviceLayout.Polygons: Rounded
     using DeviceLayout.Curvilinear: CurvilinearPolygon, CurvilinearRegion
     using DeviceLayout.SolidModels:
@@ -518,5 +520,352 @@
         render_conformal!(sm, cs)
         @test hasgroup(sm, "l1", 2)
         gmsh.finalize()
+    end
+
+    # ─── Preprocessing (split_pinches) ────────────────────────────────────
+
+    @testset "find_pinch_points detects self-touching contours" begin
+        # A rectangular polygon with a duplicate vertex at (5, 0) — a
+        # zero-width neck. The pinch is between indices 3 and 6.
+        pts = Point{typeof(1.0μm)}[
+            Point(0.0μm, 0.0μm),
+            Point(5.0μm, 0.0μm),
+            Point(5.0μm, 5.0μm),
+            Point(0.0μm, 5.0μm),
+            Point(0.0μm, 0.0μm),
+            Point(5.0μm, 0.0μm)  # same coord as index 2 → pinch (2, 6)
+        ]
+        pinches = SolidModels.ConformalRender.find_pinch_points(pts)
+        @test !isempty(pinches)
+        @test any(p -> p == (1, 5) || p == (2, 6), pinches)
+    end
+
+    @testset "find_pinch_points returns empty for a clean polygon" begin
+        pts = Point{typeof(1.0μm)}[
+            Point(0.0μm, 0.0μm),
+            Point(10.0μm, 0.0μm),
+            Point(10.0μm, 10.0μm),
+            Point(0.0μm, 10.0μm)
+        ]
+        @test isempty(SolidModels.ConformalRender.find_pinch_points(pts))
+    end
+
+    @testset "Clipper does not produce pinches on simple touching shapes" begin
+        # Simple pinch-shaped inputs (diagonal-touching rects, hourglass
+        # apex-to-apex triangles) don't produce self-touching outlines from
+        # `union2d` — Clipper separates them into distinct polygons. This
+        # documents the class of inputs where `find_pinch_points` /
+        # `split_pinches` are unnecessary.
+        #
+        # Coordinates are chosen large enough (~100 µm) that no two
+        # distinct vertices fall within `find_pinch_points`'s 2 nm
+        # atol (the fn ustrips whatever unit the point carries).
+
+        # Diagonal-touching rectangles at (0, 0)
+        r1 = Polygon([
+            Point(-100.0μm, 0.0μm),
+            Point(0.0μm, 0.0μm),
+            Point(0.0μm, 100.0μm),
+            Point(-100.0μm, 100.0μm)
+        ])
+        r2 = Polygon([
+            Point(0.0μm, -100.0μm),
+            Point(100.0μm, -100.0μm),
+            Point(100.0μm, 0.0μm),
+            Point(0.0μm, 0.0μm)
+        ])
+        polys1 = to_polygons(union2d([r1, r2]))
+        @test length(polys1) == 2  # separated, not one figure-8 poly
+        for p in polys1
+            @test isempty(SolidModels.ConformalRender.find_pinch_points(collect(points(p))))
+        end
+
+        # Hourglass triangles sharing apex at (0, 0)
+        tri1 = Polygon([
+            Point(0.0μm, 0.0μm),
+            Point(100.0μm, 100.0μm),
+            Point(-100.0μm, 100.0μm)
+        ])
+        tri2 = Polygon([
+            Point(0.0μm, 0.0μm),
+            Point(-100.0μm, -100.0μm),
+            Point(100.0μm, -100.0μm)
+        ])
+        polys2 = to_polygons(union2d([tri1, tri2]))
+        @test length(polys2) == 2  # separated, not one bow-tie poly
+        for p in polys2
+            @test isempty(SolidModels.ConformalRender.find_pinch_points(collect(points(p))))
+        end
+    end
+
+    @testset "find_pinch_points catches noding-induced pinches" begin
+        # The pinch case `find_pinch_points`/`split_pinches` actually needs
+        # to handle in a downstream pipeline: shared-boundary vertex
+        # injection (used to make adjacent physical groups share bit-
+        # identical vertex sequences on their common boundary) turns a
+        # Clipper-clean pair of outlines into a self-touching outline.
+        #
+        # Region A visits (150 µm, 0) once as an interior corner of a
+        # satellite feature. A also has a long shared-edge segment
+        # (-300, 0) → (300, 0) with no interior vertex at x=150. When
+        # a noding pass injects region B's on-edge port anchor at
+        # (150, 0) into that segment, A's outline visits (150 µm, 0)
+        # twice at non-adjacent positions — the exact failure OCC
+        # rejects with "Curve loop is not closed".
+        A = Point{typeof(1.0μm)}[
+            Point(-300.0μm, 0.0μm),
+            Point(300.0μm, 0.0μm),
+            Point(300.0μm, 200.0μm),
+            Point(200.0μm, 200.0μm),
+            Point(200.0μm, 100.0μm),
+            Point(100.0μm, 100.0μm),
+            Point(150.0μm, 0.0μm),    # A already has this vertex
+            Point(100.0μm, 50.0μm),
+            Point(0.0μm, 50.0μm),
+            Point(-300.0μm, 200.0μm)
+        ]
+        @test isempty(SolidModels.ConformalRender.find_pinch_points(A))
+
+        # Simulate the injection: B's on-edge port anchor at (150, 0)
+        # gets injected into A's long shared-edge segment.
+        A_after_noding = vcat(A[1:1], [Point(150.0μm, 0.0μm)], A[2:end])
+
+        pinches = SolidModels.ConformalRender.find_pinch_points(A_after_noding)
+        @test length(pinches) == 1
+        i, j = pinches[1]
+        @test A_after_noding[i] ≈ A_after_noding[j]
+        # split_pinches then cleaves A into two simple faces at the pinch.
+        cp = CurvilinearPolygon(A_after_noding)
+        r = CurvilinearRegion(cp, CurvilinearPolygon{typeof(1.0μm)}[])
+        @test length(SolidModels.split_pinches([r])) >= 2
+    end
+
+    @testset "render_conformal! fails on pinched outline, split_pinches fixes it" begin
+        # End-to-end: build a CoordinateSystem containing a
+        # `CurvilinearRegion` whose outline was produced by symmetric
+        # shared-boundary noding (see previous testset for construction).
+        # Rendering it directly through `render_conformal!` must raise
+        # OCC's "Curve loop is not closed" error. Preprocessing the region
+        # with `split_pinches` first must let the render complete.
+        A_pinched = Point{typeof(1.0μm)}[
+            Point(-300.0μm, 0.0μm),
+            Point(150.0μm, 0.0μm),   # injected copy
+            Point(300.0μm, 0.0μm),
+            Point(300.0μm, 200.0μm),
+            Point(200.0μm, 200.0μm),
+            Point(200.0μm, 60.0μm),
+            Point(150.0μm, 0.0μm),   # A's original notch tip — pinch
+            Point(100.0μm, 60.0μm),
+            Point(100.0μm, 200.0μm),
+            Point(-300.0μm, 200.0μm)
+        ]
+        cp = CurvilinearPolygon(A_pinched)
+        region = CurvilinearRegion(cp, CurvilinearPolygon{typeof(1.0μm)}[])
+
+        # Attempt 1: render_conformal! on the pinched outline throws.
+        cs_pinched = CoordinateSystem("pinched_direct", nm)
+        place!(cs_pinched, region, :layer_A)
+        sm_pinched = SolidModel("pinched_direct"; overwrite=true)
+        @test_throws ErrorException render_conformal!(sm_pinched, cs_pinched)
+        gmsh.finalize()
+
+        # Attempt 2: split_pinches first, then render_conformal! succeeds.
+        split_regions = SolidModels.split_pinches([region])
+        @test length(split_regions) >= 2
+
+        cs_split = CoordinateSystem("pinched_split", nm)
+        for r in split_regions
+            place!(cs_split, r, :layer_A)
+        end
+        sm_split = SolidModel("pinched_split"; overwrite=true)
+        render_conformal!(sm_split, cs_split)
+        @test hasgroup(sm_split, "layer_A", 2)
+        gmsh.finalize()
+    end
+
+    @testset "split_pinches splits a figure-8 into two simple loops" begin
+        # Figure-8: two lobes touching at (5, 0). One CurvilinearRegion
+        # in, two out.
+        pts = Point{typeof(1.0μm)}[
+            Point(0.0μm, 0.0μm),
+            Point(5.0μm, 0.0μm),  # pinch
+            Point(2.0μm, 5.0μm),
+            Point(0.0μm, 0.0μm),  # loop 1 closes here
+            Point(5.0μm, 0.0μm),  # pinch again — starts loop 2
+            Point(8.0μm, 5.0μm),
+            Point(10.0μm, 0.0μm)
+        ]
+        cp = CurvilinearPolygon(pts)
+        r = CurvilinearRegion(cp, CurvilinearPolygon{typeof(1.0μm)}[])
+        out = SolidModels.split_pinches([r])
+        @test length(out) >= 2  # at least two lobes after split
+    end
+
+    @testset "split_pinches leaves clean regions untouched" begin
+        pts = Point{typeof(1.0μm)}[
+            Point(0.0μm, 0.0μm),
+            Point(10.0μm, 0.0μm),
+            Point(10.0μm, 10.0μm),
+            Point(0.0μm, 10.0μm)
+        ]
+        cp = CurvilinearPolygon(pts)
+        r = CurvilinearRegion(cp, CurvilinearPolygon{typeof(1.0μm)}[])
+        out = SolidModels.split_pinches([r])
+        @test length(out) == 1
+        # Same points, in the same order.
+        @test points(out[1].exterior) == pts
+    end
+
+    @testset "split_pinches handles multi-lobe exterior + hole assignment" begin
+        # A region whose exterior has TWO pinches, splitting it into three
+        # simple lobes. Also has a hole that should get assigned to the
+        # containing lobe by the point-in-polygon test.
+        # Layout (drawn upside-down for clarity):
+        #   Three squares strung side-by-side, each touching the next at one
+        #   vertex — chain of pinch points at x=10 and x=20, y=0.
+        pts = Point{typeof(1.0μm)}[
+            Point(0.0μm, 0.0μm),
+            Point(10.0μm, 0.0μm),  # pinch 1 (also index below)
+            Point(10.0μm, 10.0μm),
+            Point(0.0μm, 10.0μm),
+            Point(0.0μm, 0.0μm),   # closes lobe 1, duplicate of index 1
+            Point(10.0μm, 0.0μm),  # pinch 1 continued
+            Point(20.0μm, 0.0μm),  # pinch 2
+            Point(20.0μm, 10.0μm),
+            Point(10.0μm, 10.0μm)  # duplicate of index 3
+        ]
+        cp = CurvilinearPolygon(pts)
+        # Add a hole inside what will become the first lobe.
+        hole_pts = Point{typeof(1.0μm)}[
+            Point(2.0μm, 2.0μm),
+            Point(4.0μm, 2.0μm),
+            Point(4.0μm, 4.0μm),
+            Point(2.0μm, 4.0μm)
+        ]
+        hole = CurvilinearPolygon(hole_pts)
+        r = CurvilinearRegion(cp, [hole])
+        out = SolidModels.split_pinches([r])
+        # Should split into multiple simple regions.
+        @test length(out) >= 2
+        # Total holes across all output regions should be 1 (the original hole).
+        @test sum(length(rr.holes) for rr in out) == 1
+    end
+
+    @testset "split_pinches drops zero-area sliver sub-loops" begin
+        # A polygon where a run of collinear duplicated vertices causes a
+        # 2-point sub-loop to be carved off. Such slivers should be dropped.
+        pts = Point{typeof(1.0μm)}[
+            Point(0.0μm, 0.0μm),
+            Point(5.0μm, 0.0μm),  # will pinch with index 4
+            Point(10.0μm, 0.0μm),
+            Point(5.0μm, 0.0μm),  # pinch 1
+            Point(5.0μm, 5.0μm),
+            Point(0.0μm, 5.0μm)
+        ]
+        cp = CurvilinearPolygon(pts)
+        r = CurvilinearRegion(cp, CurvilinearPolygon{typeof(1.0μm)}[])
+        # Splitting should not throw and should produce at least one region
+        # (the 2-point sliver, if any, is dropped internally).
+        out = SolidModels.split_pinches([r])
+        @test length(out) >= 1
+        # No output region should be degenerate (< 3 vertices).
+        @test all(length(points(rr.exterior)) >= 3 for rr in out)
+    end
+
+    @testset "find_pinch_points detection is unit-invariant (nm vs µm)" begin
+        # `find_pinch_points` detects at a 2 nm tolerance, so it must strip
+        # coordinates to nm regardless of the Point's storage unit. The SAME
+        # physical geometry expressed in µm and in nm must give the identical
+        # result — otherwise µm-scale vertices (0.5–1 µm apart) would ustrip to
+        # magnitudes ≤ the 2 nm cell and be mis-flagged as coincident.
+        fp = SolidModels.ConformalRender.find_pinch_points
+
+        # A clean 5-vertex outline with vertices 0.5–1 µm apart — NO pinch.
+        clean_um = Point{typeof(1.0μm)}[
+            Point(0.0μm, 0.0μm),
+            Point(1.0μm, 0.0μm),
+            Point(1.0μm, 1.0μm),
+            Point(0.5μm, 1.0μm),
+            Point(0.0μm, 1.0μm)
+        ]
+        clean_nm = [convert(Point{typeof(1.0nm)}, p) for p in clean_um]
+        @test isempty(fp(clean_um))          # µm-based: no false positives
+        @test isempty(fp(clean_nm))          # nm-based: also none
+        @test fp(clean_um) == fp(clean_nm)   # unit-invariant
+
+        # A genuine figure-8: non-adjacent vertices 2 and 5 coincide exactly.
+        # Detected in BOTH units, identically.
+        fig8_um = Point{typeof(1.0μm)}[
+            Point(0.0μm, 0.0μm),
+            Point(5.0μm, 0.0μm),
+            Point(10.0μm, 5.0μm),
+            Point(5.0μm, 10.0μm),
+            Point(5.0μm, 0.0μm),  # coincides with index 2
+            Point(0.0μm, 10.0μm)
+        ]
+        fig8_nm = [convert(Point{typeof(1.0nm)}, p) for p in fig8_um]
+        @test fp(fig8_um) == [(2, 5)]
+        @test fp(fig8_nm) == [(2, 5)]
+    end
+
+    @testset "split_pinches preserves Turn curves through a split (both lobes)" begin
+        # A pinched contour carrying a native `Paths.Turn` arc in EACH lobe.
+        # The pinch at indices (3, 6) partitions vertices into lobe1 = {3,4,5}
+        # and lobe2 = {6,1,2}; an arc starts at index 4 (→ lobe1) and another at
+        # index 1 (→ lobe2), exercising both curve-remap branches of
+        # `_split_at_pinch`. Both arcs must survive as native Turns, not be
+        # discretized.
+        R = 5.0μm
+        pp = Point{typeof(1.0μm)}[
+            Point(0.0μm, 0.0μm),        # 1: arc B start
+            Point(0.0μm + R, R),        # 2: arc B end
+            Point(20.0μm, 20.0μm),      # 3: pinch (coincides with 6)
+            Point(30.0μm, 20.0μm),      # 4: arc A start
+            Point(30.0μm + R, 20.0μm + R), # 5: arc A end
+            Point(20.0μm, 20.0μm)       # 6: coincides with index 3 → pinch
+        ]
+        turnB = Paths.Turn(90°, R, α0=90°, p0=pp[1])
+        turnA = Paths.Turn(90°, R, α0=90°, p0=pp[4])
+        cp = CurvilinearPolygon(pp, [turnB, turnA], [1, 4])
+        r = CurvilinearRegion(cp, CurvilinearPolygon{typeof(1.0μm)}[])
+        out = SolidModels.split_pinches([r])
+        @test length(out) >= 2
+        # A Turn must survive in each of the two lobes (both remap branches ran).
+        @test all(any(c -> c isa Paths.Turn, rr.exterior.curves) for rr in out)
+        # Two native Turns total across the output — none discretized away.
+        all_curves = reduce(vcat, [rr.exterior.curves for rr in out]; init=[])
+        @test count(c -> c isa Paths.Turn, all_curves) == 2
+    end
+
+    @testset "split_pinches splits a pinch inside a hole" begin
+        # The exterior is clean; a HOLE is self-touching. split_pinches must
+        # walk holes too (find_pinch_points on each hole, split, reassign).
+        ext = CurvilinearPolygon(
+            Point{typeof(1.0μm)}[
+                Point(-50.0μm, -50.0μm),
+                Point(50.0μm, -50.0μm),
+                Point(50.0μm, 50.0μm),
+                Point(-50.0μm, 50.0μm)
+            ]
+        )
+        # Figure-8 hole: non-adjacent vertices 1 and 4 coincide.
+        hole = CurvilinearPolygon(
+            Point{typeof(1.0μm)}[
+                Point(0.0μm, 0.0μm),
+                Point(10.0μm, 0.0μm),
+                Point(5.0μm, 10.0μm),
+                Point(0.0μm, 0.0μm),   # coincides with index 1
+                Point(-10.0μm, 0.0μm),
+                Point(-5.0μm, 10.0μm)
+            ]
+        )
+        r = CurvilinearRegion(ext, [hole])
+        @test !isempty(SolidModels.ConformalRender.find_pinch_points(points(hole)))
+        out = SolidModels.split_pinches([r])
+        # Exterior stays one region; the pinched hole is cleaved into simple
+        # sub-loops (so total hole count across the output grew).
+        total_holes = sum(length(rr.holes) for rr in out)
+        @test total_holes >= 2
+        @test all(length(points(h)) >= 3 for rr in out for h in rr.holes)
     end
 end

--- a/test/test_conformal_render.jl
+++ b/test/test_conformal_render.jl
@@ -14,7 +14,9 @@
         LineSegment,
         straight!,
         turn!,
-        bspline!
+        bspline!,
+        union2d,
+        to_polygons
     using DeviceLayout.Polygons: Rounded
     using DeviceLayout.Curvilinear: CurvilinearPolygon, CurvilinearRegion
     using DeviceLayout.SolidModels:
@@ -542,5 +544,352 @@
         render_conformal!(sm, cs)
         @test hasgroup(sm, "l1", 2)
         gmsh.finalize()
+    end
+
+    # ─── Preprocessing (split_pinches) ────────────────────────────────────
+
+    @testset "find_pinch_points detects self-touching contours" begin
+        # A rectangular polygon with a duplicate vertex at (5, 0) — a
+        # zero-width neck. The pinch is between indices 3 and 6.
+        pts = Point{typeof(1.0μm)}[
+            Point(0.0μm, 0.0μm),
+            Point(5.0μm, 0.0μm),
+            Point(5.0μm, 5.0μm),
+            Point(0.0μm, 5.0μm),
+            Point(0.0μm, 0.0μm),
+            Point(5.0μm, 0.0μm)  # same coord as index 2 → pinch (2, 6)
+        ]
+        pinches = SolidModels.ConformalRender.find_pinch_points(pts)
+        @test !isempty(pinches)
+        @test any(p -> p == (1, 5) || p == (2, 6), pinches)
+    end
+
+    @testset "find_pinch_points returns empty for a clean polygon" begin
+        pts = Point{typeof(1.0μm)}[
+            Point(0.0μm, 0.0μm),
+            Point(10.0μm, 0.0μm),
+            Point(10.0μm, 10.0μm),
+            Point(0.0μm, 10.0μm)
+        ]
+        @test isempty(SolidModels.ConformalRender.find_pinch_points(pts))
+    end
+
+    @testset "Clipper does not produce pinches on simple touching shapes" begin
+        # Simple pinch-shaped inputs (diagonal-touching rects, hourglass
+        # apex-to-apex triangles) don't produce self-touching outlines from
+        # `union2d` — Clipper separates them into distinct polygons. This
+        # documents the class of inputs where `find_pinch_points` /
+        # `split_pinches` are unnecessary.
+        #
+        # Coordinates are chosen large enough (~100 µm) that no two
+        # distinct vertices fall within `find_pinch_points`'s 2 nm
+        # atol (the fn ustrips whatever unit the point carries).
+
+        # Diagonal-touching rectangles at (0, 0)
+        r1 = Polygon([
+            Point(-100.0μm, 0.0μm),
+            Point(0.0μm, 0.0μm),
+            Point(0.0μm, 100.0μm),
+            Point(-100.0μm, 100.0μm)
+        ])
+        r2 = Polygon([
+            Point(0.0μm, -100.0μm),
+            Point(100.0μm, -100.0μm),
+            Point(100.0μm, 0.0μm),
+            Point(0.0μm, 0.0μm)
+        ])
+        polys1 = to_polygons(union2d([r1, r2]))
+        @test length(polys1) == 2  # separated, not one figure-8 poly
+        for p in polys1
+            @test isempty(SolidModels.ConformalRender.find_pinch_points(collect(points(p))))
+        end
+
+        # Hourglass triangles sharing apex at (0, 0)
+        tri1 = Polygon([
+            Point(0.0μm, 0.0μm),
+            Point(100.0μm, 100.0μm),
+            Point(-100.0μm, 100.0μm)
+        ])
+        tri2 = Polygon([
+            Point(0.0μm, 0.0μm),
+            Point(-100.0μm, -100.0μm),
+            Point(100.0μm, -100.0μm)
+        ])
+        polys2 = to_polygons(union2d([tri1, tri2]))
+        @test length(polys2) == 2  # separated, not one bow-tie poly
+        for p in polys2
+            @test isempty(SolidModels.ConformalRender.find_pinch_points(collect(points(p))))
+        end
+    end
+
+    @testset "find_pinch_points catches noding-induced pinches" begin
+        # The pinch case `find_pinch_points`/`split_pinches` actually needs
+        # to handle in a downstream pipeline: shared-boundary vertex
+        # injection (used to make adjacent physical groups share bit-
+        # identical vertex sequences on their common boundary) turns a
+        # Clipper-clean pair of outlines into a self-touching outline.
+        #
+        # Region A visits (150 µm, 0) once as an interior corner of a
+        # satellite feature. A also has a long shared-edge segment
+        # (-300, 0) → (300, 0) with no interior vertex at x=150. When
+        # a noding pass injects region B's on-edge port anchor at
+        # (150, 0) into that segment, A's outline visits (150 µm, 0)
+        # twice at non-adjacent positions — the exact failure OCC
+        # rejects with "Curve loop is not closed".
+        A = Point{typeof(1.0μm)}[
+            Point(-300.0μm, 0.0μm),
+            Point(300.0μm, 0.0μm),
+            Point(300.0μm, 200.0μm),
+            Point(200.0μm, 200.0μm),
+            Point(200.0μm, 100.0μm),
+            Point(100.0μm, 100.0μm),
+            Point(150.0μm, 0.0μm),    # A already has this vertex
+            Point(100.0μm, 50.0μm),
+            Point(0.0μm, 50.0μm),
+            Point(-300.0μm, 200.0μm)
+        ]
+        @test isempty(SolidModels.ConformalRender.find_pinch_points(A))
+
+        # Simulate the injection: B's on-edge port anchor at (150, 0)
+        # gets injected into A's long shared-edge segment.
+        A_after_noding = vcat(A[1:1], [Point(150.0μm, 0.0μm)], A[2:end])
+
+        pinches = SolidModels.ConformalRender.find_pinch_points(A_after_noding)
+        @test length(pinches) == 1
+        i, j = pinches[1]
+        @test A_after_noding[i] ≈ A_after_noding[j]
+        # split_pinches then cleaves A into two simple faces at the pinch.
+        cp = CurvilinearPolygon(A_after_noding)
+        r = CurvilinearRegion(cp, CurvilinearPolygon{typeof(1.0μm)}[])
+        @test length(SolidModels.split_pinches([r])) >= 2
+    end
+
+    @testset "render_conformal! fails on pinched outline, split_pinches fixes it" begin
+        # End-to-end: build a CoordinateSystem containing a
+        # `CurvilinearRegion` whose outline was produced by symmetric
+        # shared-boundary noding (see previous testset for construction).
+        # Rendering it directly through `render_conformal!` must raise
+        # OCC's "Curve loop is not closed" error. Preprocessing the region
+        # with `split_pinches` first must let the render complete.
+        A_pinched = Point{typeof(1.0μm)}[
+            Point(-300.0μm, 0.0μm),
+            Point(150.0μm, 0.0μm),   # injected copy
+            Point(300.0μm, 0.0μm),
+            Point(300.0μm, 200.0μm),
+            Point(200.0μm, 200.0μm),
+            Point(200.0μm, 60.0μm),
+            Point(150.0μm, 0.0μm),   # A's original notch tip — pinch
+            Point(100.0μm, 60.0μm),
+            Point(100.0μm, 200.0μm),
+            Point(-300.0μm, 200.0μm)
+        ]
+        cp = CurvilinearPolygon(A_pinched)
+        region = CurvilinearRegion(cp, CurvilinearPolygon{typeof(1.0μm)}[])
+
+        # Attempt 1: render_conformal! on the pinched outline throws.
+        cs_pinched = CoordinateSystem("pinched_direct", nm)
+        place!(cs_pinched, region, :layer_A)
+        sm_pinched = SolidModel("pinched_direct"; overwrite=true)
+        @test_throws ErrorException render_conformal!(sm_pinched, cs_pinched)
+        gmsh.finalize()
+
+        # Attempt 2: split_pinches first, then render_conformal! succeeds.
+        split_regions = SolidModels.split_pinches([region])
+        @test length(split_regions) >= 2
+
+        cs_split = CoordinateSystem("pinched_split", nm)
+        for r in split_regions
+            place!(cs_split, r, :layer_A)
+        end
+        sm_split = SolidModel("pinched_split"; overwrite=true)
+        render_conformal!(sm_split, cs_split)
+        @test hasgroup(sm_split, "layer_A", 2)
+        gmsh.finalize()
+    end
+
+    @testset "split_pinches splits a figure-8 into two simple loops" begin
+        # Figure-8: two lobes touching at (5, 0). One CurvilinearRegion
+        # in, two out.
+        pts = Point{typeof(1.0μm)}[
+            Point(0.0μm, 0.0μm),
+            Point(5.0μm, 0.0μm),  # pinch
+            Point(2.0μm, 5.0μm),
+            Point(0.0μm, 0.0μm),  # loop 1 closes here
+            Point(5.0μm, 0.0μm),  # pinch again — starts loop 2
+            Point(8.0μm, 5.0μm),
+            Point(10.0μm, 0.0μm)
+        ]
+        cp = CurvilinearPolygon(pts)
+        r = CurvilinearRegion(cp, CurvilinearPolygon{typeof(1.0μm)}[])
+        out = SolidModels.split_pinches([r])
+        @test length(out) >= 2  # at least two lobes after split
+    end
+
+    @testset "split_pinches leaves clean regions untouched" begin
+        pts = Point{typeof(1.0μm)}[
+            Point(0.0μm, 0.0μm),
+            Point(10.0μm, 0.0μm),
+            Point(10.0μm, 10.0μm),
+            Point(0.0μm, 10.0μm)
+        ]
+        cp = CurvilinearPolygon(pts)
+        r = CurvilinearRegion(cp, CurvilinearPolygon{typeof(1.0μm)}[])
+        out = SolidModels.split_pinches([r])
+        @test length(out) == 1
+        # Same points, in the same order.
+        @test points(out[1].exterior) == pts
+    end
+
+    @testset "split_pinches handles multi-lobe exterior + hole assignment" begin
+        # A region whose exterior has TWO pinches, splitting it into three
+        # simple lobes. Also has a hole that should get assigned to the
+        # containing lobe by the point-in-polygon test.
+        # Layout (drawn upside-down for clarity):
+        #   Three squares strung side-by-side, each touching the next at one
+        #   vertex — chain of pinch points at x=10 and x=20, y=0.
+        pts = Point{typeof(1.0μm)}[
+            Point(0.0μm, 0.0μm),
+            Point(10.0μm, 0.0μm),  # pinch 1 (also index below)
+            Point(10.0μm, 10.0μm),
+            Point(0.0μm, 10.0μm),
+            Point(0.0μm, 0.0μm),   # closes lobe 1, duplicate of index 1
+            Point(10.0μm, 0.0μm),  # pinch 1 continued
+            Point(20.0μm, 0.0μm),  # pinch 2
+            Point(20.0μm, 10.0μm),
+            Point(10.0μm, 10.0μm)  # duplicate of index 3
+        ]
+        cp = CurvilinearPolygon(pts)
+        # Add a hole inside what will become the first lobe.
+        hole_pts = Point{typeof(1.0μm)}[
+            Point(2.0μm, 2.0μm),
+            Point(4.0μm, 2.0μm),
+            Point(4.0μm, 4.0μm),
+            Point(2.0μm, 4.0μm)
+        ]
+        hole = CurvilinearPolygon(hole_pts)
+        r = CurvilinearRegion(cp, [hole])
+        out = SolidModels.split_pinches([r])
+        # Should split into multiple simple regions.
+        @test length(out) >= 2
+        # Total holes across all output regions should be 1 (the original hole).
+        @test sum(length(rr.holes) for rr in out) == 1
+    end
+
+    @testset "split_pinches drops zero-area sliver sub-loops" begin
+        # A polygon where a run of collinear duplicated vertices causes a
+        # 2-point sub-loop to be carved off. Such slivers should be dropped.
+        pts = Point{typeof(1.0μm)}[
+            Point(0.0μm, 0.0μm),
+            Point(5.0μm, 0.0μm),  # will pinch with index 4
+            Point(10.0μm, 0.0μm),
+            Point(5.0μm, 0.0μm),  # pinch 1
+            Point(5.0μm, 5.0μm),
+            Point(0.0μm, 5.0μm)
+        ]
+        cp = CurvilinearPolygon(pts)
+        r = CurvilinearRegion(cp, CurvilinearPolygon{typeof(1.0μm)}[])
+        # Splitting should not throw and should produce at least one region
+        # (the 2-point sliver, if any, is dropped internally).
+        out = SolidModels.split_pinches([r])
+        @test length(out) >= 1
+        # No output region should be degenerate (< 3 vertices).
+        @test all(length(points(rr.exterior)) >= 3 for rr in out)
+    end
+
+    @testset "find_pinch_points detection is unit-invariant (nm vs µm)" begin
+        # `find_pinch_points` detects at a 2 nm tolerance, so it must strip
+        # coordinates to nm regardless of the Point's storage unit. The SAME
+        # physical geometry expressed in µm and in nm must give the identical
+        # result — otherwise µm-scale vertices (0.5–1 µm apart) would ustrip to
+        # magnitudes ≤ the 2 nm cell and be mis-flagged as coincident.
+        fp = SolidModels.ConformalRender.find_pinch_points
+
+        # A clean 5-vertex outline with vertices 0.5–1 µm apart — NO pinch.
+        clean_um = Point{typeof(1.0μm)}[
+            Point(0.0μm, 0.0μm),
+            Point(1.0μm, 0.0μm),
+            Point(1.0μm, 1.0μm),
+            Point(0.5μm, 1.0μm),
+            Point(0.0μm, 1.0μm)
+        ]
+        clean_nm = [convert(Point{typeof(1.0nm)}, p) for p in clean_um]
+        @test isempty(fp(clean_um))          # µm-based: no false positives
+        @test isempty(fp(clean_nm))          # nm-based: also none
+        @test fp(clean_um) == fp(clean_nm)   # unit-invariant
+
+        # A genuine figure-8: non-adjacent vertices 2 and 5 coincide exactly.
+        # Detected in BOTH units, identically.
+        fig8_um = Point{typeof(1.0μm)}[
+            Point(0.0μm, 0.0μm),
+            Point(5.0μm, 0.0μm),
+            Point(10.0μm, 5.0μm),
+            Point(5.0μm, 10.0μm),
+            Point(5.0μm, 0.0μm),  # coincides with index 2
+            Point(0.0μm, 10.0μm)
+        ]
+        fig8_nm = [convert(Point{typeof(1.0nm)}, p) for p in fig8_um]
+        @test fp(fig8_um) == [(2, 5)]
+        @test fp(fig8_nm) == [(2, 5)]
+    end
+
+    @testset "split_pinches preserves Turn curves through a split (both lobes)" begin
+        # A pinched contour carrying a native `Paths.Turn` arc in EACH lobe.
+        # The pinch at indices (3, 6) partitions vertices into lobe1 = {3,4,5}
+        # and lobe2 = {6,1,2}; an arc starts at index 4 (→ lobe1) and another at
+        # index 1 (→ lobe2), exercising both curve-remap branches of
+        # `_split_at_pinch`. Both arcs must survive as native Turns, not be
+        # discretized.
+        R = 5.0μm
+        pp = Point{typeof(1.0μm)}[
+            Point(0.0μm, 0.0μm),        # 1: arc B start
+            Point(0.0μm + R, R),        # 2: arc B end
+            Point(20.0μm, 20.0μm),      # 3: pinch (coincides with 6)
+            Point(30.0μm, 20.0μm),      # 4: arc A start
+            Point(30.0μm + R, 20.0μm + R), # 5: arc A end
+            Point(20.0μm, 20.0μm)       # 6: coincides with index 3 → pinch
+        ]
+        turnB = Paths.Turn(90°, R, α0=90°, p0=pp[1])
+        turnA = Paths.Turn(90°, R, α0=90°, p0=pp[4])
+        cp = CurvilinearPolygon(pp, [turnB, turnA], [1, 4])
+        r = CurvilinearRegion(cp, CurvilinearPolygon{typeof(1.0μm)}[])
+        out = SolidModels.split_pinches([r])
+        @test length(out) >= 2
+        # A Turn must survive in each of the two lobes (both remap branches ran).
+        @test all(any(c -> c isa Paths.Turn, rr.exterior.curves) for rr in out)
+        # Two native Turns total across the output — none discretized away.
+        all_curves = reduce(vcat, [rr.exterior.curves for rr in out]; init=[])
+        @test count(c -> c isa Paths.Turn, all_curves) == 2
+    end
+
+    @testset "split_pinches splits a pinch inside a hole" begin
+        # The exterior is clean; a HOLE is self-touching. split_pinches must
+        # walk holes too (find_pinch_points on each hole, split, reassign).
+        ext = CurvilinearPolygon(
+            Point{typeof(1.0μm)}[
+                Point(-50.0μm, -50.0μm),
+                Point(50.0μm, -50.0μm),
+                Point(50.0μm, 50.0μm),
+                Point(-50.0μm, 50.0μm)
+            ]
+        )
+        # Figure-8 hole: non-adjacent vertices 1 and 4 coincide.
+        hole = CurvilinearPolygon(
+            Point{typeof(1.0μm)}[
+                Point(0.0μm, 0.0μm),
+                Point(10.0μm, 0.0μm),
+                Point(5.0μm, 10.0μm),
+                Point(0.0μm, 0.0μm),   # coincides with index 1
+                Point(-10.0μm, 0.0μm),
+                Point(-5.0μm, 10.0μm)
+            ]
+        )
+        r = CurvilinearRegion(ext, [hole])
+        @test !isempty(SolidModels.ConformalRender.find_pinch_points(points(hole)))
+        out = SolidModels.split_pinches([r])
+        # Exterior stays one region; the pinched hole is cleaved into simple
+        # sub-loops (so total hole count across the output grew).
+        total_holes = sum(length(rr.holes) for rr in out)
+        @test total_holes >= 2
+        @test all(length(points(h)) >= 3 for rr in out for h in rr.holes)
     end
 end


### PR DESCRIPTION
## Summary

Adds `split_pinches(regions)` to the `ConformalRender` submodule: it splits
every self-touching `CurvilinearRegion` (on the exterior and every hole) into
simple sub-regions.

Clipper's union can produce a polygon where two non-adjacent vertices coincide
— a zero-width neck or figure-8 — which OpenCASCADE rejects with "Curve loop is
not closed" and the mesher cannot handle. `split_pinches` detects those pinches
with an O(n) hash grid (`find_pinch_points`) and cleaves the contour into
simple loops at each pinch, assigning holes to whichever exterior piece
contains them.

## Details

- Native curve segments (`Paths.Turn`, `Paths.BSpline`, `Paths.OffsetSegment`)
  are preserved by remapping `curve_start_idx` into each lobe rather than
  discretizing.
- Sub-loops with fewer than three vertices (zero-area slivers) are dropped.
- Pinches are detected at a 2 nm tolerance matching the default
  `ConformalRenderContext` `vertex_merge_atol`, so detection predicts OCC's
  behaviour after the two coincident vertices merge.

## Tests

`test/test_conformal_render.jl` covers detection, the clean-polygon no-op, the
fact that Clipper does not itself produce pinches on simple touching shapes
(documenting the class of inputs where this is unnecessary), a downstream
vertex-injection–induced pinch, an end-to-end `render_conformal!` failure that
`split_pinches` fixes, and figure-8 cleaving into two simple loops.
