### PR TITLE
Draft: Schematic graph export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format of this changelog is based on
 
 ## Unreleased
 
+### Added
+
+  - `save_schematic(dir, ::SchematicGraph)` and `save_schematic(dir, ::Schematic)` (requires
+    `using YAML`) write a read-only YAML bundle for external tooling: `topology.yml` (nodes,
+    edges, additional hooks, and vertex/edge properties, recursing into composite subgraphs),
+    `parameters.yml` (the `extract_parameter_set` result), and, when a planned `Schematic` is
+    given, `floorplan.yml` (global transformations, resolved hooks, bounds, and resolved route
+    geometry, with composite-internal nodes addressed by node-ID path). All files share a
+    `bundle` identity with the design name, a source fingerprint, the generating package
+    version, and a timestamp.
+
 ### Fixed
 
   - Curve recovery (`union2d_curved` and friends) preserves arcs from path nodes styled with

--- a/Project.toml
+++ b/Project.toml
@@ -46,6 +46,7 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 [extensions]
 ParameterSetYAMLExt = "YAML"
 SchematicGraphMakieExt = "GraphMakie"
+SchematicGraphYAMLExt = "YAML"
 
 [compat]
 Accessors = "0.1"

--- a/docs/src/reference/schematic_api.md
+++ b/docs/src/reference/schematic_api.md
@@ -123,6 +123,7 @@ SchematicDrivenLayout.check!
 SchematicDrivenLayout.build!
 SchematicDrivenLayout.render!(::SchematicDrivenLayout.AbstractCoordinateSystem, ::SchematicDrivenLayout.Schematic, ::SchematicDrivenLayout.LayoutTarget; kwargs...)
 render!(::DeviceLayout.SolidModel, ::SchematicDrivenLayout.Schematic, ::SchematicDrivenLayout.Target; kwargs...)
