### PR TITLE
SolidModels: render_conformal_groups! for Dict{Symbol, <:AbstractVector{<:CurvilinearRegion}}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ The format of this changelog is based on
     that injects each group's vertices onto every other group's edges — the form needed to
     make adjacent physical groups conformal before `render_conformal!`. Curved edges are split
     natively via `Paths.split`; no discretization.
+  - `SolidModels.render_conformal_groups!(sm, groups::AbstractDict; zmap, context, atol)`
+    renders a `Dict{Symbol, <:AbstractVector{<:CurvilinearRegion}}` of named region groups
+    into a `SolidModel` with conformal shared edges, creating one physical group per key.
+    This is the group-oriented counterpart to `render_conformal!` for callers that have
+    already produced region groups from Clipper booleans and made them conformal with
+    `split_t_junctions!(::AbstractDict)`. It shares one `ConformalRenderContext` and one
+    `PointsCache` across every group, so a boundary shared between two groups resolves to
+    one OCC curve entity — conformal by construction, without a post-render fragment pass.
 
 ## 1.18.1 (2026-09-07)
 

--- a/src/solidmodels/conformal/conformal.jl
+++ b/src/solidmodels/conformal/conformal.jl
@@ -53,10 +53,12 @@ using ..SolidModels:
     kernel,
     STP_UNIT,
     POINT_MERGE_ATOL,
+    PointsCache,
     _render_orchestrator!,
     _fragment_three_pass!,
     _add_curve!,
-    _get_or_add_point!
+    _get_or_add_point!,
+    _synchronize!
 import DeviceLayout
 import DeviceLayout:
     AbstractCoordinateSystem,
@@ -77,7 +79,8 @@ import Unitful: ustrip, Length, @u_str, °
 import SpatialIndexing
 import SpatialIndexing: RTree
 
