### PR TITLE
Add load_parameter_set entrypoint helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format of this changelog is based on
 
 ### Added
 
+  - `load_parameter_set` (exported from `SchematicDrivenLayout`) loads a `ParameterSet` from a
+    YAML file path. Requires `YAML.jl` to be loaded.
   - `split_t_junctions!` (exported from `DeviceLayout`) injects foreign vertices onto edges
     (straight or `Paths.Turn`/`Paths.BSpline`) using an `RTree`-based noding core, with three
     methods: asymmetric `(targets, sources...)` for general 2D / GDS-gap use, single-argument

--- a/docs/src/reference/parameter_set_api.md
+++ b/docs/src/reference/parameter_set_api.md
@@ -9,6 +9,7 @@ DeviceLayout.SchematicDrivenLayout.ParameterKeyError
 DeviceLayout.SchematicDrivenLayout.resolve
 DeviceLayout.SchematicDrivenLayout.leaf_params
 DeviceLayout.SchematicDrivenLayout.save_parameter_set
+DeviceLayout.SchematicDrivenLayout.load_parameter_set
 DeviceLayout.SchematicDrivenLayout.extract_parameter_set
 ```
 

--- a/ext/ParameterSetYAMLExt.jl
+++ b/ext/ParameterSetYAMLExt.jl
@@ -129,4 +129,8 @@ function DeviceLayout.SchematicDrivenLayout.save_parameter_set(path::String, ps:
     return path
 end
 
+function DeviceLayout.SchematicDrivenLayout.load_parameter_set(file::AbstractString)
+    return ParameterSet(String(file))
+end
+
 end # module ParameterSetYAMLExt

--- a/src/schematics/SchematicDrivenLayout.jl
+++ b/src/schematics/SchematicDrivenLayout.jl
@@ -122,7 +122,8 @@ export @component,
     route!,
     set_parameters
 export ParameterSet,
-    MissingNamespace, ParameterKeyError, resolve, leaf_params, save_parameter_set
+    MissingNamespace, ParameterKeyError, resolve, leaf_params, save_parameter_set,
+    load_parameter_set
 export ProcessTechnology, SimulationTarget, ArtworkTarget, SolidModelTarget
 export base_variant, flipchip!, map_metadata!, @composite_variant, @variant
 

--- a/src/schematics/SchematicDrivenLayout.jl
+++ b/src/schematics/SchematicDrivenLayout.jl
@@ -122,7 +122,11 @@ export @component,
     route!,
     set_parameters
 export ParameterSet,
-    MissingNamespace, ParameterKeyError, resolve, leaf_params, save_parameter_set,
+    MissingNamespace,
+    ParameterKeyError,
+    resolve,
+    leaf_params,
+    save_parameter_set,
     load_parameter_set
 export ProcessTechnology, SimulationTarget, ArtworkTarget, SolidModelTarget
 export base_variant, flipchip!, map_metadata!, @composite_variant, @variant

--- a/src/schematics/parameter_set.jl
+++ b/src/schematics/parameter_set.jl
@@ -482,3 +482,34 @@ Save a `ParameterSet` to a YAML file at `path` or write YAML to an `IO` stream.
 Requires `YAML.jl` to be loaded (`using YAML`).
 """
 function save_parameter_set end
+
+"""
+    load_parameter_set(args::AbstractVector{<:AbstractString}) -> ParameterSet
+
+Load a `ParameterSet` from a command-line argument vector.
+
+Intended for a script's `@main` entry point, where the parameter file is passed as a
+command-line argument:
+
+```julia
+function (@main)(ARGS)
+    ps = load_parameter_set(ARGS)
+    ...
+end
+```
+
+The first element of `args` is the path to a YAML parameter file; any further elements
+are ignored here and left for the caller to consume. Throws an `ArgumentError` if `args`
+is empty.
+
+Requires `YAML.jl` to be loaded (`using YAML`); see [`ParameterSet`](@ref).
+"""
+function load_parameter_set(args::AbstractVector{<:AbstractString})
+    isempty(args) && throw(
+        ArgumentError(
+            "load_parameter_set requires a YAML parameter-set file path as the first " *
+            "argument, but the argument vector was empty",
+        ),
+    )
+    return ParameterSet(String(first(args)))
+end

--- a/src/schematics/parameter_set.jl
+++ b/src/schematics/parameter_set.jl
@@ -484,32 +484,10 @@ Requires `YAML.jl` to be loaded (`using YAML`).
 function save_parameter_set end
 
 """
-    load_parameter_set(args::AbstractVector{<:AbstractString}) -> ParameterSet
+    load_parameter_set(file::AbstractString) -> ParameterSet
 
-Load a `ParameterSet` from a command-line argument vector.
-
-Intended for a script's `@main` entry point, where the parameter file is passed as a
-command-line argument:
-
-```julia
-function (@main)(ARGS)
-    ps = load_parameter_set(ARGS)
-    return ...
-end
-```
-
-The first element of `args` is the path to a YAML parameter file; any further elements
-are ignored here and left for the caller to consume. Throws an `ArgumentError` if `args`
-is empty.
+Load a `ParameterSet` from the YAML file at `file`.
 
 Requires `YAML.jl` to be loaded (`using YAML`); see [`ParameterSet`](@ref).
 """
-function load_parameter_set(args::AbstractVector{<:AbstractString})
-    isempty(args) && throw(
-        ArgumentError(
-            "load_parameter_set requires a YAML parameter-set file path as the first " *
-            "argument, but the argument vector was empty"
-        )
-    )
-    return ParameterSet(String(first(args)))
-end
+function load_parameter_set end

--- a/src/schematics/parameter_set.jl
+++ b/src/schematics/parameter_set.jl
@@ -494,7 +494,7 @@ command-line argument:
 ```julia
 function (@main)(ARGS)
     ps = load_parameter_set(ARGS)