+SchematicDrivenLayout.save_schematic
 ```
 
 ### [Technologies](@id api-technologies)

--- a/ext/SchematicGraphYAMLExt.jl
+++ b/ext/SchematicGraphYAMLExt.jl
@@ -1,0 +1,327 @@
+module SchematicGraphYAMLExt
+
+import DeviceLayout
+import DeviceLayout:
+    Hook, HandedPointHook, Point, PointHook, StyledHook, in_direction, transformation
+import DeviceLayout.SchematicDrivenLayout:
+    AbstractCompositeComponent,
+    ComponentNode,
+    RouteComponent,
+    Schematic,
+    SchematicGraph,
+    additional_hooks,
+    component,
+    extract_parameter_set,
+    getpath,
+    graph,
+    save_parameter_set,
+    save_schematic
+import YAML
+import Unitful
+
+const SDL = DeviceLayout.SchematicDrivenLayout
+
+const TOPOLOGY_FILE = "topology.yml"
+const FLOORPLAN_FILE = "floorplan.yml"
+const PARAMETERS_FILE = "parameters.yml"
+const SCHEMA_VERSION = "1" # Advances in lockstep across all bundle files
+
+# Reuse the serialization conventions (unit-suffix plain scalars, !symbol tags)
+# from ParameterSetYAMLExt so the whole bundle shares one YAML dialect. Both
+# extensions are triggered by YAML.jl, so by the time any exported function
+# runs, the sibling extension is loaded and resolvable.
+function _parameter_set_yaml_ext()
+    ext = Base.get_extension(DeviceLayout, :ParameterSetYAMLExt)
+    isnothing(ext) &&
+        error("ParameterSetYAMLExt is not loaded. Load YAML.jl (`using YAML`) first.")
+    return ext
+end
+
+_serialize(data::Dict{String, Any}) = _parameter_set_yaml_ext()._serialize_units(data)
+
+function DeviceLayout.SchematicDrivenLayout.save_schematic(dir::String, g::SchematicGraph)
+    return _save_schematic(dir, g, nothing)
+end
+
+function DeviceLayout.SchematicDrivenLayout.save_schematic(dir::String, sch::Schematic)
+    return _save_schematic(dir, sch.graph, sch)
+end
+
+function _save_schematic(dir::String, g::SchematicGraph, sch::Union{Nothing, Schematic})
+    mkpath(dir)
+    topology = _topology_data(g, !isnothing(sch))
+    parameter_set = extract_parameter_set(g)
+    # The fingerprint covers the topology and parameters documents before the
+    # bundle identity is inserted, so identical graph states produce identical
+    # fingerprints regardless of when the bundle was generated.
+    topology_yaml = sprint(io -> YAML.write(io, _serialize(topology)))
+    parameters_yaml = sprint(io -> save_parameter_set(io, parameter_set))
+    identity = _bundle_identity(SDL.name(g), topology_yaml * parameters_yaml)
+
+    topology["bundle"] = identity
+    open(joinpath(dir, TOPOLOGY_FILE), "w") do io
+        return YAML.write(io, _serialize(topology))
+    end
+
+    # ParameterSet data is a plain string-keyed namespace tree, so the bundle
+    # identity is stored as a top-level `bundle` namespace.
+    getfield(parameter_set, :data)["bundle"] = copy(identity)
+    save_parameter_set(joinpath(dir, PARAMETERS_FILE), parameter_set)
+
+    if !isnothing(sch)
+        floorplan = _floorplan_data(sch)
+        floorplan["bundle"] = copy(identity)
+        open(joinpath(dir, FLOORPLAN_FILE), "w") do io
+            return YAML.write(io, _serialize(floorplan))
+        end
+    end
+    return dir
+end
+
+function _bundle_identity(design_id::String, document::String)
+    return Dict{String, Any}(
+        "design_id" => design_id,
+        "source_fingerprint" => SDL._bundle_fingerprint(document),
+        "generator" => "DeviceLayout v$(pkgversion(DeviceLayout))",
+        "generated_at" => SDL._bundle_timestamp()
+    )
+end
+
+##### topology.yml
+
+function _topology_data(g::SchematicGraph, has_floorplan::Bool)
+    data = Dict{String, Any}(
+        "schema_version" => SCHEMA_VERSION,
+        "name" => SDL.name(g),
+        "parameters" => PARAMETERS_FILE
+    )
+    has_floorplan && (data["floorplan"] = FLOORPLAN_FILE)
+    data["nodes"], data["edges"] = _graph_data(g, String[])
+    return data
+end
+
+function _graph_data(g::SchematicGraph, parent_segments::Vector{String})
+    nodes_list = Any[_topology_node(g, idx, parent_segments) for
+    idx in eachindex(SDL.nodes(g))]
+    edges_list = Any[_topology_edge(g, e) for e in SDL.edges(g.graph)]
+    return nodes_list, edges_list
+end
+
+function _topology_node(g::SchematicGraph, idx::Int, parent_segments::Vector{String})
+    node = SDL.nodes(g)[idx]
+    comp = component(node)
+    T = typeof(comp)
+    # Dots in node IDs denote nested parameter namespaces, matching the
+    # addressing used by `extract_parameter_set`.
+    segments = [parent_segments; String.(split(node.id, '.'))]
+    data = Dict{String, Any}(
+        "id" => node.id,
+        "component" => Dict{String, Any}(
+            "type" => string(nameof(T)),
+            "module" => join(string.(fullname(parentmodule(T))), "."),
+            "name" => SDL.name(comp),
+            "params" => join(["components"; segments], ".")
+        )
+    )
+    vertex_props = SDL.props(g.graph, idx)
+    add_hooks = get(vertex_props, :additional_hooks, nothing)
+    if !isnothing(add_hooks) && !isempty(add_hooks)
+        data["additional_hooks"] =
+            Dict{String, Any}(String(k) => _hook_data(v) for (k, v) in add_hooks)
+    end
+    properties = Dict{String, Any}(
+        String(k) => _property_value(v) for
+        (k, v) in vertex_props if k !== :additional_hooks
+    )
+    isempty(properties) || (data["properties"] = properties)
+    if comp isa AbstractCompositeComponent
+        subgraph = graph(comp)
+        sub_nodes, sub_edges = _graph_data(subgraph, segments)
+        data["subgraph"] = Dict{String, Any}(
+            "name" => SDL.name(subgraph),
+            "nodes" => sub_nodes,
+            "edges" => sub_edges
+        )
+    end
+    return data
+end
+
+function _topology_edge(g::SchematicGraph, e)
+    edge_props = SDL.props(g.graph, e)
+    n1 = SDL.nodes(g)[SDL.src(e)]
+    n2 = SDL.nodes(g)[SDL.dst(e)]
+    nodehooks = edge_props[:nodehooks]
+    data = Dict{String, Any}(
+        "nodes" => Any[n1.id, n2.id],
+        "hooks" => Any[String(nodehooks[n1]), String(nodehooks[n2])]
+    )
+    properties = Dict{String, Any}(
+        String(k) => _property_value(v) for (k, v) in edge_props if k !== :nodehooks
+    )
+    isempty(properties) || (data["properties"] = properties)
+    return data
+end
+
+# Vertex and edge properties are arbitrary user values. Values supported by
+# the ParameterSet extraction rules are exported as data; anything else is
+# exported as its `repr` string, since the bundle is inspection-only.
+function _property_value(v)
+    extracted = SDL._extracted_parameter_value(v)
+    extracted isa SDL._UnsupportedParameterValue && return repr(v)
+    return extracted
+end
+
+##### Shared geometry serialization
+
+_point_data(p::Point) = Any[p.x, p.y]
+
+function _hook_data(h::PointHook)
+    return Dict{String, Any}(
+        "kind" => "PointHook",
+        "point" => _point_data(h.p),
+        "direction" => in_direction(h)
+    )
+end
+
+function _hook_data(h::HandedPointHook)
+    data = _hook_data(getfield(h, :h))
+    data["kind"] = "HandedPointHook"
+    data["handedness"] = h.right_handed ? "right" : "left"
+    return data
+end
+
+# A StyledHook is flattened to its positional hook's data plus a `style` type
+# name, so consumers see uniform point/direction geometry for every hook.
+function _hook_data(h::StyledHook)
+    data = _hook_data(getfield(h, :h))
+    data["style"] = string(nameof(typeof(getfield(h, :style))))
+    return data
+end
+
+# Fallback for user-defined hook subtypes, which carry at least a point and an
+# inward direction.
+function _hook_data(h::Hook)
+    return Dict{String, Any}(
+        "kind" => string(nameof(typeof(h))),
+        "point" => _point_data(h.p),
+        "direction" => in_direction(h)
+    )
+end
+
+##### floorplan.yml
+
+function _floorplan_data(sch::Schematic{S}) where {S}
+    g = sch.graph
+    unit_string = string(Unitful.unit(zero(S)))
+    data = Dict{String, Any}(
+        "schema_version" => SCHEMA_VERSION,
+        "topology" => TOPOLOGY_FILE,
+        "name" => SDL.name(g),
+        "coordinate_type" => isempty(unit_string) ? "NoUnits" : unit_string
+    )
+    nodes_list = Any[]
+    routes_list = Any[]
+    for node in SDL.nodes(g)
+        # A node without a reference was never placed (e.g. planned with
+        # strict=:no after a failure), so it has no floorplan entry.
+        haskey(sch.ref_dict, node) || continue
+        entry = Dict{String, Any}("id" => node.id)
+        trans = transformation(sch, node)
+        entry["transformation"] =
+            _transformation_data(DeviceLayout.ScaledIsometry(trans), S)
+        hs = SDL.hooks(sch, node)
+        entry["hooks"] =
+            Dict{String, Any}(String(k) => _hook_data(v) for (k, v) in pairs(hs))
+        bounds_entry = _bounds_data(() -> DeviceLayout.bounds(sch, node), node.id)
+        isnothing(bounds_entry) || (entry["bounds"] = bounds_entry)
+        push!(nodes_list, entry)
+
+        comp = component(node)
+        comp isa RouteComponent && push!(routes_list, _floorplan_route(node, comp))
+    end
+    data["nodes"] = nodes_list
+    data["routes"] = routes_list
+    data["nested_nodes"] = _nested_nodes_data(sch)
+    return data
+end
+
+function _transformation_data(f::DeviceLayout.ScaledIsometry, ::Type{S}) where {S}
+    o = DeviceLayout.origin(f)
+    # Purely linear maps (e.g. the identity) have no stored origin.
+    isnothing(o) && (o = zero(Point{S}))
+    return Dict{String, Any}(
+        "origin" => _point_data(o),
+        "rotation" => DeviceLayout.rotation(f),
+        "xrefl" => DeviceLayout.xrefl(f),
+        "mag" => DeviceLayout.mag(f)
+    )
+end
+
+# Bounds require realizing component geometry, which is not guaranteed to
+# succeed for every plannable component; the entry is omitted with a warning
+# rather than failing the whole export.
+function _bounds_data(get_bounds, id::String)
+    rect = try
+        get_bounds()
+    catch e
+        @warn "Could not compute bounds for floorplan entry $id; omitting." exception = e
+        return nothing
+    end
+    return Dict{String, Any}("ll" => _point_data(rect.ll), "ur" => _point_data(rect.ur))
+end
+
+function _floorplan_route(node::ComponentNode, comp::RouteComponent)
+    r = comp.r
+    data = Dict{String, Any}(
+        "id" => node.id,
+        "p0" => _point_data(r.p0),
+        "p1" => _point_data(r.p1),
+        "α0" => r.α0,
+        "α1" => r.α1,
+        "rule_type" => string(nameof(typeof(r.rule)))
+    )
+    isempty(r.waypoints) ||
+        (data["waypoints"] = Any[_point_data(w) for w in r.waypoints])
+    isempty(r.waydirs) || (data["waydirs"] = Any[d for d in r.waydirs])
+    return data
+end
+
+function _nested_nodes_data(sch::Schematic{S}) where {S}
+    entries = Any[]
+    for idx in SDL.find_nodes(_ -> true, sch.graph)
+        # Top-level nodes (integer indices) are covered by the `nodes` list;
+        # tuple indices address composite-internal nodes at any depth.
+        idx isa Tuple || continue
+        node_path = getpath(sch.graph, idx...)
+        node = last(node_path)
+        comp = component(node)
+        entry = Dict{String, Any}("path" => Any[n.id for n in node_path])
+        trans = try
+            transformation(sch, idx)
+        catch e
+            @warn "Could not resolve transformation for nested node $(join([n.id for n in node_path], ".")); omitting." exception =
+                e
+            continue
+        end
+        entry["transformation"] =
+            _transformation_data(DeviceLayout.ScaledIsometry(trans), S)
+        # Additional hooks for a nested node live as vertex properties on its
+        # composite's subgraph.
+        subgraph = graph(component(node_path[end - 1]))
+        hs = SDL.hooks(comp)
+        add_hooks = additional_hooks(subgraph, node)
+        isempty(add_hooks) || (hs = merge(hs, (; pairs(add_hooks)...)))
+        entry["hooks"] = Dict{String, Any}(
+            String(k) => _hook_data(trans(v)) for (k, v) in pairs(hs)
+        )
+        bounds_entry = _bounds_data(
+            () -> DeviceLayout.bounds(sch, node_path...),
+            join([n.id for n in node_path], ".")
+        )
+        isnothing(bounds_entry) || (entry["bounds"] = bounds_entry)
+        push!(entries, entry)
+    end
+    return entries
+end
+
+end # module SchematicGraphYAMLExt

--- a/src/schematics/SchematicDrivenLayout.jl
+++ b/src/schematics/SchematicDrivenLayout.jl
@@ -120,6 +120,7 @@ export @component,
     rem_node!,
     replace_component!,
     route!,
+    save_schematic,
     set_parameters
 export ParameterSet,
     MissingNamespace, ParameterKeyError, resolve, leaf_params, save_parameter_set
@@ -148,6 +149,7 @@ include("components/composite_components.jl")
 include("components/builtin_components.jl")
 include("parameter_set_extraction.jl")
 include("routes.jl")
+include("schematic_export.jl")
 include("components/variants.jl")
 include("solidmodels.jl")
 include("pdktools.jl")

--- a/src/schematics/schematic_export.jl
+++ b/src/schematics/schematic_export.jl
@@ -1,0 +1,46 @@
+import SHA
+import Dates
+
+"""
+    save_schematic(dir::String, g::SchematicGraph)
+    save_schematic(dir::String, sch::Schematic)
+
+Save a read-only YAML description of a schematic into the directory `dir`
+(created if necessary), returning `dir`.
+
+The bundle is intended for consumption by external tooling (viewers, diff
+tools, documentation generators). It is not a round-trip persistence format:
+graphs cannot be reconstructed from YAML, and the export makes no claim about
+realized fabrication or simulation geometry.
+
+  - `save_schematic(dir, g::SchematicGraph)` writes `topology.yml`, describing
+    the graph's nodes (recursing into composite-component subgraphs), edges,
+    additional hooks, and vertex/edge properties, and `parameters.yml`, the
+    [`extract_parameter_set`](@ref) result for `g` in the existing
+    `ParameterSet` YAML format. Every node has an entry under
+    `components.<node id>` (dots in IDs become nested namespaces, and
+    composite subgraph components nest below their parent), which
+    `topology.yml` references through each node's `component.params` address.
+  - `save_schematic(dir, sch::Schematic)` additionally writes `floorplan.yml`
+    with the planned global transformation, resolved hooks, and bounding
+    rectangle of every top-level node, a flat `routes` list of resolved
+    `RouteComponent` endpoints and waypoints, and a flat `nested_nodes` list
+    addressing composite-internal nodes by their node-ID path.
+
+All files carry the same `bundle` identity mapping: the graph name as
+`design_id`, a `source_fingerprint` (SHA-256 of the topology and parameters
+documents with the `bundle` mapping omitted), the generating package version,
+and a UTC timestamp. In `parameters.yml`, the identity is stored as a
+top-level `bundle` namespace.
+
+Requires `YAML.jl` to be loaded (`using YAML`).
+"""
+function save_schematic end
+
+# Fingerprint and timestamp helpers live in the parent module rather than the
+# YAML extension because extensions cannot rely on loading the parent's strong
+# dependencies (SHA, Dates) on all supported Julia versions.
+_bundle_fingerprint(document::String) = "sha256:" * SHA.bytes2hex(SHA.sha256(document))
+
+_bundle_timestamp() =
+    Dates.format(Dates.now(Dates.UTC), Dates.dateformat"yyyy-mm-dd\THH:MM:SS\Z")

--- a/test/test_schematic_export.jl
+++ b/test/test_schematic_export.jl
@@ -1,0 +1,288 @@
+@testitem "Schematic YAML export" setup = [CommonTestSetup] begin
+    using .SchematicDrivenLayout
+    using YAML
+    import DeviceLayout: uparse
+
+    # Load YAML scalars back into comparable Julia values. Unit-suffixed plain
+    # scalars (the ParameterSet YAML dialect) parse as strings.
+    uq(x::AbstractString) = uparse(x)
+    uq(x) = x
+    pt(v) = Point(uq(v[1]), uq(v[2]))
+    byid(list, id) = only(filter(entry -> entry["id"] == id, list))
+    edge_between(edges, a, b) = only(filter(e -> Set(e["nodes"]) == Set(Any[a, b]), edges))
+    load_yml(dir, file) = YAML.load_file(joinpath(dir, file); dicttype=Dict{String, Any})
+
+    @compdef struct ExportLeaf <: Component
+        name = "leaf"
+        w = 20μm
+    end
+    SchematicDrivenLayout.hooks(c::ExportLeaf) = (;
+        east=HandedPointHook(Point(c.w / 2, zero(c.w)), 180°, true),
+        west=PointHook(Point(-c.w / 2, zero(c.w)), 0°)
+    )
+    SchematicDrivenLayout._geometry!(cs::CoordinateSystem, c::ExportLeaf) =
+        place!(cs, centered(Rectangle(c.w, c.w)), SemanticMeta(:metal))
+
+    @compdef struct ExportMid <: CompositeComponent
+        name = "mid"
+        w = 20μm
+    end
+    SchematicDrivenLayout._build_subcomponents(c::ExportMid) =
+        (; inner=ExportLeaf(name="inner", w=c.w))
+    function SchematicDrivenLayout._graph!(
+        g::SchematicGraph,
+        ::ExportMid,
+        subcomponents::NamedTuple
+    )
+        add_node!(g, subcomponents.inner)
+        return g
+    end
+    SchematicDrivenLayout.map_hooks(::Type{ExportMid}) =
+        Dict{Pair{Int, Symbol}, Symbol}((1 => :east) => :east, (1 => :west) => :west)
+
+    @compdef struct ExportOuter <: CompositeComponent
+        name = "outer"
+        w = 20μm
+    end
+    SchematicDrivenLayout._build_subcomponents(c::ExportOuter) =
+        (; mid=ExportMid(name="mid", w=c.w))
+    function SchematicDrivenLayout._graph!(
+        g::SchematicGraph,
+        ::ExportOuter,
+        subcomponents::NamedTuple
+    )
+        add_node!(g, subcomponents.mid)
+        return g
+    end
+    SchematicDrivenLayout.map_hooks(::Type{ExportOuter}) =
+        Dict{Pair{Int, Symbol}, Symbol}((1 => :east) => :east, (1 => :west) => :west)
+
+    @testset "Full bundle" begin
+        g = SchematicGraph("export_chip")
+        left = add_node!(g, ExportLeaf(name="left"); role="anchor")
+        outer = fuse!(g, left => :east, ExportOuter(name="outer") => :west)
+
+        # Path node with a component attached partway along it, which stores a
+        # generated additional hook on the path's vertex.
+        pa = Path(nm)
+        straight!(pa, 100μm, Paths.SimpleTrace(10μm))
+        pan = add_node!(g, pa)
+        fuse!(g, outer => :east, pan => :p0)
+        attached = attach!(g, pan, ExportLeaf(name="attached") => :west, 50μm)
+
+        # The same component instance in two nodes gets two distinct node IDs.
+        shared_comp = ExportLeaf(name="shared", w=30μm)
+        shared1 = fuse!(g, pan => :p1, shared_comp => :west)
+        shared2 = fuse!(g, shared1 => :east, shared_comp => :west)
+
+        # Fusing at a bare Hook records it as an additional hook on the node.
+        extra_hook = PointHook(Point(0μm, 10μm), -90°)
+        extra = fuse!(g, left => extra_hook, ExportLeaf(name="extra") => :west)
+
+        # An edge that plan ignores but the topology still records.
+        fuse!(g, extra => :east, shared2 => :east; PLAN_SKIPS_EDGE => true)
+
+        rnode = route!(
+            g,
+            Paths.BSplineRouting(),
+            left => :west,
+            shared2 => :east,
+            Paths.CPW(10μm, 6μm),
+            GDSMeta();
+            waypoints=[Point(-50μm, 50μm)]
+        )
+
+        sch = plan(g; log_dir=nothing)
+        dir = joinpath(tdir, "export_bundle")
+        @test save_schematic(dir, sch) == dir
+        @test isfile(joinpath(dir, "topology.yml"))
+        @test isfile(joinpath(dir, "parameters.yml"))
+        @test isfile(joinpath(dir, "floorplan.yml"))
+
+        @testset "topology.yml" begin
+            topo = load_yml(dir, "topology.yml")
+            @test topo["schema_version"] == "1"
+            @test topo["name"] == "export_chip"
+            @test topo["parameters"] == "parameters.yml"
+            @test topo["floorplan"] == "floorplan.yml"
+
+            ids = [n["id"] for n in topo["nodes"]]
+            @test ids == [n.id for n in nodes(g)]
+            @test allunique(ids)
+            @test shared1.id != shared2.id
+
+            left_entry = byid(topo["nodes"], left.id)
+            @test left_entry["component"]["type"] == "ExportLeaf"
+            @test left_entry["component"]["module"] isa String
+            @test !isempty(left_entry["component"]["module"])
+            @test left_entry["component"]["name"] == "left"
+            @test left_entry["component"]["params"] == "components.$(left.id)"
+            @test left_entry["properties"] == Dict{String, Any}("role" => "anchor")
+            # The bare-Hook fuse! hook, exported with resolved geometry.
+            add_hooks = left_entry["additional_hooks"]
+            @test length(add_hooks) == 1
+            hook_entry = only(values(add_hooks))
+            @test hook_entry["kind"] == "PointHook"
+            @test pt(hook_entry["point"]) ≈ extra_hook.p
+            @test uq(hook_entry["direction"]) ≈ -90°
+
+            # attach! records a handed hook on the path node.
+            pan_entry = byid(topo["nodes"], pan.id)
+            @test pan_entry["component"]["type"] == "Path"
+            @test pan_entry["component"]["module"] == "DeviceLayout.Paths"
+            pan_hook = only(values(pan_entry["additional_hooks"]))
+            @test pan_hook["kind"] == "HandedPointHook"
+            @test pan_hook["handedness"] in ("right", "left")
+            @test pt(pan_hook["point"]) ≈ Point(50μm, 0μm)
+
+            # Composite subgraphs recurse, with parameter addresses nesting
+            # below the parent node's namespace.
+            outer_entry = byid(topo["nodes"], outer.id)
+            @test outer_entry["component"]["type"] == "ExportOuter"
+            mid_entry = only(outer_entry["subgraph"]["nodes"])
+            @test mid_entry["id"] == "mid"
+            @test mid_entry["component"]["params"] == "components.$(outer.id).mid"
+            @test isempty(outer_entry["subgraph"]["edges"])
+            inner_entry = only(mid_entry["subgraph"]["nodes"])
+            @test inner_entry["id"] == "inner"
+            @test inner_entry["component"]["type"] == "ExportLeaf"
+            @test inner_entry["component"]["params"] == "components.$(outer.id).mid.inner"
+            @test !haskey(inner_entry, "subgraph")
+
+            edges = topo["edges"]
+            fused = edge_between(edges, left.id, outer.id)
+            @test fused["nodes"] == Any[left.id, outer.id]
+            @test fused["hooks"] == Any["east", "west"]
+            skipped = edge_between(edges, extra.id, shared2.id)
+            @test skipped["properties"]["plan_skips_edge"] == true
+            # Route endpoints are ordinary edges using the route's hook names.
+            route_p0 = edge_between(edges, left.id, rnode.id)
+            @test route_p0["hooks"][findfirst(==(rnode.id), route_p0["nodes"])] == "p0"
+            route_p1 = edge_between(edges, shared2.id, rnode.id)
+            @test route_p1["hooks"][findfirst(==(rnode.id), route_p1["nodes"])] == "p1"
+        end
+
+        @testset "parameters.yml" begin
+            ps = ParameterSet(joinpath(dir, "parameters.yml"))
+            @test resolve(ps, "components.$(left.id).w") == 20μm
+            @test resolve(ps, "components.$(outer.id).mid.inner.w") == 20μm
+            # Both nodes sharing one component instance have their own entry.
+            @test resolve(ps, "components.$(shared1.id).w") == 30μm
+            @test resolve(ps, "components.$(shared2.id).w") == 30μm
+
+            topo = load_yml(dir, "topology.yml")
+            @test resolve(ps, "bundle.design_id") == "export_chip"
+            @test resolve(ps, "bundle.source_fingerprint") ==
+                  topo["bundle"]["source_fingerprint"]
+        end
+
+        @testset "floorplan.yml" begin
+            fp = load_yml(dir, "floorplan.yml")
+            @test fp["schema_version"] == "1"
+            @test fp["topology"] == "topology.yml"
+            @test fp["name"] == "export_chip"
+            @test fp["coordinate_type"] == "nm"
+
+            entry = byid(fp["nodes"], shared1.id)
+            trans_entry = entry["transformation"]
+            @test pt(trans_entry["origin"]) ≈ origin(sch, shared1)
+            @test uq(trans_entry["rotation"]) ≈ 0°
+            @test trans_entry["xrefl"] == false
+            @test trans_entry["mag"] == 1
+            live_hooks = hooks(sch, shared1)
+            @test pt(entry["hooks"]["east"]["point"]) ≈ live_hooks.east.p
+            @test uq(entry["hooks"]["east"]["direction"]) ≈ in_direction(live_hooks.east)
+            @test entry["hooks"]["east"]["kind"] == "HandedPointHook"
+            rect = bounds(sch, shared1)
+            @test pt(entry["bounds"]["ll"]) ≈ rect.ll
+            @test pt(entry["bounds"]["ur"]) ≈ rect.ur
+
+            # The identity-placed root node still gets an explicit zero origin.
+            root_entry = byid(fp["nodes"], left.id)
+            @test pt(root_entry["transformation"]["origin"]) ≈ Point(0nm, 0nm)
+
+            # Resolved route geometry matches the planned route.
+            rentry = byid(fp["routes"], rnode.id)
+            r = component(rnode).r
+            @test pt(rentry["p0"]) ≈ r.p0
+            @test pt(rentry["p1"]) ≈ r.p1
+            @test uq(rentry["α0"]) ≈ r.α0
+            @test uq(rentry["α1"]) ≈ r.α1
+            @test rentry["rule_type"] == "BSplineRouting"
+            @test length(rentry["waypoints"]) == 1
+            @test pt(only(rentry["waypoints"])) ≈ only(r.waypoints)
+            @test !haskey(rentry, "waydirs")
+
+            # Composite-internal nodes are addressed by node-ID path.
+            nested = fp["nested_nodes"]
+            @test Set(Tuple(e["path"]) for e in nested) ==
+                  Set([(outer.id, "mid"), (outer.id, "mid", "inner")])
+            inner_fp = only(filter(e -> length(e["path"]) == 3, nested))
+            outer_idx = findfirst(==(outer), nodes(g))
+            inner_path = SchematicDrivenLayout.getpath(g, outer_idx, 1, 1)
+            @test pt(inner_fp["transformation"]["origin"]) ≈ origin(sch, inner_path...)
+            trans = transformation(sch, (outer_idx, 1, 1))
+            live_inner_east = trans(hooks(component(last(inner_path))).east)
+            @test pt(inner_fp["hooks"]["east"]["point"]) ≈ live_inner_east.p
+            @test uq(inner_fp["hooks"]["east"]["direction"]) ≈ in_direction(live_inner_east)
+            inner_rect = bounds(sch, inner_path...)
+            @test pt(inner_fp["bounds"]["ll"]) ≈ inner_rect.ll
+            @test pt(inner_fp["bounds"]["ur"]) ≈ inner_rect.ur
+        end
+
+        @testset "Bundle identity" begin
+            topo = load_yml(dir, "topology.yml")
+            fp = load_yml(dir, "floorplan.yml")
+            params = load_yml(dir, "parameters.yml")
+            for data in (topo, fp, params)
+                @test data["bundle"]["design_id"] == "export_chip"
+                @test data["bundle"]["generator"] ==
+                      "DeviceLayout v$(pkgversion(DeviceLayout))"
+                @test startswith(data["bundle"]["source_fingerprint"], "sha256:")
+                @test data["bundle"]["source_fingerprint"] ==
+                      topo["bundle"]["source_fingerprint"]
+                @test !isempty(data["bundle"]["generated_at"])
+            end
+        end
+
+        @testset "Fingerprint determinism" begin
+            # Identical graph state fingerprints identically across exports,
+            # even though timestamps differ.
+            dir_a = save_schematic(joinpath(tdir, "export_bundle_a"), g)
+            dir_b = save_schematic(joinpath(tdir, "export_bundle_b"), g)
+            topo_a = load_yml(dir_a, "topology.yml")
+            topo_b = load_yml(dir_b, "topology.yml")
+            @test topo_a["bundle"]["source_fingerprint"] ==
+                  topo_b["bundle"]["source_fingerprint"]
+        end
+    end
+
+    @testset "Stable identities after node removal" begin
+        g = SchematicGraph("removal")
+        a = add_node!(g, ExportLeaf(name="a"))
+        b = fuse!(g, a => :east, ExportLeaf(name="b") => :west)
+        c = fuse!(g, b => :east, ExportLeaf(name="c") => :west)
+        rem_node!(g, b)
+        dir = save_schematic(joinpath(tdir, "removal_bundle"), g)
+        topo = load_yml(dir, "topology.yml")
+        # Node IDs, not integer indices, identify nodes, so the export matches
+        # the live graph even after rem_node!'s swap-with-last reindexing.
+        @test [n["id"] for n in topo["nodes"]] == [n.id for n in nodes(g)]
+        @test Set(n["id"] for n in topo["nodes"]) == Set([a.id, c.id])
+        @test isempty(topo["edges"])
+    end
+
+    @testset "Graph-only export for a plan-failing graph" begin
+        g = SchematicGraph("failing")
+        n1 = add_node!(g, ExportLeaf(name="a"))
+        fuse!(g, n1 => :bogus, ExportLeaf(name="b") => :west)
+        @test_throws Exception plan(g; log_dir=nothing)
+        dir = save_schematic(joinpath(tdir, "failing_bundle"), g)
+        @test isfile(joinpath(dir, "topology.yml"))
+        @test isfile(joinpath(dir, "parameters.yml"))
+        @test !isfile(joinpath(dir, "floorplan.yml"))
+        topo = load_yml(dir, "topology.yml")
+        @test !haskey(topo, "floorplan")
+        @test topo["parameters"] == "parameters.yml"
+    end
+end


### PR DESCRIPTION
This is a draft for YAML export of graph topology, complementing `ParameterSet` export, which I'm opening for visibility/discussion. This version is scoped for read-only consumption by external tooling. Graph generation from YAML is out of scope (maybe could be convenient for part of authoring, but actual designs will have arbitrary Julia code in graph construction, requiring a full Julia project and manifest for reproducibility anyway).

The design produces a three-file bundle alongside any DL design project:

```
my_design/
  parameters.yml        # existing ParameterSet YAML, populated for every node
  topology.yml          # NEW: SchematicGraph as data (pre-plan!)
  floorplan.yml         # NEW (optional): post-plan! resolved geometry
