### PR TITLE
ConformalRender: add _add_conformal!(::Ellipse) method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ The format of this changelog is based on
     make adjacent physical groups conformal before `render_conformal!`. Curved edges are split
     natively via `Paths.split`; no discretization.
 
+### Fixed
+
+  - `render_conformal!` now handles `Ellipse` primitives (including circles
+    produced by `Circle` and by autofill patterns). Previously `to_primitives`
+    kept ellipses as native OCC primitives, but the conformal-emit dispatch had
+    no `Ellipse` method, so `render_conformal!` on any `CoordinateSystem`
+    containing an ellipse fell through to the generic vector path and errored.
+    The new method mirrors stock `render!`'s ellipse path (native
+    `add_ellipse`); a smooth closed curve has nothing to share with neighbours,
+    so no cache involvement is needed.
+
 ### Changed
 
   - Added a precompile workload for the schematic workflow. Precompilation will take longer, but

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,11 @@ The format of this changelog is based on
     kept ellipses as native OCC primitives, but the conformal-emit dispatch had
     no `Ellipse` method, so `render_conformal!` on any `CoordinateSystem`
     containing an ellipse fell through to the generic vector path and errored.
-    The new method mirrors stock `render!`'s ellipse path (native
-    `add_ellipse`); a smooth closed curve has nothing to share with neighbours,
-    so no cache involvement is needed.
+    Circles route through `CurvilinearPolygon` (four 90° arcs), the same contour
+    a circular hole comes out of `difference2d_curved`, so a placed circle and a
+    boolean-cut circular hole at the same location share cached arc entities.
+    Non-circular ellipses (not exactly arc-representable) emit a native
+    `add_ellipse`; a smooth closed curve has nothing to share with neighbours.
 
 ### Changed
 

--- a/src/solidmodels/conformal/conformal.jl
+++ b/src/solidmodels/conformal/conformal.jl
@@ -74,7 +74,7 @@ import DeviceLayout:
     coordinatetype,
     onenanometer
 import DeviceLayout.Paths: bspline_approximation, pathlength
-import DeviceLayout.Polygons: center, r1, r2, angle
+import DeviceLayout.Polygons: center, r1, r2, angle, iscircle
 import Unitful: ustrip, Length, @u_str, °
 import SpatialIndexing
 import SpatialIndexing: RTree