-export render_conformal!, ConformalRenderContext, add_conformal_loop!
+export render_conformal!,
+    render_conformal_groups!, ConformalRenderContext, add_conformal_loop!
 
 """
 Entry in `endpoint_curve_index`: the signed OCC tag of the curve, plus a
@@ -834,6 +837,83 @@ function render_conformal!(
         (fragment!)=fragment_backstop ? _fragment_three_pass! : (_) -> nothing,
         kwargs...
     )
+end
+
+"""
+    render_conformal_groups!(sm, groups; zmap=nothing, context, atol) -> Dict
+
+Render a `Dict{Symbol, <:AbstractVector{<:CurvilinearRegion}}` of named region
+groups into `sm` with conformal shared edges, and create one physical group
+per key. Returns a `Dict{Symbol, Vector{Int32}}` of the dim-2 surface tags per
+group.
+
+This is the group-oriented counterpart to [`render_conformal!`](@ref). Where
+`render_conformal!` drives off a `CoordinateSystem` (flatten → per-metadata
+emit), this consumes region groups a caller has already produced from Clipper
+booleans ([`union2d_curved`](@ref), [`difference2d_curved`](@ref)) and made
+conformal with [`split_t_junctions!`](@ref DeviceLayout.split_t_junctions!)
+(the `AbstractDict` method is the natural fit here). It shares a single
+edge/curve cache ([`ConformalRenderContext`](@ref)) and point cache across
+every group, so a boundary shared between two groups resolves to one OCC curve
+entity — exactly the invariant that makes the result conformal without a
+post-render fragment pass.
+
+Each region contributes one plane surface (its exterior loop minus its hole
+loops). `zmap` maps a group name to its z-height (default: all at z = 0).
+
+```julia
+groups = Dict(
+    :ground => difference2d_curved(gnd_outer, gnd_holes),
+    :metal  => union2d_curved(metal_features)
+)
+split_t_junctions!(groups)
+sm = SolidModel("device"; overwrite=true)
+render_conformal_groups!(sm, groups)
+DeviceLayout.save("device.xao", sm)
+```
+"""
+function render_conformal_groups!(
+    sm::SolidModel,
+    groups::AbstractDict{Symbol, <:AbstractVector};
+    zmap=nothing,
+    context::ConformalRenderContext=ConformalRenderContext(),
+    atol=nothing
+)
+    k = kernel(sm)
+    k isa OpenCascade || error(
+        "render_conformal_groups! is only implemented for OpenCascade kernel; " *
+        "got $(typeof(k)). Use render! instead."
+    )
+    points_cache = PointsCache()
+    group_tags = Dict{Symbol, Vector{Int32}}()
+    for (name, regions) in groups
+        isempty(regions) && continue
+        z = isnothing(zmap) ? zero(coordinatetype(regions[1])) : zmap(name)
+        tags = Int32[]
+        for region in regions
+            loop_atol = isnothing(atol) ? onenanometer(coordinatetype(region)) : atol
+            outer = _add_conformal_loop!(
+                context,
+                region.exterior,
+                k,
+                z;
+                points_cache,
+                atol=loop_atol
+            )
+            holes = [
+                _add_conformal_loop!(context, h, k, z; points_cache, atol=loop_atol) for
+                h in region.holes
+            ]
+            push!(tags, Int32(k.add_plane_surface([outer; holes...])))
+        end
+        group_tags[name] = tags
+    end
+    _synchronize!(sm)
+    for (name, tags) in group_tags
+        isempty(tags) && continue
+        sm[name] = [(Int32(2), t) for t in tags]
+    end
+    return group_tags
 end
 
 end # module ConformalRender

--- a/src/solidmodels/solidmodels.jl
+++ b/src/solidmodels/solidmodels.jl
@@ -442,7 +442,9 @@ include("render.jl")
 include("postrender.jl")
 include("conformal/conformal.jl")
 
-using .ConformalRender: render_conformal!, ConformalRenderContext, add_conformal_loop!
-export render_conformal!, ConformalRenderContext, add_conformal_loop!
+using .ConformalRender:
+    render_conformal!, render_conformal_groups!, ConformalRenderContext, add_conformal_loop!
+export render_conformal!,
+    render_conformal_groups!, ConformalRenderContext, add_conformal_loop!
 
 end # module

--- a/test/test_conformal_render.jl
+++ b/test/test_conformal_render.jl
@@ -9,6 +9,9 @@
         onenanometer,
         ClippedPolygon,
         difference2d,
+        union2d_curved,
+        difference2d_curved,
+        split_t_junctions!,
         Paths,
         Path,
         LineSegment,
@@ -22,6 +25,7 @@
         ConformalRenderContext,
         add_conformal_loop!,
         render_conformal!,
+        render_conformal_groups!,
         kernel,
         gmsh,
         hasgroup
@@ -541,6 +545,115 @@
         gmsh.option.setNumber("General.Verbosity", 0)
         render_conformal!(sm, cs)
         @test hasgroup(sm, "l1", 2)
+        gmsh.finalize()
+    end
+
+    # ─── render_conformal_groups! (group → conformal surfaces) ─────────────
+
+    @testset "render_conformal_groups! renders groups with shared physical groups" begin
+        # Metal box sitting exactly in a ground-plane hole: their common
+        # boundary must render as ONE OCC curve on both sides. The two Clipper
+        # booleans below produce region groups a caller might build from a
+        # multi-layer layout — this is the input shape render_conformal_groups!
+        # is designed for.
+        gnd = difference2d_curved(
+            Rectangle(Point(0.0μm, 0.0μm), Point(100.0μm, 100.0μm)),
+            Rectangle(Point(30.0μm, 30.0μm), Point(70.0μm, 70.0μm))
+        )
+        metal = union2d_curved(Rectangle(Point(30.0μm, 30.0μm), Point(70.0μm, 70.0μm)))
+        groups = Dict(:ground => collect(gnd), :metal => collect(metal))
+
+        sm = SolidModel("rcg_basic"; overwrite=true)
+        tags = render_conformal_groups!(sm, groups)
+
+        @test haskey(tags, :ground) && haskey(tags, :metal)
+        @test hasgroup(sm, "ground", 2)
+        @test hasgroup(sm, "metal", 2)
+        @test length(tags[:metal]) == 1
+        @test length(tags[:ground]) == 1
+
+        # Conformality: the shared boundary is the metal box perimeter (4
+        # edges). Each of those edges must be adjacent to BOTH the metal face
+        # and a ground face — i.e. shared. Count edges with >=2 adjacent faces.
+        gmsh.model.occ.synchronize()
+        shared = 0
+        for (dim, tag) in gmsh.model.getEntities(1)
+            up, _ = gmsh.model.getAdjacencies(dim, tag)
+            length(up) >= 2 && (shared += 1)
+        end
+        @test shared == 4
+        gmsh.finalize()
+    end
+
+    @testset "render_conformal_groups! end-to-end to .xao" begin
+        # The full pipeline a downstream caller runs: Clipper booleans →
+        # split_t_junctions!(::AbstractDict) → render_conformal_groups! →
+        # save(.xao). A T-junction is deliberately introduced (a notch in the
+        # ground hole that the metal box doesn't have) so the noding pass has
+        # work to do.
+        gnd_hole = DeviceLayout.union2d(
+            Rectangle(Point(30.0μm, 30.0μm), Point(70.0μm, 70.0μm)),
+            Rectangle(Point(48.0μm, 70.0μm), Point(52.0μm, 74.0μm))
+        )
+        gnd = difference2d_curved(
+            Rectangle(Point(0.0μm, 0.0μm), Point(100.0μm, 100.0μm)),
+            gnd_hole
+        )
+        metal = union2d_curved(Rectangle(Point(30.0μm, 30.0μm), Point(70.0μm, 70.0μm)))
+        groups = Dict(:ground => collect(gnd), :metal => collect(metal))
+
+        split_t_junctions!(groups)
+
+        sm = SolidModel("rcg_xao"; overwrite=true)
+        render_conformal_groups!(sm, groups)
+        @test hasgroup(sm, "ground", 2)
+        @test hasgroup(sm, "metal", 2)
+
+        mktempdir() do dir
+            xao = joinpath(dir, "rcg.xao")
+            DeviceLayout.save(xao, sm)
+            @test isfile(xao)
+            @test filesize(xao) > 0
+        end
+        gmsh.finalize()
+    end
+
+    @testset "render_conformal_groups! zmap positions groups at different z" begin
+        a = union2d_curved(Rectangle(Point(0.0μm, 0.0μm), Point(10.0μm, 10.0μm)))
+        b = union2d_curved(Rectangle(Point(0.0μm, 0.0μm), Point(10.0μm, 10.0μm)))
+        groups = Dict(:bottom => collect(a), :top => collect(b))
+        sm = SolidModel("rcg_zmap"; overwrite=true)
+        render_conformal_groups!(sm, groups; zmap=name -> (name === :top ? 5.0μm : 0.0μm))
+        gmsh.model.occ.synchronize()
+        # bottom face at z=0, top face at z=5 → two distinct z-planes present.
+        zs = Set{Float64}()
+        for (_, tag) in gmsh.model.getEntities(2)
+            bb = gmsh.model.getBoundingBox(2, tag)
+            push!(zs, round(bb[3]; digits=6) + 0.0)
+        end
+        @test any(z -> isapprox(z, 0.0; atol=1e-6), zs)
+        @test any(z -> isapprox(z, 5.0; atol=1e-6), zs)
+        gmsh.finalize()
+    end
+
+    @testset "render_conformal_groups! rejects GmshNative kernel" begin
+        sm = SolidModel("rcg_native", SolidModels.GmshNative(); overwrite=true)
+        box = union2d_curved(Rectangle(Point(0.0μm, 0.0μm), Point(10.0μm, 10.0μm)))
+        @test_throws ErrorException render_conformal_groups!(sm, Dict(:m => collect(box)))
+        gmsh.finalize()
+    end
+
+    @testset "render_conformal_groups! skips empty groups" begin
+        T = typeof(1.0μm)
+        empty_regs = CurvilinearRegion{T}[]
+        box = collect(union2d_curved(Rectangle(Point(0.0μm, 0.0μm), Point(10.0μm, 10.0μm))))
+        groups = Dict(:empty => empty_regs, :box => box)
+        sm = SolidModel("rcg_empty"; overwrite=true)
+        tags = render_conformal_groups!(sm, groups)
+        @test !haskey(tags, :empty)
+        @test haskey(tags, :box)
+        @test hasgroup(sm, "box", 2)
+        @test !hasgroup(sm, "empty", 2)
         gmsh.finalize()
     end
 end


### PR DESCRIPTION
## What this adds

`SolidModels.render_conformal_groups!(sm, groups; zmap, context, atol)` — the
group-oriented counterpart to `render_conformal!`. It renders a
`Dict{Symbol, <:AbstractVector{<:CurvilinearRegion}}` of named region groups
into a `SolidModel` with conformal shared edges, creating one physical group
per key and returning the dim-2 surface tags per group.

## Problem it solves

`render_conformal!(sm, cs)` drives off a `CoordinateSystem`, which is the
right entry point when your source of truth is a schematic or a
raw-entity layout. But callers who have already produced named region
groups upstream — typically by running Clipper booleans directly
(`union2d_curved(...)`, `difference2d_curved(...)`) and then noding those
groups with `split_t_junctions!(groups::AbstractDict)` — had no clean way to
emit the result into a `SolidModel` while keeping the conformal (shared-edge)
invariant. The workaround was to reflatten those regions back into a
CoordinateSystem, which loses group identity and re-triggers layer-mapping
plumbing that the caller already resolved.

## What it provides

`render_conformal_groups!` consumes region groups directly and:

- Shares one `ConformalRenderContext` and one `PointsCache` across every
  group, so a boundary shared between two groups (e.g. `metal ↔ ground`)
  resolves to a **single OCC curve entity** — exactly the invariant that
  makes the result conformal without a post-render fragment pass.
- Creates one physical group per `Dict` key (the group name), preserving the
  caller's naming.
- Returns `Dict{Symbol, Vector{Int32}}` of the dim-2 surface tags per group,
  so downstream postrender ops can reference the specific surfaces they own.
- Accepts `zmap` for planar-z-per-group placement (typical use: separate
  metal and ground onto different layer heights before extrusion).

Composes with `split_t_junctions!(::AbstractDict)` — the new symmetric
all-pairs method added in the shared-noding-core PR — to form the full
public-API pipeline from Clipper booleans to a conformal `.xao`:

```julia
groups = Dict(
    :ground => difference2d_curved(gnd_outer, gnd_holes),
    :metal  => union2d_curved(metal_features),
)
split_t_junctions!(groups)              # make shared boundaries conformal
render_conformal_groups!(sm, groups)    # emit with shared OCC edges
DeviceLayout.save("device.xao", sm)
```

## Why it matters

Two capabilities that required custom OCC scaffolding before:

- **Full-chip curve-preserving `.xao` output from a multi-group boolean
  pipeline** — the natural input shape for large layouts with distinct
  physical groups (metal / ground / ports / lumped elements) each formed by
  its own Clipper pass. Callers no longer need to package the result into a
  CoordinateSystem or a target just to reach a conformal SolidModel.
- **Composable postrender for group-oriented pipelines** — because the
  physical groups are created up front, later postrender ops
  (extrusions, volume booleans) can reference them by name using the
  existing `SolidModels.union_geom!` / `difference_geom!` machinery.

## Verification

Five new testsets in `test/test_conformal_render.jl`:

1. **Two-group conformality** — metal box exactly in a ground-plane hole;
   the shared boundary is 4 edges, each adjacent to both the metal face and
   a ground face (conformal, not two duplicated 4-edge loops).
2. **End-to-end to `.xao`** — full pipeline including a deliberately induced
   T-junction so `split_t_junctions!` has actual work to do; asserts the
   output file writes and is nonempty.
3. **`zmap` positions groups at different z** — two groups on the same
   footprint at z=0 and z=5 µm produce surfaces at both z-planes.
4. **GmshNative kernel rejection** — the function is OpenCascade-only and
   errors clearly on `GmshNative`.
5. **Empty groups are silently skipped** — a Dict entry with an empty
   region vector doesn't create a physical group, doesn't error.

- Full ConformalRender suite: 61/61 pass (up from 51).
- `scripts/format.jl check` clean.

## Scope

+84 lines in `src/solidmodels/conformal/conformal.jl` (the function + minor
import additions: `PointsCache`, `_synchronize!`).
+3 lines in `src/solidmodels/solidmodels.jl` (re-export).
+113 lines in `test/test_conformal_render.jl` (5 testsets).
+8 lines in `CHANGELOG.md`.

Depends on the shared-noding-core `split_t_junctions!(::AbstractDict)`
API, which is now on `main`. On layouts that hit the companion
OffsetSegment direction-canonicalize PR's failure mode (a group whose
stored curve is a `Paths.OffsetSegment` sharing a boundary with a group
whose stored curve is a plain `Paths.BSpline` that `split_t_junctions!`
has split), this API's callers will benefit from that fix being merged
first — otherwise `render_conformal_groups!` produces the same
non-manifold `.xao` as `render_conformal!` on those layouts.

## Verification

- Five new testsets in `test/test_conformal_render.jl` exercising:
  two-group shared boundary yielding a conformal set of shared edges,
  end-to-end pipeline through `.xao` with a deliberate T-junction that
  forces `split_t_junctions!` to work, `zmap` group-per-z-plane
  placement, `GmshNative` kernel rejection, empty-region handling.
- Full ConformalRender suite: 61/61 pass (up from 51).
- `scripts/format.jl check` clean.

The full pipeline the API is designed for:

```julia
groups = Dict(
    :ground => difference2d_curved(gnd_outer, gnd_holes),
    :metal  => union2d_curved(metal_features),
)
split_t_junctions!(groups)
render_conformal_groups!(sm, groups)
DeviceLayout.save("device.xao", sm)
```
