### PR TITLE
Better B-spline fitting error estimation and convergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,21 @@ The format of this changelog is based on
 
 ## Unreleased
 
+### Changed
+
+  - B-spline approximation of curves and offset curves (used in SolidModel and conformal
+    rendering) estimates candidate error at Gauss-Legendre nodes against the exact curve
+    and fits the candidate endpoint tangent magnitudes by least squares before
+    subdividing. Construction is several times faster and typically produces 2–5× fewer
+    subsegments at the same tolerance. Pass `errmetric=:dense` to
+    `Paths.bspline_approximation` for the previous behavior.
+
 ### Fixed
 
+  - B-spline approximation of an offset curve near or beyond a cusp (offset magnitude
+    approaching or exceeding the base curve's radius of curvature) could silently return
+    results exceeding the requested tolerance; such curves are now refined to tolerance
+    where possible and warn otherwise.
   - Curve recovery (`union2d_curved` and friends) preserves arcs from path nodes styled with
     `Plain` or `OptionalStyle` (as produced by `not_simulated`/`only_simulated` and friends),
     which previously fell back to discretization.

--- a/benchmark/bspline_approx_error_metric.jl
+++ b/benchmark/bspline_approx_error_metric.jl
@@ -27,7 +27,11 @@ function _pt_seg_dist(p, a, b)
     denom = ab.x^2 + ab.y^2
     t =
         iszero(denom) ? 0.0 :
-        clamp(Unitful.ustrip(Unitful.NoUnits, (ap.x * ab.x + ap.y * ab.y) / denom), 0.0, 1.0)
+        clamp(
+            Unitful.ustrip(Unitful.NoUnits, (ap.x * ab.x + ap.y * ab.y) / denom),
+            0.0,
+            1.0
+        )
     return norm(p - (a + t * ab))
 end
 
@@ -104,29 +108,19 @@ function bench(f; errmetric)
     return approx, t
 end
 
-@printf(
-    "%-26s %10s %10s %6s %6s %12s %12s\n",
-    "case",
-    "t_dense",
-    "t_gauss",
-    "N_d",
-    "N_g",
-    "err_d (nm)",
-    "err_g (nm)"
-)
+const METRICS = (:dense, :gauss, :gaussfit)
+
+@printf("%-26s", "case")
+for m in METRICS
+    @printf(" %10s %5s %10s", "t_$m", "N", "err (nm)")
+end
+println()
 for (name, f) in cases
-    a_dense, t_dense = bench(f; errmetric=:dense)
-    a_gauss, t_gauss = bench(f; errmetric=:gauss)
-    e_dense = true_max_error(f, a_dense)
-    e_gauss = true_max_error(f, a_gauss)
-    @printf(
-        "%-26s %9.2fms %9.2fms %6d %6d %12.3f %12.3f\n",
-        name,
-        1e3 * t_dense,
-        1e3 * t_gauss,
-        length(a_dense.segments),
-        length(a_gauss.segments),
-        Unitful.ustrip(nm, e_dense),
-        Unitful.ustrip(nm, e_gauss)
-    )
+    @printf("%-26s", name)
+    for m in METRICS
+        a, t = bench(f; errmetric=m)
+        e = true_max_error(f, a)
+        @printf(" %8.2fms %5d %10.3f", 1e3 * t, length(a.segments), Unitful.ustrip(nm, e))
+    end
+    println()
 end

--- a/benchmark/bspline_approx_error_metric.jl
+++ b/benchmark/bspline_approx_error_metric.jl
@@ -1,0 +1,132 @@
+# Prototype benchmark: dense (polyline) vs Gauss-point error metric in
+# `bspline_approximation` (memory issue sketch `bspline-approx-next-level`, direction #3).
+#
+# Run from the repo root:
+#   julia --project=. benchmark/bspline_approx_error_metric.jl
+#
+# For each case, runs `bspline_approximation` with both error metrics and reports:
+#   - wall time (minimum of several runs, after warmup)
+#   - number of output subsegments
+#   - true max error of the accepted output, measured against a dense reference
+#     discretization of the exact (offset) curve, independent of either metric.
+#     The referee polyline is fine enough that its own chord error is ≲0.2nm.
+
+using DeviceLayout
+using DeviceLayout: Paths, Point
+using DeviceLayout.Paths: BSpline, bspline_approximation, pathlength
+using DeviceLayout.PreferMicrons: μm, nm
+using LinearAlgebra: norm
+using Printf
+import Unitful
+
+# ---------- referee: true max error against dense exact reference ----------
+
+function _pt_seg_dist(p, a, b)
+    ab = b - a
+    ap = p - a
+    denom = ab.x^2 + ab.y^2
+    t =
+        iszero(denom) ? 0.0 :
+        clamp(Unitful.ustrip(Unitful.NoUnits, (ap.x * ab.x + ap.y * ab.y) / denom), 0.0, 1.0)
+    return norm(p - (a + t * ab))
+end
+
+function true_max_error(f, approx; nref=1500, nfine=1001)
+    L = pathlength(f)
+    ss = range(zero(L), L, length=nref)
+    pex = f.(ss) # exact target points (OffsetSegment call applies the offset)
+    pts = eltype(pex)[]
+    for seg in approx.segments
+        append!(pts, seg.r.(range(0.0, 1.0, length=nfine)))
+    end
+    maxd = zero(L)
+    for p in pex
+        best = Inf * oneunit(L)
+        for i = 1:(length(pts) - 1)
+            best = min(best, _pt_seg_dist(p, pts[i], pts[i + 1]))
+        end
+        maxd = max(maxd, best)
+    end
+    return maxd
+end
+
+# ---------- cases ----------
+
+# Gentle 2-point spline (typical CPW route segment)
+b_gentle = BSpline(
+    [Point(0.0μm, 0.0μm), Point(1000.0μm, 200.0μm)],
+    Point(800.0μm, 0.0μm),
+    Point(800.0μm, 0.0μm)
+)
+
+# S-curve with waypoints and moderate curvature
+b_scurve = BSpline(
+    [
+        Point(0.0μm, 0.0μm),
+        Point(300.0μm, 150.0μm),
+        Point(600.0μm, -150.0μm),
+        Point(900.0μm, 0.0μm)
+    ],
+    Point(400.0μm, 0.0μm),
+    Point(400.0μm, 0.0μm)
+)
+
+# Extreme signed curvature of the S-curve, for the near-cusp case
+κs = [Paths.signed_curvature(b_scurve, s) for s in range(0.0μm, pathlength(b_scurve), 401)]
+κ_ext = κs[argmax(abs.(κs))]
+r_min = 1 / abs(κ_ext)
+@printf("S-curve min radius of curvature: %.2f μm\n\n", Unitful.ustrip(μm, r_min))
+
+taper(L) = s -> 5.0μm + 10.0μm * s / L
+
+cases = [
+    ("gentle, off +5μm", Paths.offset(b_gentle, 5.0μm)),
+    ("gentle, off -12μm", Paths.offset(b_gentle, -12.0μm)),
+    ("S-curve, off +10μm", Paths.offset(b_scurve, 10.0μm)),
+    ("S-curve, off -10μm", Paths.offset(b_scurve, -10.0μm)),
+    ("S-curve taper 5→15μm", Paths.offset(b_scurve, taper(pathlength(b_scurve)))),
+    ("S-curve near-cusp 0.9r_min", Paths.offset(b_scurve, 0.9 / κ_ext)),
+    # At/beyond the min radius of curvature the offset curve has a cusp / a
+    # self-intersecting loop. These probe the dense metric's silent-skip
+    # behavior (samples whose normal ray misses the candidate polyline are
+    # dropped from the error estimate) vs the Gauss metric's forced refinement.
+    ("S-curve AT cusp 1.0r_min", Paths.offset(b_scurve, 1.0 / κ_ext)),
+    ("S-curve loop 1.2r_min", Paths.offset(b_scurve, 1.2 / κ_ext)),
+    # Plain (non-offset) generic Segment dispatch
+    ("Turn 90°, r=100μm", Paths.Turn(π / 2, 100.0μm; p0=Point(0.0μm, 0.0μm), α0=0.0))
+]
+
+# ---------- run ----------
+
+function bench(f; errmetric)
+    approx = bspline_approximation(f; errmetric) # warmup + reparam cache build
+    t = minimum((@elapsed bspline_approximation(f; errmetric)) for _ = 1:7)
+    return approx, t
+end
+
+@printf(
+    "%-26s %10s %10s %6s %6s %12s %12s\n",
+    "case",
+    "t_dense",
+    "t_gauss",
+    "N_d",
+    "N_g",
+    "err_d (nm)",
+    "err_g (nm)"
+)
+for (name, f) in cases
+    a_dense, t_dense = bench(f; errmetric=:dense)
+    a_gauss, t_gauss = bench(f; errmetric=:gauss)
+    e_dense = true_max_error(f, a_dense)
+    e_gauss = true_max_error(f, a_gauss)
+    @printf(
+        "%-26s %9.2fms %9.2fms %6d %6d %12.3f %12.3f\n",
+        name,
+        1e3 * t_dense,
+        1e3 * t_gauss,
+        length(a_dense.segments),
+        length(a_gauss.segments),
+        Unitful.ustrip(nm, e_dense),
+        Unitful.ustrip(nm, e_gauss)
+    )
+end

--- a/src/paths/segments/bspline_approximation.jl
+++ b/src/paths/segments/bspline_approximation.jl
@@ -1,3 +1,5 @@
+import QuadGK
+
 # Sample points used to estimate approximation error
 function _testvals(f::Paths.Segment{T}, f_approx::Paths.BSpline) where {T}
     l = Paths.pathlength(f)
@@ -135,13 +137,178 @@ end
 _default_curve_atol(::Type{<:Real}) = 1e-3
 _default_curve_atol(::Type{<:Length}) = 1nm
 
+############################################################################
+# Prototype (#3): Gauss-point error metric.
+#
+# The dense metric above builds a full discretization grid of the curve at the
+# package-default atol (1nm) and measures each exact sample against the
+# *polyline* discretization of the candidate. That has two structural problems:
+#   1. Cost scales with the 1nm grid regardless of the requested atol; post-#245
+#      this dense sampling dominates bspline_approximation.
+#   2. The polyline's own chord-height error is ~atol by construction, so the
+#      accept/reject decision carries a measurement noise floor of order atol.
+# Instead, sample a fixed, small set of Gauss-Legendre nodes per candidate and
+# intersect each exact-curve normal ray with the candidate *cubic itself* via a
+# scalar root solve. The fit error of a cubic Hermite candidate is a smooth,
+# low-frequency function of the parameter, so a modest fixed sample captures
+# its maximum well. (Same approach as kurbo / Levien's cubic fitting.)
+############################################################################
+
+# Gauss-Legendre nodes mapped from [-1, 1] to (0, 1). Endpoints are excluded
+# because the candidate interpolates them exactly.
+const _GAUSS_NODES = (QuadGK.gauss(24)[1] .+ 1) ./ 2
+
+_cross2(a::Point, b::Point) = getx(a) * gety(b) - gety(a) * getx(b)
+
+# Per-candidate exact samples at the Gauss nodes: (tgrid, exact, normal, offsets)
+# with the same semantics as _testvals. `normal` need not be normalized: it is
+# only used as a ray direction (the error is measured as a point distance).
+function _gauss_testvals(f::Paths.Segment{T}) where {T}
+    l = Paths.pathlength(f)
+    sgrid = _GAUSS_NODES * l
+    exact = f.(sgrid)
+    dir = direction.(Ref(f), sgrid)
+    normal = oneunit(T) * Point.(-sin.(dir), cos.(dir))
+    return _GAUSS_NODES, exact, normal, fill(zero(T), length(sgrid))
+end
+
+# For offset segments, sample the base curve and check the offset distance
+function _gauss_testvals(f::Paths.OffsetSegment{T}) where {T}
+    l = Paths.pathlength(f)
+    sgrid = _GAUSS_NODES * l
+    offsets = abs.(getoffset.(Ref(f), sgrid))
+    exact = f.seg.(sgrid)
+    dir = direction.(Ref(f.seg), sgrid)
+    normal = oneunit(T) * Point.(-sin.(dir), cos.(dir))
+    return _GAUSS_NODES, exact, normal, offsets
+end
+
+# Offset BSplines evaluate the interpolation directly (no arclength_to_t)
+function _gauss_testvals(f::Paths.GeneralOffset{T, BSpline{T}}) where {T}
+    tgrid = _GAUSS_NODES
+    sgrid = t_to_arclength.(Ref(f.seg), tgrid)
+    offsets = abs.(getoffset.(Ref(f), sgrid))
+    exact = f.seg.r.(tgrid)
+    tangent = first.(Paths.Interpolations.gradient.(Ref(f.seg.r), tgrid))
+    normal = Point.(-gety.(tangent), getx.(tangent))
+    return tgrid, exact, normal, offsets
+end
+
+function _gauss_testvals(f::Paths.ConstantOffset{T, BSpline{T}}) where {T}
+    tgrid = _GAUSS_NODES
+    off = abs(getoffset(f))
+    exact = f.seg.r.(tgrid)
+    tangent = first.(Paths.Interpolations.gradient.(Ref(f.seg.r), tgrid))
+    normal = Point.(-gety.(tangent), getx.(tangent))
+    return tgrid, exact, normal, fill(off, length(tgrid))
+end
+
+# Find u ∈ [0, 1] such that r(u) lies on the line through p along n, i.e.
+# g(u) = (r(u) - p) × n = 0. Newton seeded at the sample's own parameter
+# (candidates roughly preserve parameterization), bisection scan as fallback.
+# Returns nothing if the line misses the candidate entirely.
+function _ray_spline_param(p::Point, n::Point, r, t_seed)
+    u = t_seed
+    for _ = 1:20
+        g = _cross2(r(u) - p, n)
+        dg = _cross2(first(Paths.Interpolations.gradient(r, u)), n)
+        iszero(dg) && break # normal parallel to candidate tangent; use fallback
+        du = g / dg
+        u_new = u - du
+        # The interpolation is only defined on [0, 1]; if Newton steps outside
+        # (root beyond the candidate's domain, or diverging), use the fallback.
+        (u_new < 0.0 || u_new > 1.0) && break
+        u = u_new
+        abs(du) < 1e-12 && return u
+    end
+    return _ray_param_bisect(p, n, r, t_seed)
+end
+
+function _ray_param_bisect(p::Point, n::Point, r, t_seed)
+    N = 32
+    us = range(0.0, 1.0, length=N + 1)
+    gs = [_cross2(r(u) - p, n) for u in us]
+    best = nothing
+    for i = 1:N
+        glo, ghi = gs[i], gs[i + 1]
+        (sign(glo) == sign(ghi) && !iszero(glo)) && continue
+        lo, hi = us[i], us[i + 1]
+        for _ = 1:50
+            mid = (lo + hi) / 2
+            gm = _cross2(r(mid) - p, n)
+            if sign(gm) == sign(glo)
+                lo, glo = mid, gm
+            else
+                hi = mid
+            end
+        end
+        u = (lo + hi) / 2
+        # The line can cross a cubic up to 3 times; keep the root nearest the seed
+        if isnothing(best) || abs(u - t_seed) < abs(best - t_seed)
+            best = u
+        end
+    end
+    return best
+end
+
+function _approximation_error_gauss(f_approx::Paths.BSpline{T}, testvals) where {T}
+    tgrid, exact, normal, offsets = testvals
+    maxerr = zero(T)
+    for (t, p, n, off) in zip(tgrid, exact, normal, offsets)
+        u = _ray_spline_param(p, n, f_approx.r, t)
+        # A missed ray means the candidate doesn't even cross this sample's
+        # normal line: force refinement. (The dense metric silently skips such
+        # samples instead.)
+        isnothing(u) && return Inf * oneunit(T)
+        maxerr = max(maxerr, abs(norm(f_approx.r(u) - p) - off))
+    end
+    return maxerr
+end
+
+function _bspline_approximation_gauss(
+    f::Paths.Segment{T};
+    atol=_default_curve_atol(T),
+    maxits=10
+) where {T}
+    approxs = BSpline{T}[]
+    err = _approx_gauss!(approxs, f, atol, 0, maxits)
+    if err > atol
+        @warn """
+        Maximum error $err > tolerance $atol after $maxits refinement iterations.
+        Check curve $f for cusps and self-intersections, which may cause approximation to fail.
+        Increase `maxits` or manually split path to refine further, or increase `atol` to relax tolerance.
+        """
+    end
+    return CompoundSegment(convert(Vector{Segment{T}}, approxs))
+end
+
+# Push accepted candidates onto `approxs`; return the largest estimated error
+# among leaves accepted only because `maxdepth` was reached (zero if all leaves
+# converged), so the caller can warn once per curve rather than once per leaf.
+function _approx_gauss!(approxs, f::Paths.Segment{T}, atol, depth, maxdepth) where {T}
+    approx = _initial_guess(f)
+    err = _approximation_error_gauss(approx, _gauss_testvals(f))
+    if err > atol && depth < maxdepth
+        suberr = zero(T)
+        for sub in split(f, pathlength(f) / 2)
+            suberr = max(suberr, _approx_gauss!(approxs, sub, atol, depth + 1, maxdepth))
+        end
+        return suberr
+    end
+    push!(approxs, approx)
+    return err > atol ? err : zero(T)
+end
+
 # Approximate f with a BSpline
 function bspline_approximation(
     f::Paths.Segment{T};
     atol=_default_curve_atol(T),
     maxits=10,
-    rtol=nothing
+    rtol=nothing,
+    errmetric=:dense
 ) where {T}
+    # errmetric=:gauss is a prototype alternative error measurement; see above.
+    errmetric === :gauss && return _bspline_approximation_gauss(f; atol, maxits)
     # rtol is accepted for API consistency with render-time callers (e.g. OffsetSegment).
     # The internal _testvals sampling grid is construction-time, not render-time, and
     # intentionally stays at the package default atol.

--- a/src/paths/segments/bspline_approximation.jl
+++ b/src/paths/segments/bspline_approximation.jl
@@ -138,7 +138,7 @@ _default_curve_atol(::Type{<:Real}) = 1e-3
 _default_curve_atol(::Type{<:Length}) = 1nm
 
 ############################################################################
-# Prototype (#3): Gauss-point error metric.
+# Gauss-point error metric (default, via errmetric=:gaussfit or :gauss).
 #
 # The dense metric above builds a full discretization grid of the curve at the
 # package-default atol (1nm) and measures each exact sample against the
@@ -265,13 +265,100 @@ function _approximation_error_gauss(f_approx::Paths.BSpline{T}, testvals) where 
     return maxerr
 end
 
+############################################################################
+# Tangent-magnitude fitting (errmetric=:gaussfit).
+#
+# A 2-point BSpline candidate with Neumann end conditions is exactly the cubic
+# Hermite interpolant r(u) = h00(u)p₀ + h10(u)T₀ + h01(u)p₁ + h11(u)T₁ (four
+# conditions — two positions, two end derivatives — determine the cubic). With
+# endpoint positions and tangent DIRECTIONS fixed by G1 continuity, candidates
+# form a two-parameter family: T₀ = s₀t₀, T₁ = s₁t₁. The normal-direction
+# mismatch at each sample is LINEAR in (s₀, s₁), so the least-squares fit is a
+# closed-form 2×2 solve — no iterative optimizer. (Levien's cubic fitting pins
+# the same two-parameter family with area/moment constraints instead; fitted
+# cubics converge like O(h⁶) vs O(h⁴) for the fixed-magnitude initial guess.)
+############################################################################
+
+_hermite00(u) = (1 + 2u) * (1 - u)^2
+_hermite10(u) = u * (1 - u)^2
+_hermite01(u) = u^2 * (3 - 2u)
+_hermite11(u) = u^2 * (u - 1)
+
+# Least-squares fit of the tangent magnitude scales (s₀, s₁) of `approx` to the
+# exact samples in `testvals`, using `approx` itself for ray correspondence and
+# for the side of the base curve each (unsigned) offset sample lies on.
+# Returns the fitted candidate, or nothing when the fit has no leverage (e.g.
+# nearly straight: the tangents barely move points in the normal direction).
+function _fit_tangent_magnitudes(approx::Paths.BSpline{T}, testvals) where {T}
+    tgrid, exact, normal, offsets = testvals
+    pa, pb = approx.p[1], approx.p[end]
+    t0, t1 = approx.t0, approx.t1
+    uT = oneunit(T)
+    A11 = A12 = A22 = b1 = b2 = 0.0
+    nvalid = 0
+    for (t, p, n, off) in zip(tgrid, exact, normal, offsets)
+        u = _ray_spline_param(p, n, approx.r, t)
+        isnothing(u) && continue
+        n̂ = n / norm(n)
+        # Exact target point: offsets are stored unsigned, so take the side of
+        # the base curve the current candidate is on at this sample
+        d = dot(approx.r(u) - p, n̂)
+        q = p + (d < zero(d) ? -off : off) * n̂
+        a1 = _hermite10(u) * dot(t0, n̂) / uT
+        a2 = _hermite11(u) * dot(t1, n̂) / uT
+        rhs = (dot(q, n̂) - _hermite00(u) * dot(pa, n̂) - _hermite01(u) * dot(pb, n̂)) / uT
+        A11 += a1 * a1
+        A12 += a1 * a2
+        A22 += a2 * a2
+        b1 += a1 * rhs
+        b2 += a2 * rhs
+        nvalid += 1
+    end
+    nvalid < 6 && return nothing
+    det = A11 * A22 - A12 * A12
+    det <= 1e-10 * (A11 * A22 + eps()) && return nothing
+    s0 = (b1 * A22 - b2 * A12) / det
+    s1 = (b2 * A11 - b1 * A12) / det
+    # Preserve tangent directions (G1): reject sign flips and runaway scales
+    (0.05 <= s0 <= 20.0 && 0.05 <= s1 <= 20.0) || return nothing
+    return BSpline{T}([pa, pb], s0 * t0, s1 * t1)
+end
+
+# Fitted candidates are accepted only against atol scaled by this margin: a
+# near-optimal fit's error curve equioscillates (more, narrower lobes than the
+# single-lobed initial-guess error), so the fixed Gauss sample can undershoot
+# the true peak slightly. O(h⁶) convergence makes the margin cheap: ~2% extra
+# subdivision at 0.9. The unfitted acceptance test stays at plain atol,
+# matching errmetric=:gauss.
+const _FIT_ACCEPT_MARGIN = 0.9
+
+# Fit, verify with the true Gauss metric, and iterate the correspondence once
+# if the first fit is not yet within tolerance. Returns the best (candidate,
+# error) seen, never worse than the input pair.
+function _fit_and_check(approx::Paths.BSpline{T}, testvals, atol, err) where {T}
+    best, besterr = approx, err
+    cand = approx
+    for _ = 1:2
+        fitted = _fit_tangent_magnitudes(cand, testvals)
+        isnothing(fitted) && break
+        errf = _approximation_error_gauss(fitted, testvals)
+        if errf < besterr
+            best, besterr = fitted, errf
+        end
+        besterr <= _FIT_ACCEPT_MARGIN * atol && break
+        cand = fitted
+    end
+    return best, besterr
+end
+
 function _bspline_approximation_gauss(
     f::Paths.Segment{T};
     atol=_default_curve_atol(T),
-    maxits=10
+    maxits=10,
+    fit=false
 ) where {T}
     approxs = BSpline{T}[]
-    err = _approx_gauss!(approxs, f, atol, 0, maxits)
+    err = _approx_gauss!(approxs, f, atol, 0, maxits, fit)
     if err > atol
         @warn """
         Maximum error $err > tolerance $atol after $maxits refinement iterations.
@@ -285,30 +372,55 @@ end
 # Push accepted candidates onto `approxs`; return the largest estimated error
 # among leaves accepted only because `maxdepth` was reached (zero if all leaves
 # converged), so the caller can warn once per curve rather than once per leaf.
-function _approx_gauss!(approxs, f::Paths.Segment{T}, atol, depth, maxdepth) where {T}
+function _approx_gauss!(approxs, f::Paths.Segment{T}, atol, depth, maxdepth, fit) where {T}
     approx = _initial_guess(f)
-    err = _approximation_error_gauss(approx, _gauss_testvals(f))
-    if err > atol && depth < maxdepth
+    testvals = _gauss_testvals(f)
+    err = _approximation_error_gauss(approx, testvals)
+    tol = atol
+    if fit && err > atol
+        fitted, errf = _fit_and_check(approx, testvals, atol, err)
+        if errf < err
+            approx, err = fitted, errf
+            # Fitted candidates must clear the tighter acceptance threshold
+            # (see _FIT_ACCEPT_MARGIN); unfitted ones match errmetric=:gauss.
+            tol = _FIT_ACCEPT_MARGIN * atol
+        end
+    end
+    if err > tol && depth < maxdepth
         suberr = zero(T)
         for sub in split(f, pathlength(f) / 2)
-            suberr = max(suberr, _approx_gauss!(approxs, sub, atol, depth + 1, maxdepth))
+            suberr =
+                max(suberr, _approx_gauss!(approxs, sub, atol, depth + 1, maxdepth, fit))
         end
         return suberr
     end
     push!(approxs, approx)
-    return err > atol ? err : zero(T)
+    return err > tol ? err : zero(T)
 end
 
-# Approximate f with a BSpline
+# Approximate f with a BSpline.
+#
+# `errmetric` selects how candidate error is estimated:
+#   :gaussfit (default) — Gauss-point metric plus closed-form fitting of the
+#       candidate tangent magnitudes before subdividing (see above).
+#   :gauss — Gauss-point metric with fixed-magnitude candidates only.
+#   :dense — legacy metric: project a dense (package-default atol) sampling of
+#       the exact curve onto the candidate's polyline discretization. Retained
+#       for comparison during the transition; note its accept/reject decision
+#       carries a noise floor of order atol (the polyline's own chord error),
+#       and samples whose normal ray misses the candidate polyline are silently
+#       dropped from the estimate, which can accept out-of-tolerance results
+#       near cusps without warning.
 function bspline_approximation(
     f::Paths.Segment{T};
     atol=_default_curve_atol(T),
     maxits=10,
     rtol=nothing,
-    errmetric=:dense
+    errmetric=:gaussfit
 ) where {T}
-    # errmetric=:gauss is a prototype alternative error measurement; see above.
     errmetric === :gauss && return _bspline_approximation_gauss(f; atol, maxits)
+    errmetric === :gaussfit &&
+        return _bspline_approximation_gauss(f; atol, maxits, fit=true)
     # rtol is accepted for API consistency with render-time callers (e.g. OffsetSegment).
     # The internal _testvals sampling grid is construction-time, not render-time, and
     # intentionally stays at the package default atol.

--- a/test/test_bspline.jl
+++ b/test/test_bspline.jl
@@ -306,6 +306,56 @@ end
     @test_logs (:warn, r"Maximum error") Paths.bspline_approximation(cps[1].curves[1])
 end
 
+@testitem "BSpline approximation error metrics" setup = [CommonTestSetup] begin
+    # S-curve with a 68μm minimum radius of curvature
+    b = Paths.BSpline(
+        [
+            Point(0.0μm, 0.0μm),
+            Point(300.0μm, 150.0μm),
+            Point(600.0μm, -150.0μm),
+            Point(900.0μm, 0.0μm)
+        ],
+        Point(400.0μm, 0.0μm),
+        Point(400.0μm, 0.0μm)
+    )
+    L = Paths.pathlength(b)
+    taper(s) = 5.0μm + 10.0μm * s / L
+    κs = [Paths.signed_curvature(b, s) for s in range(zero(L), L, length=201)]
+    κ = κs[argmax(abs.(κs))]
+    segs = [
+        Paths.offset(b, 10.0μm),
+        Paths.offset(b, -10.0μm),
+        Paths.offset(b, taper),
+        Paths.offset(b, 0.9 / κ) # near-cusp: offset approaching radius of curvature
+    ]
+    # Deviation between exact curve and approximation, both discretized at `tol`:
+    # enclosed area / perimeter is bounded by roughly the sum of the
+    # approximation and discretization errors
+    function deviation(c, approx, tol)
+        pts = DeviceLayout.discretize_curve(c, tol)
+        pts_approx = vcat(DeviceLayout.discretize_curve.(approx.segments, tol)...)
+        poly = Polygon([pts; reverse(pts_approx)])
+        return abs(Polygons.area(poly) / perimeter(poly))
+    end
+    for f in segs
+        nsegs = Dict{Symbol, Int}()
+        for m in (:gaussfit, :gauss, :dense)
+            approx = Paths.bspline_approximation(f; errmetric=m)
+            @test deviation(f, approx, 1.0nm) < 2nm
+            @test Paths.arclength(approx) ≈ Paths.arclength(f) atol = 2nm
+            nsegs[m] = length(approx.segments)
+            # The approximation is G1: subsegments share endpoint tangent
+            # directions (magnitude fitting must not change directions)
+            for i = 1:(length(approx.segments) - 1)
+                Δα = Paths.α1(approx.segments[i]) - Paths.α0(approx.segments[i + 1])
+                @test abs(rem(Δα, 360°, RoundNearest)) < 1e-6°
+            end
+        end
+        # Tangent-magnitude fitting reduces the subdivision count
+        @test nsegs[:gaussfit] <= nsegs[:gauss]
+    end
+end
+
 @testitem "BSpline optimization" setup = [CommonTestSetup] begin
     ## 90 degree turn
     pa = Path() # auto_speed


### PR DESCRIPTION
B-spline approximation of curves and offset curves (used in SolidModel and conformal rendering) now estimates candidate error at Gauss-Legendre nodes against the exact curve and fits the candidate endpoint tangent magnitudes by least squares before subdividing. Construction is several times faster and typically produces 2–5× fewer subsegments at the same tolerance.

In the current draft you can pass `errmetric=:dense` to `Paths.bspline_approximation` for the previous behavior for easier comparison, but I may drop the legacy behavior (so far the new version is strictly better).

The next improvement would probably be to choose an initial non-uniform subdivision based on curvature change. We could also consider cusp handling (with #259 machinery) if we decide not to just treat cusps as user error.

At this point it can actually be faster to approximate then discretize a GeneralOffset than to call `discretize_curve` directly, although the latter could itself be improved. If you can amortize the approximation then it's probably worth it. ConstantOffset probably not.

For various curves, the number of segments and time, where "dense" is using the original error estimation procedure, "gauss" is the new one, and "gaussfit" combines that with fitting tangent magnitudes resulting in maximum error estimate "err_fit":

| case | N dense | N gauss | **N gaussfit** | t dense | t gauss | **t gaussfit** | err_fit (nm) |
|---|---|---|---|---|---|---|---|
| gentle ±off | 8 | 8 | **2** | 0.45–0.56 ms | 0.34 ms | **0.11–0.14 ms** | 0.36–0.81 |
| S-curve ±10 μm | 41 | 41 | **15** | ~12–13 ms | 2.2 ms | **1.5 ms** | 0.853 |
| S-curve taper 5→15 μm | 42 | 42 | **22** | 10.5 ms | 3.7 ms | **2.8 ms** | 0.849 |
| near-cusp 0.9 r_min | 69 | 69 | **27** | 16.6 ms | 3.1 ms | **2.3 ms** | 0.997 |
| AT cusp 1.0 r_min | 70 | 70 | **30** | 15.3 ms | 3.3 ms | **2.6 ms** | 0.777 |
| loop 1.2 r_min | 70 | 74 | **35** | 14.9 ms | 3.3 ms | **2.8 ms** | 0.875 |
| Turn 90° (plain) | 8 | 8 | **2** | 0.23 ms | 0.19 ms | **0.09 ms** | 0.321 |