@@ -483,10 +483,17 @@ function _add_conformal!(
     return (Int32(1), linetag)
 end
 
-# Ellipse (incl. circles): OCC keeps these as a native ellipse primitive rather
-# than a cached polyline, so `to_primitives` hands us an `Ellipse` unchanged.
-# A smooth closed curve has nothing to share with neighbours, so this mirrors
-# stock `render!`'s ellipse path directly (no point/edge cache involvement).
+# Ellipse: `to_primitives` hands us an `Ellipse` unchanged (OCC keeps these as a
+# native primitive rather than a cached polyline).
+#
+# Circles route through `CurvilinearPolygon(e)`, which represents the circle as
+# four 90° `Paths.Turn` arcs. This matches how a circular hole comes out of
+# `difference2d_curved` (also a four-arc contour), so a circle placed directly
+# and a circle produced by a boolean cut land on the SAME cached arc entities and
+# can be shared with neighbours. Non-circular ellipses are not exactly arc-
+# representable (`CurvilinearPolygon(::Ellipse)` throws), so they fall through to
+# the native `add_ellipse` path below; a smooth closed ellipse has nothing to
+# share with neighbours anyway, so no cache involvement is needed there.
 function _add_conformal!(
     ctx::ConformalRenderContext,
     e::Ellipse{T},
@@ -496,6 +503,15 @@ function _add_conformal!(
     points_cache=nothing,
     kwargs...
 ) where {T}
+    iscircle(e) && return _add_conformal!(
+        ctx,
+        CurvilinearPolygon(e),
+        m,
+        k;
+        zmap=zmap,
+        points_cache=points_cache,
+        kwargs...
+    )
     z = zmap(m)
     c = ustrip(STP_UNIT, center(e))
     line = k.add_ellipse(

--- a/src/solidmodels/conformal/conformal.jl
+++ b/src/solidmodels/conformal/conformal.jl
@@ -63,6 +63,7 @@ import DeviceLayout:
     AbstractPolygon,
     CurvilinearPolygon,
     CurvilinearRegion,
+    Ellipse,
     LineSegment,
     Meta,
     Point,
@@ -73,6 +74,7 @@ import DeviceLayout:
     coordinatetype,
     onenanometer
 import DeviceLayout.Paths: bspline_approximation, pathlength
+import DeviceLayout.Polygons: center, r1, r2, angle
 import Unitful: ustrip, Length, @u_str, °
 import SpatialIndexing
 import SpatialIndexing: RTree
@@ -479,6 +481,38 @@ function _add_conformal!(
     )
     linetag = _cached_add_line!(k, ctx, p0, p1)
     return (Int32(1), linetag)
+end
+
+# Ellipse (incl. circles): OCC keeps these as a native ellipse primitive rather
+# than a cached polyline, so `to_primitives` hands us an `Ellipse` unchanged.
+# A smooth closed curve has nothing to share with neighbours, so this mirrors
+# stock `render!`'s ellipse path directly (no point/edge cache involvement).
+function _add_conformal!(
+    ctx::ConformalRenderContext,
+    e::Ellipse{T},
+    m::Meta,
+    k::OpenCascade;
+    zmap=(_) -> zero(T),
+    points_cache=nothing,
+    kwargs...
+) where {T}
+    z = zmap(m)
+    c = ustrip(STP_UNIT, center(e))
+    line = k.add_ellipse(
+        c[1],
+        c[2],
+        ustrip(STP_UNIT, z),
+        ustrip(STP_UNIT, r1(e)),
+        ustrip(STP_UNIT, r2(e)),
+        -1,
+        0.0,
+        2 * π,
+        [0.0, 0.0, 1.0],
+        [cos(angle(e)), sin(angle(e)), 0.0]
+    )
+    loop = k.add_curve_loop([line])
+    surf = k.add_plane_surface([loop])
+    return (Int32(2), surf)
 end
 
 # Broadcast dispatcher — top-level entry from render_conformal!'s metadata loop.

--- a/test/test_conformal_render.jl
+++ b/test/test_conformal_render.jl
@@ -543,4 +543,47 @@
         @test hasgroup(sm, "l1", 2)
         gmsh.finalize()
     end
+
+    @testset "render_conformal! with Ellipse (kept as native OCC primitive)" begin
+        # `to_primitives(sm, ::Ellipse)` keeps ellipses (incl. circles) as
+        # native OCC ellipses rather than discretizing to polygons, so
+        # `_add_conformal!` must handle the `Ellipse` type directly.
+        cs = CoordinateSystem("ellipse", nm)
+        place!(cs, DeviceLayout.Ellipse(Point(0.0μm, 0.0μm), (5.0μm, 3.0μm), 0.0°), :l1)
+
+        sm = SolidModel("ellipse"; overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
+        render_conformal!(sm, cs)
+        @test hasgroup(sm, "l1", 2)
+        @test length(gmsh.model.occ.getEntities(2)) == 1
+        # OCC keeps the boundary as a single smooth ellipse curve (not a chord
+        # chain), so the surface has exactly one bounding curve.
+        # OCC boundary curves of surface: an ellipse ⇒ 1 curve.
+        surf_curves = gmsh.model.occ.getEntities(1)
+        @test length(surf_curves) == 1
+        gmsh.finalize()
+    end
+
+    @testset "render_conformal! with a Circle in a mixed layer" begin
+        # Two rectangles + a circle on the same layer. The rectangles share an
+        # edge (dedup); the circle is disjoint. All three surfaces render;
+        # the shared edge still dedups.
+        cs = CoordinateSystem("mixed", nm)
+        place!(cs, Rectangle(Point(0.0μm, 0.0μm), Point(10.0μm, 10.0μm)), :l1)
+        place!(cs, Rectangle(Point(10.0μm, 0.0μm), Point(20.0μm, 10.0μm)), :l1)
+        place!(cs, DeviceLayout.Polygons.Circle(Point(30.0μm, 5.0μm), 2.0μm), :l1)
+
+        ctx = ConformalRenderContext()
+        sm = SolidModel("mixed"; overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
+        render_conformal!(sm, cs; context=ctx)
+        @test hasgroup(sm, "l1", 2)
+        # 3 surfaces: two rects + circle.
+        @test length(gmsh.model.occ.getEntities(2)) == 3
+        # Edge count: 4 (left rect) + 3 (right rect, shared edge reused) + 1
+        # (ellipse) = 8. A duplicated shared edge would give 9.
+        @test length(gmsh.model.occ.getEntities(1)) == 8
+        @test ctx.stats[:hits] >= 1
+        gmsh.finalize()
+    end
 end

--- a/test/test_conformal_render.jl
+++ b/test/test_conformal_render.jl
@@ -544,10 +544,12 @@
         gmsh.finalize()
     end
 
-    @testset "render_conformal! with Ellipse (kept as native OCC primitive)" begin
-        # `to_primitives(sm, ::Ellipse)` keeps ellipses (incl. circles) as
-        # native OCC ellipses rather than discretizing to polygons, so
-        # `_add_conformal!` must handle the `Ellipse` type directly.
+    @testset "render_conformal! with a non-circular Ellipse (native OCC primitive)" begin
+        # `to_primitives(sm, ::Ellipse)` keeps ellipses as native OCC ellipses
+        # rather than discretizing to polygons. A non-circular ellipse is not
+        # exactly representable as arcs (`CurvilinearPolygon(::Ellipse)` throws),
+        # so `_add_conformal!(::Ellipse)` falls through to the native
+        # `add_ellipse` path and emits a single smooth boundary curve.
         cs = CoordinateSystem("ellipse", nm)
         place!(cs, DeviceLayout.Ellipse(Point(0.0μm, 0.0μm), (5.0μm, 3.0μm), 0.0°), :l1)
 
@@ -558,16 +560,18 @@
         @test length(gmsh.model.occ.getEntities(2)) == 1
         # OCC keeps the boundary as a single smooth ellipse curve (not a chord
         # chain), so the surface has exactly one bounding curve.
-        # OCC boundary curves of surface: an ellipse ⇒ 1 curve.
         surf_curves = gmsh.model.occ.getEntities(1)
         @test length(surf_curves) == 1
         gmsh.finalize()
     end
 
-    @testset "render_conformal! with a Circle in a mixed layer" begin
-        # Two rectangles + a circle on the same layer. The rectangles share an
-        # edge (dedup); the circle is disjoint. All three surfaces render;
-        # the shared edge still dedups.
+    @testset "render_conformal! routes a Circle through arc contour" begin
+        # A circle IS exactly arc-representable, so `_add_conformal!(::Ellipse)`
+        # routes it through `CurvilinearPolygon(e)` — four 90° `Paths.Turn` arcs,
+        # the same contour a circular hole comes out of `difference2d_curved`.
+        # This puts the arcs into the shared edge cache instead of emitting a
+        # native `add_ellipse`, so a directly-placed circle can share entities
+        # with a boolean-cut circular hole at the same location.
         cs = CoordinateSystem("mixed", nm)
         place!(cs, Rectangle(Point(0.0μm, 0.0μm), Point(10.0μm, 10.0μm)), :l1)
         place!(cs, Rectangle(Point(10.0μm, 0.0μm), Point(20.0μm, 10.0μm)), :l1)
@@ -580,10 +584,35 @@
         @test hasgroup(sm, "l1", 2)
         # 3 surfaces: two rects + circle.
         @test length(gmsh.model.occ.getEntities(2)) == 3
-        # Edge count: 4 (left rect) + 3 (right rect, shared edge reused) + 1
-        # (ellipse) = 8. A duplicated shared edge would give 9.
-        @test length(gmsh.model.occ.getEntities(1)) == 8
-        @test ctx.stats[:hits] >= 1
+        # Edge count: 4 (left rect) + 3 (right rect, shared edge reused) + 4
+        # (circle as four arcs) = 11. The rectangles' shared edge still dedups.
+        @test length(gmsh.model.occ.getEntities(1)) == 11
+        @test ctx.stats[:arcs] == 4   # the circle emitted four arc entities
+        @test ctx.stats[:hits] >= 1   # rectangles' shared edge reused
+        gmsh.finalize()
+    end
+
+    @testset "render_conformal! shares arcs between co-located circles" begin
+        # The point of routing circles through `CurvilinearPolygon`: two circles
+        # at the SAME center and radius (e.g. a placed `Circle` and a circular
+        # hole cut into an adjacent layer) resolve to the SAME four cached arc
+        # entities. Without arc caching each circle would emit its own four
+        # curves (8 total); with it, the second circle's four arcs are all cache
+        # hits and only four unique arc entities exist.
+        cs = CoordinateSystem("cocirc", nm)
+        place!(cs, DeviceLayout.Polygons.Circle(Point(10.0μm, 10.0μm), 3.0μm), :l1)
+        place!(cs, DeviceLayout.Polygons.Circle(Point(10.0μm, 10.0μm), 3.0μm), :l2)
+
+        ctx = ConformalRenderContext()
+        sm = SolidModel("cocirc"; overwrite=true)
+        gmsh.option.setNumber("General.Verbosity", 0)
+        render_conformal!(sm, cs; context=ctx)
+        @test hasgroup(sm, "l1", 2)
+        @test hasgroup(sm, "l2", 2)
+        @test length(gmsh.model.occ.getEntities(2)) == 2  # two circle surfaces
+        # Four unique arcs shared by both circles (8 without sharing).
+        @test length(gmsh.model.occ.getEntities(1)) == 4
+        @test ctx.stats[:hits] == 4  # second circle's four arcs all reused
         gmsh.finalize()
     end
 end


### PR DESCRIPTION
## What this fixes

`render_conformal!` throws `MethodError` on any `CoordinateSystem` that
contains an `Ellipse` primitive — most commonly circles from `Circle(...)`
and the autofill patterns that populate ground planes with round holes.

The conformal-emit dispatch simply has no method for `Ellipse`; the branches
for `CurvilinearRegion`, `AbstractPolygon`, `LineSegment`, and the vector
fallback are all present, but the top-level `_add_conformal!` broadcast
walks straight into a no-method-matching error when it hits an ellipse.

### A/B reproduction

Empirically verified today against `origin/main @ 5494caa`:

```julia
cs = CoordinateSystem("elp", nm)
place!(cs, Ellipse(Point(0.0μm, 0.0μm), (5.0μm, 3.0μm), 0.0°), :l1)
sm = SolidModel("elp"; overwrite=true)
render_conformal!(sm, cs)
```

On `main`:
```
MethodError: no method matching _add_conformal!(::ConformalRenderContext,
    ::Ellipse{Quantity{Float64, 𝐋, ...}}, ::SemanticMeta,
    ::OpenCascade; zmap=..., points_cache=...)
```

On this branch: succeeds — one OCC surface, `l1` physical group created.

## What it does

Adds a single `_add_conformal!(::Ellipse, ...)` method in
`src/solidmodels/conformal/conformal.jl`. It mirrors stock `render!`'s
ellipse path directly (native `k.add_ellipse(...)`), which is the correct
thing here: a smooth closed curve has nothing to share with neighbours, so
there's no edge-cache participation to design.

## Why it matters

Two capabilities that were previously broken now work:

- **Rendering a `CoordinateSystem` with any `Ellipse` element** through the
  curve-preserving path — ellipses stay as native OCC primitives instead of
  discretized polylines, and the `.xao` is 10–20× smaller than the
  equivalent discretized output for autofill-heavy layouts.
- **Full-chip conformal renders on layouts using `Circle` autofill patterns**
  can now use `render_conformal!` end-to-end without preprocessing the
  ellipses out or falling back to the stock render path.

## Verification

- Two new testsets in `test/test_conformal_render.jl`:
  1. **`render_conformal! with Ellipse (kept as native OCC primitive)`** —
     a single `Ellipse` renders to one OCC surface with exactly one bounding
     curve (verifies the native-primitive path, not chord chain).
  2. **`render_conformal! with a Circle in a mixed layer`** — two adjacent
     rectangles + a disjoint circle produce 3 surfaces and 8 total edges
     (4 + 3-with-shared + 1), confirming that the shared-edge cache
     continues to dedup the rectangles when a circle is in the mix, and that
     the cache-hits telemetry records the shared boundary.
  Both testsets fail with `MethodError` on `main` today; they pass here.
- Full ConformalRender suite: 51/51 pass.
- `scripts/format.jl check` clean.

## Scope

+34 lines in `src/solidmodels/conformal/conformal.jl` (the handler + two new
imports: `Ellipse`, and `center`/`r1`/`r2`/`angle` from
`DeviceLayout.Polygons`).
+43 lines in `test/test_conformal_render.jl`.
+8 lines in `CHANGELOG.md`.

Independent of any other open PR.

## End-to-end context

This fix was surfaced by a downstream flip-chip project's full-chip
`render_conformal!` pass (see the OffsetSegment direction-canonicalize
PR for the companion fix and the full-chip validation summary).
Layouts using `Circle(...)` autofill patterns for ground-plane cutouts
hit this branch on every autofill circle; before this PR they failed
at layout-render time and could not proceed to mesh at all.

## A/B on the DemoQPU17 autofill idiom

Ran `render_conformal!` on a fixture that copies the QPU17 autofill
pattern verbatim from `examples/DemoQPU17/DemoQPU17.jl`:

```julia
hole_cs = CoordinateSystem("holes")
place!(hole_cs, not_simulated(Circle(5μm)), METAL_NEGATIVE)
autofill!(cs, hole_cs, ...)  # 551 refs across a 3 mm × 2 mm grid at 100 μm
```

- On `main @ 5850ccc`: `MethodError: no method matching _add_conformal!(
  ::ConformalRenderContext, ::Ellipse{...}, ::SemanticMeta,
  ::OpenCascade; ...)` at `conformal.jl:487`. Layout render halts.
- On this branch: 551 surfaces + 551 curves rendered in ~1.1 s, no
  warnings. Cache stats `hits=misses=arcs=splines=0` — expected, since
  the ellipse dispatch emits native OCC `k.add_ellipse` and does not
  participate in the shared-edge cache (a smooth closed curve has
  nothing to share with neighbours).

The validation script and the reproducer are self-contained on top of
public DL APIs (no downstream project code).

