### PR TITLE
Quiet test output

### DIFF
--- a/src/render/termination.jl
+++ b/src/render/termination.jl
@@ -76,7 +76,12 @@ function __poly(f::Paths.Straight{T}, s::Paths.CPWOpenTermination) where {T}
 
         # Note, `min_side_len` is needed to make sure rounding happens consistently;
         # it can happen that length of the side is one grid unit smaller than expected.
-        return Polygons.Rounded(tr; p0=pts[[3, 4, 7, 8]], min_side_len=zero(tr))(
+        return Polygons.Rounded(
+            tr;
+            p0=pts[[3, 4, 7, 8]],
+            min_side_len=zero(tr),
+            selection_tolerance=DeviceLayout.onenanometer(T)
+        )(
             Polygon(pts)
         )
     end
@@ -131,8 +136,18 @@ function __poly(f::Paths.Straight{T}, s::Paths.CPWShortTermination) where {T}
     poly2 = Polygon([c0[1], c1[1], c1[2], c0[2]])
     iszero(tr) && return [poly1, poly2]
     round_idx = s.initial ? [1, 4] : [2, 3]
-    round1 = Polygons.Rounded(tr; p0=points(poly1)[round_idx], min_side_len=zero(T))
-    round2 = Polygons.Rounded(tr; p0=points(poly2)[round_idx], min_side_len=zero(T))
+    round1 = Polygons.Rounded(
+        tr;
+        p0=points(poly1)[round_idx],
+        min_side_len=zero(T),
+        selection_tolerance=DeviceLayout.onenanometer(T)
+    )
+    round2 = Polygons.Rounded(
+        tr;
+        p0=points(poly2)[round_idx],
+        min_side_len=zero(T),
+        selection_tolerance=DeviceLayout.onenanometer(T)
+    )
     return [round1(poly1), round2(poly2)]
 end
 
@@ -156,7 +171,12 @@ function __poly(f::Paths.Straight{T}, s::Paths.TraceTermination) where {T}
     poly = to_polygons(f, Paths.SimpleTrace(s.width))
     iszero(s.rounding) && return poly
     round_idx = s.initial ? [1, 4] : [2, 3]
-    return Polygons.Rounded(s.rounding; p0=points(poly)[round_idx], min_side_len=zero(T))(
+    return Polygons.Rounded(
+        s.rounding;
+        p0=points(poly)[round_idx],
+        min_side_len=zero(T),
+        selection_tolerance=DeviceLayout.onenanometer(T)
+    )(
         poly
     )
 end

--- a/src/schematics/ExamplePDK/components/ClawCapacitors/ClawCapacitors.jl
+++ b/src/schematics/ExamplePDK/components/ClawCapacitors/ClawCapacitors.jl
@@ -179,8 +179,12 @@ function _series_claw(cc)
                 gety(pt) == upperright(cutout_poly).y,
         points(cutout_poly)
     )
-    rounded =
-        Rounded(rounding; p0=points(cutout_poly)[interface_points], inverse_selection=true)
+    rounded = Rounded(
+        rounding;
+        p0=points(cutout_poly)[interface_points],
+        inverse_selection=true,
+        selection_tolerance=DeviceLayout.onenanometer(rounding)
+    )
     return rounded(cutout_poly)
 end
 

--- a/src/schematics/ExamplePDK/components/Transmons/star_island.jl
+++ b/src/schematics/ExamplePDK/components/Transmons/star_island.jl
@@ -103,7 +103,8 @@ function SchematicDrivenLayout._geometry!(cs::CoordinateSystem, isl::ExampleStar
     roundsty[1] = Rounded(
         rounding; # Outer contour: Round coupler pads and outer circumference
         p0=interface_pts, # Don't round these points so coupler interface is flat
-        inverse_selection=true
+        inverse_selection=true,
+        selection_tolerance=DeviceLayout.onenanometer(rounding)
     )
     roundsty[1, 1] = Rounded(rounding) # Inner contour: round everything
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,6 +37,61 @@ using TestItemRunner
 
     const tdir = mktempdir()
 
+    function check_test_logs(logger, allowed; required=nothing)
+        unexpected = filter(!allowed, logger.logs)
+        if !isempty(unexpected)
+            show(stderr, "text/plain", unexpected)
+            println(stderr)
+        end
+        @test isempty(unexpected)
+        isnothing(required) || @test any(required, logger.logs)
+        return
+    end
+
+    function with_test_logger(f, allowed; required=nothing)
+        logger = TestLogger()
+        try
+            result = with_logger(f, logger)
+            check_test_logs(logger, allowed; required)
+            return result
+        catch
+            check_test_logs(logger, allowed; required)
+            rethrow()
+        end
+    end
+
+    function with_expected_info(f, pattern)
+        allowed = log -> log.level < Logging.Warn
+        required = log -> log.level == Logging.Info && occursin(pattern, log.message)
+        return with_test_logger(f, allowed; required)
+    end
+
+    function quiet_test_output(f; allowed_log=(_ -> false))
+        logger = TestLogger()
+        result = mktemp() do _, io
+            try
+                return redirect_stdio(stdout=io, stderr=io) do
+                    return with_logger(f, logger)
+                end
+            catch
+                flush(io)
+                seekstart(io)
+                write(stderr, read(io))
+                isempty(logger.logs) || show(stderr, "text/plain", logger.logs)
+                rethrow()
+            end
+        end
+        unexpected = filter(logger.logs) do log
+            return log.level >= Logging.Warn && !allowed_log(log)
+        end
+        if !isempty(unexpected)
+            show(stderr, "text/plain", unexpected)
+            println(stderr)
+        end
+        @test isempty(unexpected)
+        return result
+    end
+
     # G1 continuity check: verify no angle jump exceeds the discretization step
     function check_g1_continuity(poly_pts, dθ_max)
         n = length(poly_pts)
@@ -148,6 +203,12 @@ using TestItemRunner
 
         @test n_filleted == n_line_arc
     end
+end
+
+@testsnippet QuietGmshSetup begin
+    DeviceLayout.SolidModels.gmsh.is_initialized() == 0 &&
+        DeviceLayout.SolidModels.gmsh.initialize()
+    DeviceLayout.SolidModels.set_gmsh_option("General.Verbosity", 0)
 end
 
 @run_package_tests filter =

--- a/test/test_conformal_render.jl
+++ b/test/test_conformal_render.jl
@@ -1,4 +1,4 @@
-@testitem "ConformalRender smoke" setup = [CommonTestSetup] begin
+@testitem "ConformalRender smoke" setup = [CommonTestSetup, QuietGmshSetup] begin
     using DeviceLayout:
         Point,
         Rectangle,
@@ -46,6 +46,7 @@
         # Two rectangles sharing an edge — the shared edge should resolve to
         # the same OCC tag in both loops, proving the cache works.
         sm = SolidModel("conformal_share_edge"; overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
         k = kernel(sm)
         ctx = ConformalRenderContext()
         import SpatialIndexing
@@ -90,10 +91,12 @@
         place!(cs, Rectangle(Point(10.0μm, 0.0μm), Point(20.0μm, 10.0μm)), :l1)
 
         sm_stock = SolidModel("stock"; overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
         render!(sm_stock, cs)
         n_surf_stock = length(gmsh.model.occ.getEntities(2))
 
         sm_conformal = SolidModel("conformal"; overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
         render_conformal!(sm_conformal, cs)
         n_surf_conformal = length(gmsh.model.occ.getEntities(2))
 
@@ -114,12 +117,14 @@
 
         # Default: no backstop
         sm1 = SolidModel("bs_default"; overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
         render_conformal!(sm1, cs)
         @test hasgroup(sm1, "l1", 2)
 
         # With backstop: same result (backstop runs as no-op when the cache
         # already produced conformal geometry).
         sm2 = SolidModel("bs_on"; overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
         render_conformal!(sm2, cs; fragment_backstop=true)
         @test hasgroup(sm2, "l1", 2)
 
@@ -128,6 +133,7 @@
 
     @testset "render_conformal! rejects GmshNative kernel" begin
         sm_native = SolidModel("native", SolidModels.GmshNative(); overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
         cs = CoordinateSystem("dummy", nm)
         place!(cs, Rectangle(Point(0.0μm, 0.0μm), Point(1.0μm, 1.0μm)), :l1)
         @test_throws ErrorException render_conformal!(sm_native, cs)
@@ -137,6 +143,7 @@
     @testset "add_conformal_loop! with Paths.Turn (short arc)" begin
         # Direct exercise of _add_conformal_curve!(Paths.Turn) — a 90° arc.
         sm = SolidModel("turn_short"; overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
         k = kernel(sm)
         ctx = ConformalRenderContext()
         import SpatialIndexing
@@ -154,6 +161,7 @@
     @testset "add_conformal_loop! with Paths.Turn (large arc)" begin
         # Turn with |α| >= 180° triggers the multi-segment arc path.
         sm = SolidModel("turn_large"; overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
         k = kernel(sm)
         ctx = ConformalRenderContext()
         import SpatialIndexing
@@ -171,6 +179,7 @@
     @testset "add_conformal_loop! with Paths.BSpline" begin
         # Exercise _add_conformal_curve!(Paths.BSpline).
         sm = SolidModel("bspline"; overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
         k = kernel(sm)
         ctx = ConformalRenderContext()
         import SpatialIndexing
@@ -201,6 +210,7 @@
         place!(cs, Rounded(5.0μm)(rect), :l1)
 
         sm = SolidModel("cvr"; overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
         render_conformal!(sm, cs)
         @test hasgroup(sm, "l1", 2)
         @test length(SolidModels.mesh_control_points()[(5.0, -1.0)]) == 4
@@ -208,6 +218,7 @@
         @test length(gmsh.model.occ.getEntities(2)) >= 1
 
         sm_off = SolidModel("cvr_off"; overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
         render_conformal!(sm_off, cs; curvature_sizing=false)
         @test isempty(SolidModels.mesh_control_points())
         gmsh.finalize()
@@ -222,6 +233,7 @@
         place!(cs, clipped, :l1)
 
         sm = SolidModel("holed"; overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
         render_conformal!(sm, cs)
         @test hasgroup(sm, "l1", 2)
         gmsh.finalize()
@@ -237,6 +249,7 @@
 
         ctx = ConformalRenderContext()
         sm = SolidModel("shared"; overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
         render_conformal!(sm, cs; context=ctx)
         # Each rect contributes 4 edges; a duplicated shared edge would give 8.
         # With dedup, the shared edge is 1, so total = 7.
@@ -252,6 +265,7 @@
         place!(cs, Rectangle(Point(0.0μm, 0.0μm), Point(10.0μm, 10.0μm)), :l1)
 
         sm = SolidModel("zmap"; overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
         z_target = 5.0μm
         render_conformal!(sm, cs; zmap=(_) -> z_target)
         @test hasgroup(sm, "l1", 2)
@@ -269,6 +283,7 @@
         # edge — otherwise a shared boundary between an arc-side and a
         # line-side face is non-conformal.
         sm = SolidModel("prefer_curve_arc_line"; overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
         k = kernel(sm)
         ctx = ConformalRenderContext()
         import SpatialIndexing
@@ -291,6 +306,7 @@
 
     @testset "prefer-curve invariant: spline then line on shared endpoints" begin
         sm = SolidModel("prefer_curve_spline_line"; overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
         k = kernel(sm)
         ctx = ConformalRenderContext()
         import SpatialIndexing
@@ -326,6 +342,7 @@
         place!(cs, LineSegment(Point(10.0μm, 0.0μm), Point(10.0μm, 5.0μm)), :l1)
 
         sm = SolidModel("linesegs"; overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
         render_conformal!(sm, cs)
         # `l1` should end up as a group at dim=1 (segments do not get closed
         # into a 2D face) with at least two 1D entities in the model.
@@ -338,6 +355,7 @@
         # Same Turn requested twice → second call hits the exact-key branch
         # and returns the same tag (up to sign).
         sm = SolidModel("arc_dup"; overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
         k = kernel(sm)
         ctx = ConformalRenderContext()
         import SpatialIndexing
@@ -363,6 +381,7 @@
 
     @testset "spline curve_cache exact-key hit" begin
         sm = SolidModel("spline_dup"; overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
         k = kernel(sm)
         ctx = ConformalRenderContext()
         import SpatialIndexing
@@ -400,6 +419,7 @@
         # add_conformal_loop! so we can construct the exact "two arcs on the
         # same endpoints, different centers" case without a Path adapter.
         sm = SolidModel("lens_primitive"; overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
         k = kernel(sm)
         ctx = ConformalRenderContext()
         import SpatialIndexing
@@ -458,6 +478,7 @@
         # than silently BSpline-approximating (which would leave the edge out
         # of the cache and break conformality with the caching side).
         sm = SolidModel("bad_seg"; overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
         k = kernel(sm)
         ctx = ConformalRenderContext()
         import SpatialIndexing
@@ -484,6 +505,7 @@
         place!(cs, pa, :l1)
 
         sm = SolidModel("trace_path"; overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
         render_conformal!(sm, cs)
         @test hasgroup(sm, "l1", 2)
         gmsh.finalize()
@@ -499,6 +521,7 @@
         place!(cs, pa, :l1)
 
         sm = SolidModel("taper_path"; overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
         render_conformal!(sm, cs)
         @test hasgroup(sm, "l1", 2)
         gmsh.finalize()
@@ -515,6 +538,7 @@
         place!(cs, pa, :l1)
 
         sm = SolidModel("cpw_bspline"; overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
         render_conformal!(sm, cs)
         @test hasgroup(sm, "l1", 2)
         gmsh.finalize()

--- a/test/test_corner_rounding.jl
+++ b/test/test_corner_rounding.jl
@@ -368,13 +368,13 @@
     v2 = Point(6.0, 0.0)μm
 
     # Round first line-arc corner
-    pol1 = styled_loop(semi_cp, Rounded(r_la; p0=[v1]))
+    pol1 = styled_loop(semi_cp, Rounded(r_la; p0=[v1], selection_tolerance=1nm))
     pol1_poly = to_polygons(pol1)
     pol1_pts = points(pol1_poly)
     @test length(pol1_pts) > 2
 
     # Round both line-arc corners
-    pol2 = styled_loop(pol1, Rounded(r_la; p0=[v2]))
+    pol2 = styled_loop(pol1, Rounded(r_la; p0=[v2], selection_tolerance=1nm))
     pol2_poly = to_polygons(pol2)
     pol2_pts = points(pol2_poly)
     @test length(pol2_pts) > length(pol1_pts)
@@ -419,7 +419,7 @@
         )
     end
     la_pts = simple_cp.p[line_arc_cornerindices(simple_cp)]
-    inv_sty = Rounded(0.5μm; p0=la_pts, inverse_selection=true)
+    inv_sty = Rounded(0.5μm; p0=la_pts, inverse_selection=true, selection_tolerance=1nm)
     # inverse_selection with line-arc p0: should select all straight-straight corners
     sc = cornerindices(simple_cp, inv_sty)
     @test sort(sc) == sort(cornerindices(simple_cp))
@@ -428,7 +428,7 @@
     @test isempty(la)
 
     # The inverse: selecting with those p0 points should select the line-arc corners
-    fwd_sty = Rounded(0.5μm; p0=la_pts)
+    fwd_sty = Rounded(0.5μm; p0=la_pts, selection_tolerance=1nm)
     la_fwd = line_arc_cornerindices(simple_cp, fwd_sty)
     @test sort(la_fwd) == sort(line_arc_cornerindices(simple_cp))
     sc_fwd = cornerindices(simple_cp, fwd_sty)
@@ -512,7 +512,9 @@
 
     # RelativeRounded with a p0 selection must not error on the unit promotion
     rect = Rectangle(10.0μm2nm, 10.0μm2nm)
-    rr = to_polygons(RelativeRounded(0.15; p0=[Point(0μm2nm, 0μm2nm)])(rect))
+    rr = to_polygons(
+        RelativeRounded(0.15; p0=[Point(0μm2nm, 0μm2nm)], selection_tolerance=1nm)(rect)
+    )
     @test length(points(rr)) > 20
 
     # Unitful issue addressed by Unitful.jl PR#845 bypassed
@@ -981,11 +983,14 @@ end
     @test_nowarn to_polygons(blob, Rounded(fillet_r))
 
     # Selection: a p0 point rounds only the nearest arc-arc corner; inverse_selection the rest.
-    sel = arc_arc_cornerindices(clover, Rounded(fillet_r; p0=[cusps[1]]))
+    sel = arc_arc_cornerindices(
+        clover,
+        Rounded(fillet_r; p0=[cusps[1]], selection_tolerance=1nm)
+    )
     @test sel == [1]
     inv = arc_arc_cornerindices(
         clover,
-        Rounded(fillet_r; p0=[cusps[1]], inverse_selection=true)
+        Rounded(fillet_r; p0=[cusps[1]], inverse_selection=true, selection_tolerance=1nm)
     )
     @test sort(inv) == [2, 3, 4]
 

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -1,6 +1,18 @@
 @testitem "ExamplePDK" setup = [CommonTestSetup] begin
     include("../examples/DemoQPU17/DemoQPU17.jl")
-    @time "Total" schematic, artwork = DemoQPU17.qpu17_demo(dir=tdir)
+    logger = TestLogger()
+    schematic, artwork = quiet_test_output() do
+        with_logger(logger) do
+            return DemoQPU17.qpu17_demo(dir=tdir)
+        end
+    end
+    expected_error_groups = ("bridge", "_shadow", "_leg")
+    @test all(logger.logs) do log
+        return log.level < Logging.Warn || (
+            log.level == Logging.Error &&
+            any(group -> occursin(group, log.message), expected_error_groups)
+        )
+    end
     # Check for changes to geometry
     if VERSION >= v"1.12-"
         # Julia v1.10 and v1.11 give different fingerprints
@@ -25,7 +37,7 @@
     @test ("port_2", 2) in fc_target.rendering_options.retained_physical_groups # Backwards compatibility
 end
 
-@testitem "Single Transmon" setup = [CommonTestSetup] begin
+@testitem "Single Transmon" setup = [CommonTestSetup, QuietGmshSetup] begin
     # Single transmon example file requires CSV, JSON, JSONSchema, DataFrames
     # Just test the components
     using .SchematicDrivenLayout
@@ -57,7 +69,10 @@ end
     attach!(p_readout, sref(csport), 2mm - 10μm, i=2) # @ end
     p_readout_node = add_node!(g, p_readout)
     attach!(g, p_readout_node, rres_node => :feedline, 0mm, location=1)
-    floorplan = plan(g)
+    logger = TestLogger()
+    floorplan = with_logger(logger) do
+        return plan(g; log_dir=nothing)
+    end
     # Define bounds for bounding simulation box
     chip = offset(bounds(floorplan), 2mm)[1]
     sim_area = chip
@@ -78,6 +93,13 @@ end
         ]);
         strict=:no
     )
+    expected_error_groups = ("bridge", "_shadow", "_leg")
+    @test all(logger.logs) do log
+        return log.level < Logging.Warn || (
+            log.level == Logging.Error &&
+            any(group -> occursin(group, log.message), expected_error_groups)
+        )
+    end
     # Ensure fragment and map found all the exterior boundaries: 3*4 sides of chip and vacuum boxes + top + bottom = 14
     @test length(SolidModels.dimtags(sm["exterior_boundary", 2])) == 14
     @test length(SolidModels.dimtags(sm["metal", 2])) == 7 # Island + ground + 2x leads + 2x mesh control partitions of ground + CPW trace between ports

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -6,12 +6,8 @@
             return DemoQPU17.qpu17_demo(dir=tdir)
         end
     end
-    expected_error_groups = ("bridge", "_shadow", "_leg")
     @test all(logger.logs) do log
-        return log.level < Logging.Warn || (
-            log.level == Logging.Error &&
-            any(group -> occursin(group, log.message), expected_error_groups)
-        )
+        return log.level < Logging.Warn
     end
     # Check for changes to geometry
     if VERSION >= v"1.12-"

--- a/test/test_pdktools.jl
+++ b/test/test_pdktools.jl
@@ -1,6 +1,8 @@
 @testitem "PDK Tools" setup = [CommonTestSetup] begin
     # PDK
-    SchematicDrivenLayout.generate_pdk("MyPDK"; dir=tdir, user="testuser")
+    quiet_test_output() do
+        return SchematicDrivenLayout.generate_pdk("MyPDK"; dir=tdir, user="testuser")
+    end
     pdkpath = joinpath(tdir, "MyPDK")
     using Pkg
     pdktoml = Pkg.TOML.parsefile(joinpath(pdkpath, "Project.toml"))
@@ -13,22 +15,28 @@
     # load-and-generate-component path on 1.13+; the 1.10/1.11/1.12 matrix
     # entries still exercise it.
     @static if VERSION < v"1.13-"
-        Pkg.develop(path=pdkpath)
-        using MyPDK
+        quiet_test_output() do
+            Pkg.develop(path=pdkpath)
+            @eval using MyPDK
+        end
 
         # Component package
-        SchematicDrivenLayout.without_precompile() do
-            SchematicDrivenLayout.generate_component_package(
-                "MyComps",
-                MyPDK,
-                user="testuser"
-            )
-            @test ENV["JULIA_PKG_PRECOMPILE_AUTO"] == "0" # Environment variable is not changed
+        quiet_test_output() do
+            SchematicDrivenLayout.without_precompile() do
+                SchematicDrivenLayout.generate_component_package(
+                    "MyComps",
+                    MyPDK,
+                    user="testuser"
+                )
+                @test ENV["JULIA_PKG_PRECOMPILE_AUTO"] == "0" # Environment variable is not changed
+            end
         end
         @test !haskey(ENV, "JULIA_PKG_PRECOMPILE_AUTO") # Temporary env var was removed
         comppkg = joinpath(pdkpath, "components", "MyComps")
         @test isfile(joinpath(comppkg, "test", "runtests.jl")) # Package template includes tests
-        Pkg.develop(path=comppkg)
+        quiet_test_output() do
+            return Pkg.develop(path=comppkg)
+        end
 
         # Component file
         SchematicDrivenLayout.generate_component_definition(
@@ -38,7 +46,9 @@
             composite=true
         )
         @test isfile(joinpath(comppkg, "src", "MyComposites.jl")) # File was generated
-        Pkg.rm("MyComps")
-        Pkg.rm("MyPDK")
+        quiet_test_output() do
+            Pkg.rm("MyComps")
+            return Pkg.rm("MyPDK")
+        end
     end
 end

--- a/test/test_schematic_solidmodel.jl
+++ b/test/test_schematic_solidmodel.jl
@@ -1,4 +1,4 @@
-@testitem "Schematic + SolidModel" setup = [CommonTestSetup] begin
+@testitem "Schematic + SolidModel" setup = [CommonTestSetup, QuietGmshSetup] begin
     using .SchematicDrivenLayout
     import .SchematicDrivenLayout: AbstractComponent
 
@@ -42,15 +42,35 @@
         u = base_shape(r)
 
         d[1] = Polygons.Rounded(r.d[1] / 4)
-        d[1, 1, 1, 1] = Polygons.Rounded(r.d[4] / 4, p0=u[1, 1, 1, 1].contour[[4]])
-        d[1, 2, 1, 1] = Polygons.Rounded(r.d[4] / 4, p0=u[1, 2, 1, 1].contour[[1]])
-        d[1, 3, 1, 1] = Polygons.Rounded(r.d[4] / 4, p0=u[1, 3, 1, 1].contour[[3]])
-        d[1, 4, 1, 1] = Polygons.Rounded(r.d[4] / 4, p0=u[1, 4, 1, 1].contour[[2]])
+        d[1, 1, 1, 1] = Polygons.Rounded(
+            r.d[4] / 4,
+            p0=u[1, 1, 1, 1].contour[[4]],
+            selection_tolerance=1nm
+        )
+        d[1, 2, 1, 1] = Polygons.Rounded(
+            r.d[4] / 4,
+            p0=u[1, 2, 1, 1].contour[[1]],
+            selection_tolerance=1nm
+        )
+        d[1, 3, 1, 1] = Polygons.Rounded(
+            r.d[4] / 4,
+            p0=u[1, 3, 1, 1].contour[[3]],
+            selection_tolerance=1nm
+        )
+        d[1, 4, 1, 1] = Polygons.Rounded(
+            r.d[4] / 4,
+            p0=u[1, 4, 1, 1].contour[[2]],
+            selection_tolerance=1nm
+        )
 
-        d[1, 1] = Polygons.Rounded(r.d[2] / 4, p0=u[1, 1].contour[[4]])
-        d[1, 2] = Polygons.Rounded(r.d[2] / 4, p0=u[1, 2].contour[[1]])
-        d[1, 3] = Polygons.Rounded(r.d[2] / 4, p0=u[1, 3].contour[[1]])
-        d[1, 4] = Polygons.Rounded(r.d[2] / 4, p0=u[1, 4].contour[[4]])
+        d[1, 1] =
+            Polygons.Rounded(r.d[2] / 4, p0=u[1, 1].contour[[4]], selection_tolerance=1nm)
+        d[1, 2] =
+            Polygons.Rounded(r.d[2] / 4, p0=u[1, 2].contour[[1]], selection_tolerance=1nm)
+        d[1, 3] =
+            Polygons.Rounded(r.d[2] / 4, p0=u[1, 3].contour[[1]], selection_tolerance=1nm)
+        d[1, 4] =
+            Polygons.Rounded(r.d[2] / 4, p0=u[1, 4].contour[[4]], selection_tolerance=1nm)
         return render!(cs, DeviceLayout.StyledEntity(u, d), BASE_NEGATIVE)
     end
 
@@ -70,7 +90,10 @@
     function SchematicDrivenLayout._geometry!(cs::CoordinateSystem, r::NestedSquares)
         !r.rounded && return render!(cs, base_shape(r), BASE_NEGATIVE)
         p = base_shape(r)
-        u = Polygons.Rounded(r.d[end] / 4, p0=p[1].contour[[1, 3]])(p)
+        u =
+            Polygons.Rounded(r.d[end] / 4, p0=p[1].contour[[1, 3]], selection_tolerance=1nm)(
+                p
+            )
         return render!(cs, u, BASE_NEGATIVE)
     end
 
@@ -92,7 +115,8 @@
         p = base_shape(r)
         u = Polygons.Rounded(
             norm(upperright(r.p) - lowerleft(r.p)) / 5,
-            p0=p[1].contour[[1]]
+            p0=p[1].contour[[1]],
+            selection_tolerance=1nm
         )(
             p
         )
@@ -303,7 +327,8 @@
     end
 end
 
-@testitem "Schematic + SolidModel + Paths and Bridges" setup = [CommonTestSetup] begin
+@testitem "Schematic + SolidModel + Paths and Bridges" setup =
+    [CommonTestSetup, QuietGmshSetup] begin
     using .SchematicDrivenLayout
 
     reset_uniquename!()
@@ -406,7 +431,10 @@ end
         p_readout_node = add_node!(g, p_readout)
 
         ## Position the components
-        floorplan = plan(g; log_dir=nothing)
+        logger = TestLogger()
+        floorplan = with_logger(logger) do
+            return plan(g; log_dir=nothing)
+        end
 
         # Setup an optional "fine mesh" size field.
         refinement_style = OptionalStyle(
@@ -525,6 +553,7 @@ end
         sm = SolidModel("test", overwrite=true)
         # SolidModels.set_gmsh_option("")
         render!(sm, floorplan, target)
+        @test all(log -> log.level < Logging.Warn, logger.logs)
         cp_rendered = SolidModels.mesh_control_points()
         @test !isempty(cp_rendered)
         # Solid-model projections can preserve circular path turns that the default
@@ -544,8 +573,6 @@ end
         @test !SolidModels.hasgroup(sm, "writeable_area", 2)
         @test !SolidModels.hasgroup(sm, "base_negative", 2)
 
-        # Reduce the noise in the REPL
-        SolidModels.gmsh.option.setNumber("General.Verbosity", 0)
         SolidModels.reset_mesh_control!()
         @test_nowarn SolidModels.gmsh.model.mesh.generate(3)
 
@@ -612,7 +639,7 @@ end
     end
 end
 
-@testitem "Schematic + SolidModel + Overlap Path" setup = [CommonTestSetup] begin
+@testitem "Schematic + SolidModel + Overlap Path" setup = [CommonTestSetup, QuietGmshSetup] begin
     using .SchematicDrivenLayout
     import .SchematicDrivenLayout: AbstractComponent
 
@@ -729,7 +756,7 @@ end
     end
 end
 
-@testitem "Schematic + SolidModel + Wave ports" setup = [CommonTestSetup] begin
+@testitem "Schematic + SolidModel + Wave ports" setup = [CommonTestSetup, QuietGmshSetup] begin
     using .SchematicDrivenLayout
     import .SchematicDrivenLayout: AbstractComponent
     import .SchematicDrivenLayout.ExamplePDK: add_wave_ports!
@@ -1202,7 +1229,8 @@ end
     end
 end
 
-@testitem "Schematic + SolidModel + Problematic extrusions" setup = [CommonTestSetup] begin
+@testitem "Schematic + SolidModel + Problematic extrusions" setup =
+    [CommonTestSetup, QuietGmshSetup] begin
     using .SchematicDrivenLayout
 
     # Reproducer for Gmsh booleanOperator preserve-numbering and PLC error bugs:
@@ -1562,7 +1590,8 @@ end
     end
 end
 
-@testitem "Schematic + SolidModel + levelwise extrusion signs" setup = [CommonTestSetup] begin
+@testitem "Schematic + SolidModel + levelwise extrusion signs" setup =
+    [CommonTestSetup, QuietGmshSetup] begin
     using .SchematicDrivenLayout
 
     # A levelwise layer's thickness vector indexes levels 1, 2, ...; positive thickness is

--- a/test/test_schematicdriven.jl
+++ b/test/test_schematicdriven.jl
@@ -1,4 +1,4 @@
-@testitem "Schematic-Driven Layout" setup = [CommonTestSetup] begin
+@testitem "Schematic-Driven Layout" setup = [CommonTestSetup, QuietGmshSetup] begin
     using .SchematicDrivenLayout
 
     import .SchematicDrivenLayout: AbstractComponent, AbstractCompositeComponent
@@ -73,17 +73,19 @@
 
     @variant CutoutFlipchipArrow SchematicDrivenLayout.ArrowAnnotation{typeof(1.0nm)} map_meta =
         facing new_defaults = (; cutout_margin=20μm)
-    function SchematicDrivenLayout._geometry!(
-        cs::CoordinateSystem,
-        arrow::CutoutFlipchipArrow
-    )
-        _geometry!(cs, base_variant(arrow))
-        map_metadata!(cs, facing)
-        return place!(
-            cs,
-            offset(bounds(cs), parameters(arrow).cutout_margin)[1],
-            SemanticMeta(:base_negative)
+    quiet_test_output() do
+        @eval function SchematicDrivenLayout._geometry!(
+            cs::CoordinateSystem,
+            arrow::CutoutFlipchipArrow
         )
+            _geometry!(cs, base_variant(arrow))
+            map_metadata!(cs, facing)
+            return place!(
+                cs,
+                offset(bounds(cs), parameters(arrow).cutout_margin)[1],
+                SemanticMeta(:base_negative)
+            )
+        end
     end
     @testset "Variants" begin
         cs = geometry(CutoutFlipchipArrow(; cutout_margin=10μm))
@@ -206,12 +208,24 @@
         g2 = SchematicGraph("test_graph_attach")
         template_node2 = add_node!(g2, template(name="template_2"))
         @test_throws "No matching hook" fuse!(g2, template_node2 => :bq, bq)
-        SchematicDrivenLayout.matching_hook(::TestComponent, ::Symbol, ::TestComponent) = :z
+        use_test_matching_hook = Ref(true)
+        use_test_matching_hooks = Ref(false)
+        function SchematicDrivenLayout.matching_hook(
+            t1::TestComponent,
+            s::Symbol,
+            ::TestComponent
+        )
+            return use_test_matching_hook[] ? :z :
+                   SchematicDrivenLayout.matching_hook(t1, s, Spacer())
+        end
+        function SchematicDrivenLayout.matching_hooks(t1::TestComponent, ::TestComponent)
+            return use_test_matching_hooks[] ? (:xy, :qubit) :
+                   SchematicDrivenLayout.matching_hooks(t1, Spacer())
+        end
         bq_node2 = fuse!(g2, template_node2 => :bq, bq)
         z_node2 = fuse!(g2, bq_node2, zline => :qubit)
         @test_throws "No matching hook" fuse!(g2, bq_node2, xyline)
-        SchematicDrivenLayout.matching_hooks(::TestComponent, ::TestComponent) =
-            (:xy, :qubit)
+        use_test_matching_hooks[] = true
         xy_node2 = fuse!(g2, bq_node2, xyline)
         floorplan2 = plan(g2; log_dir=nothing)
         @test transformation(floorplan2, bq_node2) == transformation(floorplan, bq_node)
@@ -230,10 +244,8 @@
         @test transformation(floorplan2, xy_node2) == transformation(floorplan, xy_node)
 
         # Reset matching hooks to something that returns original error
-        SchematicDrivenLayout.matching_hook(t1::TestComponent, s::Symbol, ::TestComponent) =
-            SchematicDrivenLayout.matching_hook(t1, s, Spacer())
-        SchematicDrivenLayout.matching_hooks(t1::TestComponent, ::TestComponent) =
-            SchematicDrivenLayout.matching_hooks(t1, Spacer())
+        use_test_matching_hook[] = false
+        use_test_matching_hooks[] = false
 
         # `rem_node!` drops the node from `nodes` and from the name lookup. `node_dict` is
         # keyed by `Symbol`, as `add_node!` inserts it, so deleting with the node's `String`
@@ -334,7 +346,10 @@
                 meta
             )
             log_dir = mktempdir()
-            floorplan = plan(g; log_dir=log_dir)
+            logger = TestLogger()
+            floorplan = with_logger(logger) do
+                return plan(g; log_dir=log_dir)
+            end
             check!(floorplan)
             @test_throws "Encountered errors" build!(floorplan)
             build!(floorplan; strict=:no)
@@ -343,6 +358,12 @@
                 read(floorplan.logger.logname, String),
                 "Could not automatically route"
             )
+            @test all(logger.logs) do log
+                return log.level < Logging.Warn || (
+                    log.level == Logging.Error &&
+                    occursin("Could not automatically route", log.message)
+                )
+            end
         end
 
         @testset "Check" begin
@@ -489,9 +510,23 @@
                 comp3_node = fuse!(g, comp2_node => :hook1, qubit[3] => :hook2)
                 comp4_node = fuse!(g, comp3_node => :hook1, qubit[4] => :hook2)
                 fuse!(g, comp4_node => :hook1, comp1_node => :hook1)
-                @test_throws "Encountered errors" plan(g; log_dir=nothing)
+                allowed_cycle_log =
+                    log ->
+                        log.level == Logging.Error && (
+                            occursin("overconstrained", log.message) ||
+                            occursin("Failed to plan", log.message)
+                        )
+                @test_throws "Encountered errors" with_test_logger(
+                    allowed_cycle_log;
+                    required=allowed_cycle_log
+                ) do
+                    return plan(g; log_dir=nothing)
+                end
                 log_dir = mktempdir()
-                floorplan = plan(g; strict=:no, log_dir=log_dir)
+                floorplan =
+                    with_test_logger(allowed_cycle_log; required=allowed_cycle_log) do
+                        return plan(g; strict=:no, log_dir=log_dir)
+                    end
                 @test SchematicDrivenLayout.max_level_logged(floorplan, :plan) ==
                       Logging.Error
                 @test contains(read(floorplan.logger.logname, String), "is overconstrained")
@@ -566,13 +601,21 @@
         render!(cs, rect, GDSMeta(2, 2))
 
         cell = Cell("test", nm)
-        render!(cell, cs, ArtworkTarget(tech; levels=[1])) # meta, undef_meta, GDSMeta(2,2)
+        @test_logs (:warn, r"Target technology") render!(
+            cell,
+            cs,
+            ArtworkTarget(tech; levels=[1])
+        ) # meta, undef_meta, GDSMeta(2,2)
         @test cell.element_metadata == [GDSMeta(), GDSMeta(), GDSMeta(2, 2)]
         cell = Cell("test", nm)
         render!(cell, cs, ArtworkTarget(tech; levels=[2])) # facing(meta), (:GDS2_2,2,2), GDSMeta(2,2)
         @test cell.element_metadata == [GDSMeta(), GDSMeta(2, 2), GDSMeta(2, 2)]
         cell = Cell("test", nm)
-        render!(cell, cs, ArtworkTarget(tech; levels=[1, 2], indexed_layers=[:GDS2_2]))
+        @test_logs (:warn, r"Target technology") render!(
+            cell,
+            cs,
+            ArtworkTarget(tech; levels=[1, 2], indexed_layers=[:GDS2_2])
+        )
         @test cell.element_metadata ==
               [GDSMeta(), GDSMeta(300), GDSMeta(302, 4), GDSMeta(), GDSMeta(2, 2)]
         @test SchematicDrivenLayout.map_layer(ArtworkTarget(tech), SemanticMeta(:GDS2)) ==
@@ -583,7 +626,7 @@
         target.map_meta_dict[meta] = nothing
         target.map_meta_dict[GDSMeta(2, 2)] = GDSMeta(3, 3)
         cell = Cell("test", nm)
-        render!(cell, cs, target) # undef_meta, GDSMeta(2,2)
+        @test_logs (:warn, r"Target technology") render!(cell, cs, target) # undef_meta, GDSMeta(2,2)
         @test cell.element_metadata == [GDSMeta(), GDSMeta(3, 3)]
 
         @testset "Target style helpers" begin
@@ -596,7 +639,19 @@
                 (not_solidmodel!, artwork, solidmodel),
                 (only_solidmodel!, solidmodel, artwork)
             )
-            nrendered(cs, target) = length(elements(flatten(Cell(cs, nm, target))))
+            function nrendered(cs, target)
+                logger = TestLogger()
+                cell = with_logger(logger) do
+                    return flatten(Cell(cs, nm, target))
+                end
+                @test all(logger.logs) do log
+                    return log.level == Logging.Warn && occursin(
+                        "Target technology does not have a mapping",
+                        log.message
+                    )
+                end
+                return length(elements(cell))
+            end
 
             @testset "Coordinate-system references" begin
                 arr!(parent, child) = addarr!(
@@ -705,7 +760,7 @@
                     rot=30°
                 )
 
-                pa = Path(Point(0μm, 0μm))
+                pa = Path(Point(0μm, 0μm); metadata=meta)
                 straight!(pa, 100μm, Paths.SimpleTrace(10.0μm))
                 turn!(pa, 90°, 50μm)
                 attach!(pa, attached, 25μm; i=2)
@@ -747,7 +802,7 @@
             end
 
             @testset "Path and Cell arrays preserve their shape" begin
-                array_path = Path(Point(0μm, 0μm))
+                array_path = Path(Point(0μm, 0μm); metadata=meta)
                 straight!(array_path, 10μm, Paths.SimpleTrace(1.0μm))
                 array_cell = Cell("array_cell", nm)
                 render!(array_cell, rect, GDSMeta())
@@ -956,13 +1011,14 @@
             fuse!(g, n1 => :z, subcomps.pz => :p0)
             return g
         end
-        SchematicDrivenLayout.map_hooks(::Type{Test2BQ}) = Dict{Pair{Int, Symbol}, Symbol}()
+        test_hook_map = Ref(Dict{Pair{Int, Symbol}, Symbol}())
+        SchematicDrivenLayout.map_hooks(::Type{Test2BQ}) = test_hook_map[]
 
         bq2 = Test2BQ(; name="2bq", jj_width=200nm)
         @test SchematicDrivenLayout.decompose_hookname(bq2, :_1_xy) == (1 => :xy)
         @test_throws "No hook" SchematicDrivenLayout.decompose_hookname(bq2, :_1_q)
 
-        SchematicDrivenLayout.map_hooks(::Type{Test2BQ}) =
+        test_hook_map[] =
             Dict((1 => :xy) => :xy1, (2 => :xy) => :xy2, (1 => :z) => :z1, (2 => :z) => :z2)
         empty!(bq2._hooks)
 
@@ -1265,11 +1321,11 @@
         cc = MyCompositeComponent(; templates=(; subcomp1, subcomp2))
         @test SchematicDrivenLayout.filter_parameters(MySubComponent, cc) ==
               Dict(:length => 2mm)
-        @test SchematicDrivenLayout.filter_parameters(
+        @test (@test_logs (:warn, r"No shared parameters") SchematicDrivenLayout.filter_parameters(
             MySubComponent,
             cc,
             except=[:length]
-        ) == Dict()
+        )) == Dict()
         @test SchematicDrivenLayout.filter_parameters(subcomp1, cc) == Dict(:width => 2mm)
         @test_logs (:warn, r"No shared parameters") SchematicDrivenLayout.filter_parameters(
             Spacer,

--- a/test/test_shapes.jl
+++ b/test/test_shapes.jl
@@ -58,12 +58,18 @@
     @test_nowarn render!(Cell("test", nm), cs)
 
     # Rounding of subset of vertices with style
-    rs1 = Polygons.Rounded(0.25μm, p0=points(r1)[[1, 3]])(r1)
-    rs2 = Polygons.Rounded(0.25μm, p0=points(r2)[[1, 3]])(r2)
+    rs1 = Polygons.Rounded(0.25μm, p0=points(r1)[[1, 3]], selection_tolerance=1nm)(r1)
+    rs2 = Polygons.Rounded(0.25μm, p0=points(r2)[[1, 3]], selection_tolerance=1nm)(r2)
 
     # Clipping subrounded style
     rd1 = Polygons._round_poly(difference2d(r1, r2), 0.25μm, corner_indices=[1, 3])
-    rd2 = Polygons.Rounded(0.25μm, p0=points(r1)[[1, 3]])(difference2d(r1, r2))
+    rd2 = with_test_logger(
+        log ->
+            log.level == Logging.Warn &&
+                occursin("Non-finite selection tolerance", log.message)
+    ) do
+        return Polygons.Rounded(0.25μm, p0=points(r1)[[1, 3]])(difference2d(r1, r2))
+    end
     @test all(isapprox.(to_polygons(rd1), to_polygons(rd2), atol=0.1nm))
 
     # StyleDict to apply different style at each level.
@@ -158,7 +164,11 @@
     @test to_polygons(DeviceLayout.styled(rd1, d3)) == to_polygons(rds)
 
     # Apply a Rounding style specified by target points
-    sty = Polygons.Rounded(2.0μm, p0=[Point(1.0μm, 1.0μm), Point(-1.0μm, -1.0μm)])
+    sty = Polygons.Rounded(
+        2.0μm,
+        p0=[Point(1.0μm, 1.0μm), Point(-1.0μm, -1.0μm)],
+        selection_tolerance=1nm
+    )
     r = centered(Rectangle(2.0μm, 2.0μm))
     rs = styled(r, sty)
     cs = CoordinateSystem("test", nm)
@@ -188,7 +198,8 @@
     sty = Polygons.Rounded(
         2.0μm,
         p0=[Point(1.0μm, 1.0μm), Point(-1.0μm, -1.0μm)],
-        inverse_selection=true
+        inverse_selection=true,
+        selection_tolerance=1nm
     )
     rs = styled(r, sty)
     cs = CoordinateSystem("test", nm)
@@ -216,7 +227,7 @@
 
     r = Rectangle(2μm, 1μm)
     cs_local = CoordinateSystem("test", μm)
-    sty = Rounded(0.25μm, p0=points(r))
+    sty = Rounded(0.25μm, p0=points(r), selection_tolerance=1nm)
     place!(cs_local, styled(r, sty), GDSMeta())
     cs = CoordinateSystem("outer", nm)
     addref!(cs, sref(cs_local, angle=π / 2))
@@ -229,7 +240,7 @@
     # mixing rendering units works, and directly on polygons works
     r = to_polygons(Rectangle(2μm, 1μm))
     cs_local = CoordinateSystem("test", nm)
-    sty = Rounded(0.25μm, p0=points(r))
+    sty = Rounded(0.25μm, p0=points(r), selection_tolerance=1nm)
     place!(cs_local, styled(r, sty), GDSMeta())
     cs = CoordinateSystem("outer", nm)
     addref!(cs, sref(cs_local, angle=π / 2))
@@ -271,8 +282,20 @@
         difference2d(centered(Rectangle(4.0μm, 4.0μm)), centered(Rectangle(2.0μm, 2.0μm)))
 
     sty = StyleDict()
-    sty[1] = RelativeRounded(0.5, p0=[Point(2.0μm, 2.0μm), Point(-2.0μm, -2.0μm)])
-    sty[1, 1] = RelativeRounded(0.5, p0=[Point(2.0μm, -2.0μm), Point(-2.0μm, 2.0μm)])
+    sty[1] = with_test_logger(
+        log ->
+            log.level == Logging.Warn &&
+                occursin("Non-finite selection tolerance", log.message)
+    ) do
+        return RelativeRounded(0.5, p0=[Point(2.0μm, 2.0μm), Point(-2.0μm, -2.0μm)])
+    end
+    sty[1, 1] = with_test_logger(
+        log ->
+            log.level == Logging.Warn &&
+                occursin("Non-finite selection tolerance", log.message)
+    ) do
+        return RelativeRounded(0.5, p0=[Point(2.0μm, -2.0μm), Point(-2.0μm, 2.0μm)])
+    end
     e = styled(poly, sty)
     # correct end points removed
     pp = points(to_polygons(e)[1])
@@ -302,7 +325,13 @@
     c = Cell("test", nm)
     @test_nowarn render!(c, cs)
 
-    er = Rotation(90°)(e)
+    er = with_test_logger(
+        log ->
+            log.level == Logging.Warn &&
+                occursin("Non-finite selection tolerance", log.message)
+    ) do
+        return Rotation(90°)(e)
+    end
     pp = points(Rotation(-90°)(to_polygons(er)[1]))
     # Should be equivalent to original (although keyhole will be different)
     # correct end points removed
@@ -337,7 +366,13 @@
     r1 = centered(Rectangle(2.0μm, 2.0μm))
     r2 = centered(Rectangle(4.0μm, 4.0μm))
     p0 = [Point(1.0μm, 1.0μm)] # should be only point on outer poly
-    sty = Rounded(1.0μm; p0)
+    sty = with_test_logger(
+        log ->
+            log.level == Logging.Warn &&
+                occursin("Non-finite selection tolerance", log.message)
+    ) do
+        return Rounded(1.0μm; p0)
+    end
 
     # Removes top right
     pp = points(to_polygons(styled(r1, sty)))
@@ -935,7 +970,16 @@ end
         @test characters_demo(path) == 60138 # bytes written
         rm(path; force=true)
         path = joinpath(tdir, "referenced_characters.gds")
-        @test referenced_characters_demo(path, verbose_override=true) == 2460
+        logger = TestLogger()
+        result = with_logger(logger) do
+            return referenced_characters_demo(path, verbose_override=true)
+        end
+        @test result == 2460
+        @test length(logger.logs) == 4
+        @test all(
+            log -> log.level == Logging.Warn && occursin("Cannot render", log.message),
+            logger.logs
+        )
         rm(path; force=true)
         path = joinpath(tdir, "scripted.gds")
         @test scripted_demo(path) == 8682

--- a/test/test_solidmodel.jl
+++ b/test/test_solidmodel.jl
@@ -1,4 +1,4 @@
-@testitem "SolidModels" setup = [CommonTestSetup] begin
+@testitem "SolidModels" setup = [CommonTestSetup, QuietGmshSetup] begin
     import DeviceLayout.SolidModels.STP_UNIT
     pa = Path(0nm, 0nm)
     turn!(pa, -90°, 50μm, Paths.SimpleTrace(10μm))
@@ -102,8 +102,6 @@
             atol=1e-6 # If discretized, the right boundary is < 61 (atol ~1e-4)
         )
     )
-    # Reduce the noise in the REPL
-    SolidModels.gmsh.option.setNumber("General.Verbosity", 0)
     @test_nowarn SolidModels.gmsh.model.mesh.generate(3) # Should run without error
 
     # Try native kernel
@@ -185,7 +183,7 @@
     ymax = maximum(getindex.(pcorner, 2))
     # Find the coordinates of all points which have at least one coordinate at one of these limits
     pp = filter(c -> c[1] ≈ xmin || c[1] ≈ xmax || c[2] ≈ ymin || c[2] ≈ ymax, pcorner)
-    rs = RelativeRounded(0.25; inverse_selection=true, p0=pp)
+    rs = RelativeRounded(0.25; inverse_selection=true, p0=pp, selection_tolerance=1nm)
     rsc = rs(union2d([sc]))
     prim = SolidModels.to_primitives(sm, rsc)
 
@@ -490,7 +488,14 @@
     @test length(SolidModels.gmsh.model.get_entities(3)) == 0
 
     cs = CoordinateSystem("test", nm)
-    place!(cs, Polygons.Rounded(0.25μm, p0=points(r1)[[1, 3]])(u), SemanticMeta(:test))
+    selected_rounding = with_test_logger(
+        log ->
+            log.level == Logging.Warn &&
+                occursin("Non-finite selection tolerance", log.message)
+    ) do
+        return Polygons.Rounded(0.25μm, p0=points(r1)[[1, 3]])
+    end
+    place!(cs, selected_rounding(u), SemanticMeta(:test))
     sm = SolidModel("test"; overwrite=true)
     @test_nowarn render!(sm, cs)
     @test SolidModels.hasgroup(sm, "test", 2)
@@ -548,12 +553,11 @@
     sm = SolidModel("test"; overwrite=true)
     render!(sm, cs)
     @test SolidModels.to_primitives(sm, e) === e
-    @test SolidModels.to_primitives(sm, e; rounded=true) === e
-    @test length(points(SolidModels.to_primitives(sm, e; rounded=false))) == 8
+    @test length(points(SolidModels.to_primitives(sm, e; Δθ=360° / 8))) == 8
     @test length(points(SolidModels.to_primitives(sm, e; Δθ=pi / 2))) == 4
     smg = SolidModel("test_gmsh_ellipse", SolidModels.GmshNative(); overwrite=true)
     @test SolidModels.to_primitives(smg, e) isa Polygon
-    @test length(points(SolidModels.to_primitives(smg, e; rounded=false))) == 8
+    @test length(points(SolidModels.to_primitives(smg, e; Δθ=360° / 8))) == 8
     cs = CoordinateSystem("test_gmsh_ellipse", nm)
     place!(cs, e, SemanticMeta(:test))
     @test_nowarn render!(smg, cs)
@@ -573,7 +577,10 @@
     prim1 = SolidModels.to_primitives(sm, cp)
     prim2 = SolidModels.to_primitives(
         sm,
-        styled(Rectangle(1.0μm, 1.0μm), Rounded(1.0μm, p0=[Point(1.0μm, 1.0μm)]))
+        styled(
+            Rectangle(1.0μm, 1.0μm),
+            Rounded(1.0μm, p0=[Point(1.0μm, 1.0μm)], selection_tolerance=1nm)
+        )
     )
     # Manually check the fields given Turn is mutable.
     function test_turn(x, y, op)
@@ -626,10 +633,10 @@
         [Point(0.0μm, 0.0μm), Point(1.0μm, 0.0μm), Point(1.0μm, 1.0μm), Point(0.0μm, 1.0μm)]
     poly = Polygon(pp)
     sty = [
-        RelativeRounded(0.05, p0=[pp[1]]),
-        RelativeRounded(0.125, p0=[pp[2]]),
-        RelativeRounded(0.25, p0=[pp[3]]),
-        RelativeRounded(0.5, p0=[pp[4]])
+        RelativeRounded(0.05, p0=[pp[1]], selection_tolerance=1nm),
+        RelativeRounded(0.125, p0=[pp[2]], selection_tolerance=1nm),
+        RelativeRounded(0.25, p0=[pp[3]], selection_tolerance=1nm),
+        RelativeRounded(0.5, p0=[pp[4]], selection_tolerance=1nm)
     ]
     psty = styled(styled(styled(styled(poly, sty[1]), sty[2]), sty[3]), sty[4])
     pri = SolidModels.to_primitives(sm, psty)
@@ -661,8 +668,8 @@
     cs = CoordinateSystem("abc", nm)
     place!(cs, cc, SemanticMeta(:test))
     place!(cs, Rounded(1.0μm)(cc), SemanticMeta(:test))
-    sty1 = Rounded(2.0μm, p0=points(r))
-    sty2 = Rounded(0.5μm, p0=points(ss))
+    sty1 = Rounded(2.0μm, p0=points(r), selection_tolerance=1nm)
+    sty2 = Rounded(0.5μm, p0=points(ss), selection_tolerance=1nm)
     cs = CoordinateSystem("abc", nm)
     place!(cs, styled(styled(cc, sty1), sty2), SemanticMeta(:test))
     @test_nowarn render!(SolidModel("test"; overwrite=true), cs)
@@ -909,7 +916,11 @@
     @test SolidModels.to_primitives(sm, styled(e, sty); simulation=false) == e
 
     # Apply a Rounding style specified by target points
-    sty = Polygons.Rounded(1.0μm, p0=[Point(1.0μm, 1.0μm), Point(-1.0μm, -1.0μm)])
+    sty = Polygons.Rounded(
+        1.0μm,
+        p0=[Point(1.0μm, 1.0μm), Point(-1.0μm, -1.0μm)],
+        selection_tolerance=1nm
+    )
     r = centered(Rectangle(2.0μm, 2.0μm))
     rs = styled(r, sty)
     cs = CoordinateSystem("test", nm)
@@ -1009,8 +1020,8 @@
     m_sty = MeshSized(0.25μm)
     for e ∈
         [styled(r, r_sty), styled(styled(r, r_sty), m_sty), styled(styled(r, m_sty), r_sty)]
-        cs = CoordinateSystem("test", nm)
-        sm = test_sm()
+        local cs = CoordinateSystem("test", nm)
+        local sm = test_sm()
         place!(cs, e, SemanticMeta(:test))
         render!(sm, cs)
         # 8 vertices, 4 radius origins
@@ -1025,8 +1036,8 @@
         OptionalStyle(Polygons.Rounded(0.25μm), :rounded, false_style=DeviceLayout.Plain())
     e = styled(styled(r, r_sty), m_sty)
     for rounded ∈ (false, true)
-        cs = CoordinateSystem("test", nm)
-        sm = test_sm()
+        local cs = CoordinateSystem("test", nm)
+        local sm = test_sm()
         place!(cs, e, SemanticMeta(:test))
         render!(sm, cs, rounded=rounded)
         @test length(SolidModels.gmsh.model.get_entities(0)) == (rounded ? 12 : 4)
@@ -1039,8 +1050,8 @@
     m_sty = OptionalStyle(MeshSized(0.25μm), :meshed)
     e = styled(styled(r, m_sty), r_sty)
     for meshed ∈ (false, true)
-        cs = CoordinateSystem("test", nm)
-        sm = test_sm()
+        local cs = CoordinateSystem("test", nm)
+        local sm = test_sm()
         place!(cs, e, SemanticMeta(:test))
         render!(sm, cs, meshed=meshed)
         @test length(SolidModels.gmsh.model.get_entities(0)) == 12
@@ -1063,8 +1074,8 @@
     # Adding sizing does not change the primitive
     for e ∈
         [styled(c, r_sty), styled(styled(c, r_sty), m_sty), styled(styled(c, m_sty), r_sty)]
-        cs = CoordinateSystem("test", nm)
-        sm = test_sm()
+        local cs = CoordinateSystem("test", nm)
+        local sm = test_sm()
         place!(cs, e, SemanticMeta(:test))
         render!(sm, cs)
         # 16 vertices, 8 radius origins
@@ -1080,8 +1091,8 @@
     m_sty = MeshSized(0.25μm)
     e = styled(styled(c, r_sty), m_sty)
     for rounded ∈ (false, true)
-        cs = CoordinateSystem("test", nm)
-        sm = test_sm()
+        local cs = CoordinateSystem("test", nm)
+        local sm = test_sm()
         place!(cs, e, SemanticMeta(:test))
         render!(sm, cs, rounded=rounded)
         @test length(SolidModels.gmsh.model.get_entities(0)) == (rounded ? 24 : 8)
@@ -1101,8 +1112,8 @@
     )
     e = styled(poly, r_sty)
     for rounded ∈ (false, true)
-        cs = CoordinateSystem("test", nm)
-        sm = test_sm()
+        local cs = CoordinateSystem("test", nm)
+        local sm = test_sm()
         place!(cs, e, SemanticMeta(:test))
         render!(sm, cs, rounded=rounded)
         @test length(SolidModels.gmsh.model.get_entities(0)) == (rounded ? 3 * 6 : 6)
@@ -1115,8 +1126,8 @@
     poly = difference2d(Rectangle(2μm, 2μm), Rectangle(1μm, 1μm))
     e = styled(poly, r_sty)
     for rounded ∈ (false, true)
-        cs = CoordinateSystem("test", nm)
-        sm = test_sm()
+        local cs = CoordinateSystem("test", nm)
+        local sm = test_sm()
         place!(cs, e, SemanticMeta(:test))
         render!(sm, cs, rounded=rounded)
         @test length(SolidModels.gmsh.model.get_entities(0)) == (rounded ? 3 * 6 : 6)
@@ -1128,8 +1139,8 @@
     # RelativeRounded works with holey ClippedPolygon
     e = styled(c, r_sty)
     for rounded ∈ (false, true)
-        cs = CoordinateSystem("test", nm)
-        sm = test_sm()
+        local cs = CoordinateSystem("test", nm)
+        local sm = test_sm()
         place!(cs, e, SemanticMeta(:test))
         render!(sm, cs, rounded=rounded)
         @test length(SolidModels.gmsh.model.get_entities(0)) == (rounded ? 24 : 8)
@@ -1143,8 +1154,18 @@
     r2 = Rectangle(1μm, 1μm) + Point(0.5μm, 0.5μm)
     cs = CoordinateSystem("test", nm)
     sty = StyleDict()
-    sty[1] = Rounded(1μm; p0=[Point(0.0μm, 0.0μm)], inverse_selection=true)
-    sty[1, 1] = Rounded(0.5μm; p0=[Point(0.5μm, 0.5μm)], inverse_selection=true)
+    sty[1] = Rounded(
+        1μm;
+        p0=[Point(0.0μm, 0.0μm)],
+        inverse_selection=true,
+        selection_tolerance=1nm
+    )
+    sty[1, 1] = Rounded(
+        0.5μm;
+        p0=[Point(0.5μm, 0.5μm)],
+        inverse_selection=true,
+        selection_tolerance=1nm
+    )
     place!(cs, sty(difference2d(r1, r2)), :test)
     place!(cs, Rectangle(0.5μm, 0.5μm), :test)
     sm = test_sm()
@@ -1248,58 +1269,64 @@
         bad_tiles = union(tiles, ["foo"])
 
         sm = SolidModel("test", overwrite=true)
-        render!(
-            sm,
-            tiled_cs();
-            postrender_ops=[(
-                "tile",
-                SolidModels.union_geom!,
-                (bad_tiles, 2),
-                :remove_object => true,
-                :remove_tool => true
-            )]
-        )
-        @test length(SolidModels.gmsh.model.get_entities(0)) == 4
-        @test length(SolidModels.gmsh.model.get_entities(1)) == 4
-        @test length(SolidModels.gmsh.model.get_entities(2)) == 1
-        @test length(SolidModels.gmsh.model.get_entities(3)) == 0
-        @test SolidModels.hasgroup(sm, "tile", 2)
-        @test !any(SolidModels.hasgroup.(sm, tiles, 2))
-
-        sm = SolidModel("test", overwrite=true)
-        render!(
-            sm,
-            tiled_cs();
-            postrender_ops=[(
-                "tile",
-                SolidModels.union_geom!,
-                (bad_tiles[1:4], bad_tiles[5:end], 2, 2),
-                :remove_object => true,
-                :remove_tool => true
-            )]
-        )
-        @test length(SolidModels.gmsh.model.get_entities(0)) == 4
-        @test length(SolidModels.gmsh.model.get_entities(1)) == 4
-        @test length(SolidModels.gmsh.model.get_entities(2)) == 1
-        @test length(SolidModels.gmsh.model.get_entities(3)) == 0
-        @test SolidModels.hasgroup(sm, "tile", 2)
-        @test !any(SolidModels.hasgroup.(sm, tiles, 2))
-
-        sm = SolidModel("test", overwrite=true)
-        render!(
-            sm,
-            tiled_cs();
-            postrender_ops=[
-                (
-                    "diff",
-                    SolidModels.difference_geom!,
-                    (bad_tiles, ["tile11", "tile21", "tile12", "bar"], 2, 2),
+        with_expected_info("invalid arguments") do
+            return render!(
+                sm,
+                tiled_cs();
+                postrender_ops=[(
+                    "tile",
+                    SolidModels.union_geom!,
+                    (bad_tiles, 2),
                     :remove_object => true,
                     :remove_tool => true
-                ),
-                ("diff", SolidModels.union_geom!, ("diff", 2))
-            ]
-        )
+                )]
+            )
+        end
+        @test length(SolidModels.gmsh.model.get_entities(0)) == 4
+        @test length(SolidModels.gmsh.model.get_entities(1)) == 4
+        @test length(SolidModels.gmsh.model.get_entities(2)) == 1
+        @test length(SolidModels.gmsh.model.get_entities(3)) == 0
+        @test SolidModels.hasgroup(sm, "tile", 2)
+        @test !any(SolidModels.hasgroup.(sm, tiles, 2))
+
+        sm = SolidModel("test", overwrite=true)
+        with_expected_info("invalid arguments") do
+            return render!(
+                sm,
+                tiled_cs();
+                postrender_ops=[(
+                    "tile",
+                    SolidModels.union_geom!,
+                    (bad_tiles[1:4], bad_tiles[5:end], 2, 2),
+                    :remove_object => true,
+                    :remove_tool => true
+                )]
+            )
+        end
+        @test length(SolidModels.gmsh.model.get_entities(0)) == 4
+        @test length(SolidModels.gmsh.model.get_entities(1)) == 4
+        @test length(SolidModels.gmsh.model.get_entities(2)) == 1
+        @test length(SolidModels.gmsh.model.get_entities(3)) == 0
+        @test SolidModels.hasgroup(sm, "tile", 2)
+        @test !any(SolidModels.hasgroup.(sm, tiles, 2))
+
+        sm = SolidModel("test", overwrite=true)
+        with_expected_info("invalid arguments") do
+            return render!(
+                sm,
+                tiled_cs();
+                postrender_ops=[
+                    (
+                        "diff",
+                        SolidModels.difference_geom!,
+                        (bad_tiles, ["tile11", "tile21", "tile12", "bar"], 2, 2),
+                        :remove_object => true,
+                        :remove_tool => true
+                    ),
+                    ("diff", SolidModels.union_geom!, ("diff", 2))
+                ]
+            )
+        end
         @test length(SolidModels.gmsh.model.get_entities(0)) == 10
         @test length(SolidModels.gmsh.model.get_entities(1)) == 10
         @test length(SolidModels.gmsh.model.get_entities(2)) == 2
@@ -1308,45 +1335,47 @@
         @test !any(SolidModels.hasgroup.(sm, tiles, 2))
 
         sm = SolidModel("test", overwrite=true)
-        render!(
-            sm,
-            tiled_cs();
-            postrender_ops=[
-                (
-                    "int",
-                    SolidModels.intersect_geom!,
+        with_expected_info("invalid arguments") do
+            return render!(
+                sm,
+                tiled_cs();
+                postrender_ops=[
                     (
-                        [
-                            "tile00",
-                            "tile01",
-                            "tile10",
-                            "tile02",
-                            "tile12",
-                            "tile11",
-                            "tile21",
-                            "tile20",
-                            "foo"
-                        ],
-                        [
-                            "tile22",
-                            "tile21",
-                            "tile12",
-                            "tile02",
-                            "tile12",
-                            "tile11",
-                            "tile21",
-                            "tile20",
-                            "bar"
-                        ],
-                        2,
-                        2
+                        "int",
+                        SolidModels.intersect_geom!,
+                        (
+                            [
+                                "tile00",
+                                "tile01",
+                                "tile10",
+                                "tile02",
+                                "tile12",
+                                "tile11",
+                                "tile21",
+                                "tile20",
+                                "foo"
+                            ],
+                            [
+                                "tile22",
+                                "tile21",
+                                "tile12",
+                                "tile02",
+                                "tile12",
+                                "tile11",
+                                "tile21",
+                                "tile20",
+                                "bar"
+                            ],
+                            2,
+                            2
+                        ),
+                        :remove_object => true,
+                        :remove_tool => true
                     ),
-                    :remove_object => true,
-                    :remove_tool => true
-                ),
-                ("int", SolidModels.union_geom!, ("int", 2))
-            ]
-        )
+                    ("int", SolidModels.union_geom!, ("int", 2))
+                ]
+            )
+        end
         @test length(SolidModels.gmsh.model.get_entities(0)) == 10
         @test length(SolidModels.gmsh.model.get_entities(1)) == 10
         @test length(SolidModels.gmsh.model.get_entities(2)) == 1
@@ -1355,16 +1384,18 @@
         @test !any(SolidModels.hasgroup.(sm, tiles, 2))
 
         sm = SolidModel("test", overwrite=true)
-        render!(
-            sm,
-            tiled_cs(true);
-            postrender_ops=[(
-                "frag",
-                SolidModels.fragment_geom!,
-                (bad_tiles, 2),
-                :remove_object => true
-            )]
-        )
+        with_expected_info("invalid arguments") do
+            return render!(
+                sm,
+                tiled_cs(true);
+                postrender_ops=[(
+                    "frag",
+                    SolidModels.fragment_geom!,
+                    (bad_tiles, 2),
+                    :remove_object => true
+                )]
+            )
+        end
         @test length(SolidModels.gmsh.model.get_entities(0)) == 16
         @test length(SolidModels.gmsh.model.get_entities(1)) == 2 * 4 * 3
         @test length(SolidModels.gmsh.model.get_entities(2)) == 9
@@ -1844,12 +1875,14 @@
         place!(cs2, r4, SemanticMeta(:a))
         place!(cs2, r5, SemanticMeta(:b))
         sm3 = SolidModel("test_auto_union_compose", overwrite=true)
-        render!(
-            sm3,
-            cs2;
-            auto_union=true,
-            postrender_ops=[("combined", SolidModels.union_geom!, ("a", "b", 2, 2))]
-        )
+        with_expected_info("single entity") do
+            return render!(
+                sm3,
+                cs2;
+                auto_union=true,
+                postrender_ops=[("combined", SolidModels.union_geom!, ("a", "b", 2, 2))]
+            )
+        end
         @test SolidModels.hasgroup(sm3, "combined", 2)
         @test length(SolidModels.dimtags(sm3["combined", 2])) == 2
     end
@@ -1966,7 +1999,7 @@
     end
 end
 
-@testitem "Full turns render in SolidModel (#252)" setup = [CommonTestSetup] begin
+@testitem "Full turns render in SolidModel (#252)" setup = [CommonTestSetup, QuietGmshSetup] begin
     # A 360° turn previously reached OpenCASCADE as a collapsed 2-point polygon and
     # produced a silent zero-area surface; it now renders as two half-annulus surfaces.
     for (sty, nsurf, expected) in [
@@ -2021,6 +2054,7 @@ end
         # returned tag must be the lower one.
         import SpatialIndexing
         sm = SolidModel("get_or_add_point_tie"; overwrite=true)
+        SolidModels.set_gmsh_option("General.Verbosity", 0)
         k = SolidModels.kernel(sm)
         cache = SolidModels.PointsCache()
         # Symmetric pair around the origin.
@@ -2053,6 +2087,7 @@ end
         # back to a fresh `add_point` and drop the stale entry from the tree.
         import SpatialIndexing
         sm = SolidModel("get_or_add_point_stale"; overwrite=true)
+        SolidModels.set_gmsh_option("General.Verbosity", 0)
         k = SolidModels.kernel(sm)
         cache = SolidModels.PointsCache()
         stale = SolidModels._get_or_add_point!(

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -114,9 +114,14 @@ end
 @testitem "Preferences" setup = [CommonTestSetup] begin
     @test DeviceLayout.unit_preference == "PreferNanometers"
     @test_throws ArgumentError DeviceLayout.set_unit_preference!("Nanometers")
-    DeviceLayout.set_unit_preference!("PreferMicrons"; local_only=false) # triggers @info, just ignore
+    @test_logs (:info, r"New unit preference set") DeviceLayout.set_unit_preference!(
+        "PreferMicrons";
+        local_only=false
+    )
     @test DeviceLayout.load_preference(DeviceLayout, "units") == "PreferMicrons"
-    DeviceLayout.set_unit_preference!("PreferNanometers") # local_only => will override
+    @test_logs (:info, r"currently compiled setting") DeviceLayout.set_unit_preference!(
+        "PreferNanometers"
+    ) # local_only => will override
     @test DeviceLayout.load_preference(DeviceLayout, "units") == "PreferNanometers"
     # Delete units preference in generated LocalPreferences.toml; this ensures that
     # a second execution of this test block will pass when running locally.
@@ -129,7 +134,7 @@ end
     @test DeviceLayout.Graphics.get_color_scheme() == :glasbey_bw_minc_20_maxl_70_n256
     c = DeviceLayout.Graphics.lcolor(1)
     # Switch to dark
-    DeviceLayout.Graphics.set_theme!("dark")
+    @test_logs (:info, r"Color scheme set") DeviceLayout.Graphics.set_theme!("dark")
     @test DeviceLayout.Graphics.get_color_scheme() == :glasbey_bw_minc_20_minl_30_n256
     # Change takes place without restarting
     @test DeviceLayout.Graphics.lcolor(1) != c
@@ -901,7 +906,11 @@ end
         push!(top_casc.refs, CellReference(c_foo2, p(10.0μm, 0.0μm)))
         push!(top_casc.refs, CellReference(c_foo_1, p(20.0μm, 0.0μm)))
         casc_path = joinpath(tdir, "rename_casc.gds")
-        save(casc_path, top_casc; options=rename_opts)
+        @test_logs (:info, r"Renamed duplicate cell") (:info, r"Renamed duplicate cell") save(
+            casc_path,
+            top_casc;
+            options=rename_opts
+        )
         cells_casc = load(casc_path)
         casc_names = collect(keys(cells_casc))
         # All cell names must be unique (case-insensitively)
@@ -953,7 +962,12 @@ end
         main = Cell("main", nm)
         render!(main, Rectangle(10μm, 10μm), GDSMeta(-1, 0))
         path = joinpath(tdir, "bad_layer.gds")
-        @test_throws CapturedException save(path, main)
+        quiet_test_output(;
+            allowed_log=log ->
+                log.level == Logging.Warn && occursin("Layer -1", log.message)
+        ) do
+            @test_throws CapturedException save(path, main)
+        end
 
         # Layer 64 with strict GDSII spec limits should warn
         main = Cell("main", nm)
@@ -990,9 +1004,11 @@ end
         @test_logs (:warn, r"unimplemented record type 0x2202") load(
             joinpath(dirname(@__FILE__), "unimplemented_record.gds")
         )
-        @test_throws CapturedException load(
-            joinpath(dirname(@__FILE__), "badbytes_record.gds")
-        )
+        quiet_test_output() do
+            @test_throws CapturedException load(
+                joinpath(dirname(@__FILE__), "badbytes_record.gds")
+            )
+        end
         @test_logs (:warn, r"did not start with a BGNLIB") load(
             joinpath(dirname(@__FILE__), "no_bgnlib.gds")
         )
@@ -1001,23 +1017,27 @@ end
         )
 
         # Corrupt file tests: cells
-        @test_throws CapturedException load(
-            joinpath(dirname(@__FILE__), "badbytes_cell.gds")
-        )
-        @test_throws CapturedException load(
-            joinpath(dirname(@__FILE__), "unknown_cell.gds")
-        ) # unknown token in cell (0xffff)
-        @test_throws CapturedException load(
-            joinpath(dirname(@__FILE__), "unimplemented_cell.gds")
-        ) # unimplemented token in cell (0x0c00, TEXT)
+        quiet_test_output() do
+            @test_throws CapturedException load(
+                joinpath(dirname(@__FILE__), "badbytes_cell.gds")
+            )
+            @test_throws CapturedException load(
+                joinpath(dirname(@__FILE__), "unknown_cell.gds")
+            ) # unknown token in cell (0xffff)
+            @test_throws CapturedException load(
+                joinpath(dirname(@__FILE__), "unimplemented_cell.gds")
+            ) # unimplemented token in cell (0x0c00, TEXT)
+        end
 
         # Corrupt file tests: boundaries
-        @test_throws CapturedException load(
-            joinpath(dirname(@__FILE__), "badbytes_boundary.gds")
-        )
-        @test_throws CapturedException load(
-            joinpath(dirname(@__FILE__), "unknown_boundary.gds")
-        ) # unknown token in boundary (0xffff)
+        quiet_test_output() do
+            @test_throws CapturedException load(
+                joinpath(dirname(@__FILE__), "badbytes_boundary.gds")
+            )
+            @test_throws CapturedException load(
+                joinpath(dirname(@__FILE__), "unknown_boundary.gds")
+            ) # unknown token in boundary (0xffff)
+        end
 
         # Round-trip tests
         let c = Cell("main", nm), c2 = Cell("sub", nm)
@@ -1298,7 +1318,12 @@ end
         save(path, cs2)
         rm(path, force=true)
         # With intermediate cell
-        c = Cell(cs2)
+        c = @test_logs (:warn, r"Automatically converting") (
+            :warn,
+            r"Automatically converting"
+        ) (:warn, r"Automatically converting") (:warn, r"Automatically converting") Cell(
+            cs2
+        )
         save(path, c)
         rm(path, force=true)
     end


### PR DESCRIPTION
Close #298.

1. Replace deprecated rounding syntax with finite 1 nm selection tolerances where semantics permit.                                                                                                                                           
 2. Preserve intentional legacy-selection tests while capturing only the expected deprecation.                                                                                                                                                 
 3. Silence Gmsh native output with test-specific verbosity setup.                                                                                                                                                                             
 4. Capture expected schematic, GDS, PolyText, and post-render logs while rejecting unexpected warnings/errors.                                                                                                                                
 5. Suppress successful Pkg/template output, replaying captured output if an exception occurs.                                                                                                                                                 
 6. Fix soft-scope and test method-overwrite warnings.