-    ...
+    return ...
 end
 ```
 
@@ -508,8 +508,8 @@ function load_parameter_set(args::AbstractVector{<:AbstractString})
     isempty(args) && throw(
         ArgumentError(
             "load_parameter_set requires a YAML parameter-set file path as the first " *
-            "argument, but the argument vector was empty",
-        ),
+            "argument, but the argument vector was empty"
+        )
     )
     return ParameterSet(String(first(args)))
 end

--- a/test/test_parameter_set.jl
+++ b/test/test_parameter_set.jl
@@ -1161,25 +1161,18 @@ end
         @test ps2.components.cap.count == 6
     end
 
-    @testset "load_parameter_set from args vector" begin
+    @testset "load_parameter_set from file path" begin
         ps = ParameterSet()
         ps.global.version = 7
         ps.components.cap.width = 150μm
         path = joinpath(tdir, "loader_ps.yaml")
         save_parameter_set(path, ps)
 
-        # First arg is the parameter-file path, the loaded set records it.
-        loaded = load_parameter_set([path])
+        # The named counterpart to save_parameter_set: loads the YAML file at `path`.
+        loaded = load_parameter_set(path)
         @test loaded.path == path
         @test loaded.global.version == 7
         @test loaded.components.cap.width == 150μm
-
-        # Extra args (e.g. an output dir) are ignored by the loader.
-        loaded2 = load_parameter_set([path, joinpath(tdir, "out")])
-        @test loaded2.global.version == 7
-
-        # An empty argument vector has no parameter-file path to load.
-        @test_throws ArgumentError load_parameter_set(String[])
     end
 
     @testset "Nested namespaces round-trip" begin

--- a/test/test_parameter_set.jl
+++ b/test/test_parameter_set.jl
@@ -935,7 +935,7 @@ end
 
 @testitem "ParameterSet YAML IO" setup = [CommonTestSetup] begin
     using DeviceLayout.SchematicDrivenLayout:
-        ParameterSet, resolve, leaf_params, save_parameter_set
+        ParameterSet, resolve, leaf_params, save_parameter_set, load_parameter_set
     using YAML
     using Unitful: μm, ustrip, unit
 
@@ -1159,6 +1159,27 @@ end
         @test ps2.components.cap.width == 150μm
         @test ps2.components.cap.gap == 3μm
         @test ps2.components.cap.count == 6
+    end
+
+    @testset "load_parameter_set from args vector" begin
+        ps = ParameterSet()
+        ps.global.version = 7
+        ps.components.cap.width = 150μm
+        path = joinpath(tdir, "loader_ps.yaml")
+        save_parameter_set(path, ps)
+
+        # First arg is the parameter-file path, the loaded set records it.
+        loaded = load_parameter_set([path])
+        @test loaded.path == path
+        @test loaded.global.version == 7
+        @test loaded.components.cap.width == 150μm
+
+        # Extra args (e.g. an output dir) are ignored by the loader.
+        loaded2 = load_parameter_set([path, joinpath(tdir, "out")])
+        @test loaded2.global.version == 7
+
+        # An empty argument vector has no parameter-file path to load.
+        @test_throws ArgumentError load_parameter_set(String[])
     end
 
     @testset "Nested namespaces round-trip" begin


### PR DESCRIPTION
Adds `load_parameter_set(file::AbstractString)`, which loads a `ParameterSet` from a YAML file. This is the named load-side counterpart to `save_parameter_set`, so load/save call sites read symmetrically instead of pairing a `save_parameter_set` function with a bare `ParameterSet(path)` constructor. Following `save_parameter_set`, the function is declared in the core and its method lives in the YAML extension (requires using YAML).