```

Implementation is a new `SchematicGraphYAMLExt` package extension paired with
`save_parameter_set` from `ParameterSetYAMLExt`.

Example `topology.yml`:

```yaml
schema_version: "1"
parameters: parameters.yml
floorplan: floorplan.yml          # optional pointer
name: my_design

nodes:
  - id: cpw_1
    component:
      type: RouteComponent
      module: DeviceLayout
      params: components.cpw_1    # address in corresponding parameters.yml
      name: cpw_1
    additional_hooks:             # only when :additional_hooks vertex prop set
      attach_label_1:
        kind: HandedPointHook
        point: ["1mm", "1mm"]
        direction: "90°"
        handedness: left
    properties:                   # other vertex props; absent if none
      some_user_prop: 42

  - id: qubit_1
    component:
      type: ExampleStarTransmon
      module: DeviceLayout.SchematicDrivenLayout.ExamplePDK.Transmons
      params: components.qubit_1
      name: qubit_1
    subgraph:                     # present iff component is AbstractCompositeComponent
      name: qubit_1
      nodes: [...]                # recursive: same node schema
      edges: [...]                # recursive: same edge schema

edges:
  - nodes: [qubit_1, cpw_1]
    hooks: [readout, p0]
    properties:
      plan_skips_edge: true
