### PR TITLE
Add schematic precompile workload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ The format of this changelog is based on
     that injects each group's vertices onto every other group's edges — the form needed to
     make adjacent physical groups conformal before `render_conformal!`. Curved edges are split
     natively via `Paths.split`; no discretization.
+  - Added a precompile workload for the schematic workflow. Precompilation will take longer, but
+  first execution in all subsequent new Julia sessions will be faster.
+  - `Route` and `RouteComponent` now have their concrete `RouteRule` type as a second type parameter
+  (after coordinate type). This should not have functional consequences for ordinary usage, but it
+  does mean that `Route{T}` and `RouteComponent{T}` are no longer concrete, and their `RouteRule` cannot
+  be changed in-place to a different type.
 
 ## 1.18.1 (2026-09-07)
 

--- a/src/paths/routes.jl
+++ b/src/paths/routes.jl
@@ -1,5 +1,5 @@
 """
-    abstract type RouteRule end
+    abstract type RouteRule
 
 Controls how a `Route` is turned into a `Path`.
 
@@ -125,7 +125,7 @@ CompoundRouteRule(rules::Vector{RouteRule}) =
     CompoundRouteRule(rules, ones(Int, length(rules)))
 
 """
-    mutable struct Route{S<:Coordinate}
+    mutable struct Route{S<:Coordinate, R <: RouteRule}
     Route(rule, startpoint::Point{S}, endpoint::Point, start_direction, end_direction; waypoints=Point{S}[], waydirs=[])
     Route(rule, path0::Path, endpoint::Point, end_direction)
 
@@ -143,8 +143,8 @@ If `waydirs` is not `nothing`, it should have the same length as `waypoints`. If
 is provided and is not ignored by the `RouteRule` (check the specific rule documentation),
 then `waypoints[i]` will be reached with the path pointing along `waydirs[i]`.
 """
-mutable struct Route{S <: Coordinate}
-    rule::RouteRule
+mutable struct Route{S <: Coordinate, R <: RouteRule}
+    rule::R
     p0::Point{S}
     p1::Point{S}
     α0::typeof(1.0°)
@@ -160,7 +160,7 @@ Route(
     end_direction;
     waypoints=Point{S}[],
     waydirs=[]
-) where {S} = Route{float(S)}(
+) where {S} = Route{float(S), typeof(rule)}(
     rule,
     startpoint,
     endpoint,
@@ -174,7 +174,7 @@ Route(rule, path0::Path, endpoint::Point, end_direction; kwargs...) =
     Route(rule, p1(path0), endpoint, α1(path0), end_direction; kwargs...)
 
 @inline Base.eltype(::Route{T}) where {T} = T
-@inline Base.eltype(::Type{Route{T}}) where {T} = T
+@inline Base.eltype(::Type{<:Route{T}}) where {T} = T
 
 """
     p0(r::Route)

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -10,6 +10,26 @@ using PrecompileTools
     end
 else
     @setup_workload begin
+        using .SchematicDrivenLayout
+        using .SchematicDrivenLayout.ExamplePDK
+        using .SchematicDrivenLayout.ExamplePDK.LayerVocabulary
+        using .ExamplePDK.ChipTemplates,
+            .ExamplePDK.Transmons, .ExamplePDK.ReadoutResonators
+        import FileIO: File, @format_str, add_format
+        # FileIO formats are normally registered in `__init__`, which has not run yet.
+        # Registrations made here live in FileIO's global registry, which is not part
+        # of this package's image, so `__init__` still registers them on load.
+        add_format(
+            format"GDS",
+            UInt8[0x00, 0x06, 0x00, 0x02],
+            ".gds",
+            [:DeviceLayout => UUID("ebf59a4a-04ec-49d7-8cd4-c9382ceb8e85")]
+        )
+        # Clipper handles are normally created in `__init__`, which has not run yet;
+        # `__init__` replaces these when the package is loaded.
+        global _clip = Ref(Clipper.Clip())
+        global _coffset = Ref(Clipper.ClipperOffset())
+        outdir = mktempdir()
         @compile_workload begin
             cs = CoordinateSystem("test", nm)
             cs2 = CoordinateSystem("attachment", nm)
@@ -23,7 +43,84 @@ else
             pa.metadata = SemanticMeta(:test)
 
             addref!(cs, sref(pa, rot=45°))
