### PR TITLE
Small optimization in b-spline curvature calculations

### DIFF
--- a/src/paths/segments/bspline.jl
+++ b/src/paths/segments/bspline.jl
@@ -490,7 +490,7 @@ function curvatureradius(b::BSpline{T}, s) where {T}
     t = clamp(arclength_to_t(b, s), 0.0, 1.0)
     g = Interpolations.gradient(b.r, t)[1]
     h = Interpolations.hessian(b.r, t)[1]
-    return (g[1]^2 + g[2]^2)^(3 // 2) / (g[1] * h[2] - g[2] * h[1])
+    return norm(g)^3 / (g[1] * h[2] - g[2] * h[1])
 end
 
 """

--- a/src/render/discretization.jl
+++ b/src/render/discretization.jl
@@ -168,7 +168,7 @@ end
 function _bspline_signed_curvature(r, t)
     g = Paths.Interpolations.gradient(r, t)[1]
     h = Paths.Interpolations.hessian(r, t)[1]
-    return (g.x * h.y - g.y * h.x) / (g.x^2 + g.y^2)^(3 // 2)
+    return (g.x * h.y - g.y * h.x) / norm(g)^3
 end
 
 function _offset_bspline_point(s::Paths.ConstantOffset, t)


### PR DESCRIPTION
`norm(g)^3` is simpler, more consistent with other code, and measurably faster.