```

There is no geometry or parameter information here. The one potential exception is if a node has `additional_hooks`, they need to be present here, with their type and geometry. This arguably could be a graph-native format but right now it's YAML for consistency with ParameterSet.

Example `floorplan.yml`:

```yaml
schema_version: "1"
topology: topology.yml
name: my_design
coordinate_type: nm                # type parameter S of Schematic{S}, as unit string

nodes:
  - id: qubit_1
    transformation:                # decomposed ScaledIsometry
      origin: ["1.5mm", "0.8mm"]
      rotation: "90°"
      xrefl: false
      mag: 1.0
    hooks:                         # resolved global pos+dir for every hook (named + additional)
      readout:
        kind: HandedPointHook
        point: ["1.6mm", "0.85mm"]
        direction: "180°"
        handedness: right
      drive:
        kind: PointHook
        point: ["1.4mm", "0.85mm"]
        direction: "0°"
    bounds:                        # global Rectangle from bounds(sch, node)
      ll: ["1.4mm", "0.7mm"]
      ur: ["1.6mm", "0.9mm"]

routes:                            # one entry per RouteComponent node, post-resolution
  - id: cpw_1
    p0: ["1.6mm", "0.85mm"]
    p1: ["3.2mm", "0.85mm"]
    α0: "0°"
    α1: "180°"
    waypoints: [["2.0mm", "0.85mm"], ["2.5mm", "1.0mm"]]
    waydirs: ["0°", "45°"]
    rule_type: BSplineRouting
    # Rule parameters could live here, current draft assumes they're in parameters.yml if needed.

nested_nodes:                      # composite-internal nodes, flattened
  - path: [unit_cell_1, qubit_2]   # tuple addressing matches find_components
    transformation: { ... }
    hooks: { ... }
    bounds: { ... }
```

This is flat while `topology.yml` is nested on the assumption that most floorplan consumers are interested in a global view of the design.

Also adds a "bundle" entry to each of the three files:

```yaml
bundle:
  source_fingerprint: "sha256:7446ae74…b1d950"
  design_id: "demo"
  generator: "DeviceLayout v1.18.0"
  generated_at: "2026-08-25T11:57:54Z"
```

---

If we ever go through a major redesign, it's worth considering different models of reproducibility/authoring, e.g. with component parameterized geometry as data along with as many manual-code finishing touches as possible (e.g. autofill). The `additional_hooks` in the SchematicGraph are also a bit impure if we really want to separate connectivity and placement. But I think we value the flexibility too much.