-            c = Cell(cs, map_meta=_ -> GDSMeta())
+            c = Cell(cs)
+
+            # Schematic-driven layout: chip, launchers, transmon, tapped resonator, and one
+            # route per built-in rule, rendered to GDS and to an image.
+            reset_uniquename!()
+            g = SchematicGraph("precompile")
+            chip = add_node!(g, ExampleChip(; port_lr_count=2, port_tb_count=2))
+            l1 = fuse!(g, chip => :port_4, example_launcher((:readout, 1)) => :p0)
+            l2 = fuse!(g, chip => :port_8, example_launcher((:xy, 1)) => :p0)
+            l3 = fuse!(g, chip => :port_6, example_launcher((:z, 1)) => :p0)
+            tr = add_node!(g, ExampleRectangleTransmon())
+            res = fuse!(
+                g,
+                tr => :readout,
+                ExampleTappedHairpin(; straight_length=1.25mm) => :tap
+            )
+            # Attach a component at a point along a path node
+            pa2 = Path(nm; name="pa2", metadata=METAL_NEGATIVE)
+            straight!(pa2, 1mm, Paths.CPW(10μm, 6μm))
+            pa2_node = add_node!(g, pa2)
+            attach!(
+                g,
+                pa2_node,
+                ExampleTappedHairpin(; straight_length=1.25mm, name="res2") => :tap,
+                0.5mm;
+                i=1,
+                location=1
+            )
+            fuse!(g, chip => :port_3, pa2_node => :p0)
+            route!(
+                g,
+                Paths.StraightAnd90(0.2mm),
+                res => :p0,
+                l1 => :p1,
+                Paths.CPW(10μm, 6μm),
+                METAL_NEGATIVE;
+                name="r1",
+                waypoints=[Point(2mm, -0.3mm)],
+                global_waypoints=true
+            )
+            route!(
+                g,
+                Paths.StraightAnd45(0.1mm),
+                tr => :xy,
+                l2 => :p1,
+                Paths.CPW(4μm, 2μm),
+                METAL_NEGATIVE;
+                name="r2"
+            )
+            route!(
+                g,
+                Paths.BSplineRouting(),
+                tr => :z,
+                l3 => :p1,
+                Paths.CPW(4μm, 2μm),
+                METAL_NEGATIVE;
+                name="r3"
+            )
+            sch = plan(g; log_dir=nothing)
+            check!(sch)
+            cell = Cell("precompile", nm)
+            render!(cell, sch, ExamplePDK.L1_TARGET)
+            save(File{format"GDS"}(joinpath(outdir, "precompile.gds")), cell)
+            flat = flatten(cell)
+            bounds(sch, tr)
+            save(File{format"PNG"}(joinpath(outdir, "precompile.png")), flat; width=200)
+            b = bounds(sch, tr)
+            colors = Dict(GDSMeta(1, 2) => (0.1, 0.1, 0.6, 1.0))
+            save(
+                File{format"PNG"}(joinpath(outdir, "precompile_zoom.png")),
+                flat;
+                width=100,
+                bbox=Rectangle(b.ll, b.ur),
+                layercolors=colors
+            )
         end
+        # Don't bake stale Clipper handles into the package image
+        global _clip = nothing
+        global _coffset = nothing
     end
 end

--- a/src/schematics/routes.jl
+++ b/src/schematics/routes.jl
@@ -8,9 +8,9 @@ Route(rule, hook0::PointHook, hook1::PointHook; kwargs...) =
     Route(rule, hook0.p, hook1.p, out_direction(hook0), hook1.in_direction; kwargs...)
 
 """
-    mutable struct RouteComponent{T} <: AbstractComponent{T}
+    mutable struct RouteComponent{T, R <: Paths.RouteRule} <: AbstractComponent{T}
         name::String
-        r::Paths.Route{T}
+        r::Paths.Route{T, R}
         global_waypoints::Bool
         sty::Vector{Paths.Style}
         meta::Meta
@@ -22,22 +22,22 @@ Wraps a `Route` in a `Component` type for use with schematics.
 taken to be relative to the component coordinate system. Otherwise, they will be relative to
 the schematic global coordinate system.
 """
-mutable struct RouteComponent{T} <: AbstractComponent{T}
+mutable struct RouteComponent{T, R <: Paths.RouteRule} <: AbstractComponent{T}
     name::String
-    r::Paths.Route{T}
+    r::Paths.Route{T, R}
     global_waypoints::Bool
     sty::Vector{Paths.Style}
     meta::Meta
     _path::Path{T}
-    RouteComponent{T}(n, r, g, s, m) where {T} = new{T}(n, r, g, s, m, Path{T}(n))
+    RouteComponent{T, R}(n, r, g, s, m) where {T, R} = new{T, R}(n, r, g, s, m, Path{T}(n))
 end
 RouteComponent(
     name::String,
-    r::Paths.Route{T},
+    r::Paths.Route{T, R},
     gw::Bool,
     sty::Paths.Style,
     meta::Meta
-) where {T} = RouteComponent{T}(name, r, gw, [sty], meta)
+) where {T, R} = RouteComponent{T, R}(name, r, gw, [sty], meta)
 
 function hooks(rc::RouteComponent{T}) where {T}
     p0 = StyledHook(

--- a/src/schematics/schematics.jl
+++ b/src/schematics/schematics.jl
@@ -11,7 +11,7 @@ import MetaGraphs:
     add_vertex!,
     add_edge!,
     rem_vertex!,
-    set_prop!
+    set_props!
 
 # If an edge has the property :plan_skips_edge => true, skip it in the plan! function
 PLAN_SKIPS_EDGE = :plan_skips_edge
@@ -272,8 +272,10 @@ function fuse!(
     h1sym = Symbol(uniquename("attach_" * first(nodehook2).id, counter=g.namecounter))
 
     add_hooks = additional_hooks(g, node1)
+    # `set_props!` rather than `set_prop!`: `:additional_hooks` is never an indexing
+    # property, and inferring the indexing branch (Dict{Symbol,Hook} equality) is slow.
     isempty(add_hooks) &&
-        set_prop!(g.graph, indexof(node1, g), :additional_hooks, add_hooks)
+        set_props!(g.graph, indexof(node1, g), Dict(:additional_hooks => add_hooks))
     add_hooks[h1sym] = hook1
 
     return fuse!(g, node1 => h1sym, nodehook2; kwargs...)
@@ -291,7 +293,7 @@ function fuse!(
 
     add_hooks = additional_hooks(g, node2)
     isempty(add_hooks) &&
-        set_prop!(g.graph, indexof(node2, g), :additional_hooks, add_hooks)
+        set_props!(g.graph, indexof(node2, g), Dict(:additional_hooks => add_hooks))
     add_hooks[h2sym] = hook2
 
     return fuse!(g, nodehook1, node2 => h2sym; kwargs...)


### PR DESCRIPTION
Extends the precompile workload to cover the schematic workflow, and also fixes a couple issues leading the compiler to spend more time than necessary on inference.