### PR TITLE
Remove ArrayEntity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ The format of this changelog is based on
   does mean that `Route{T}` and `RouteComponent{T}` are no longer concrete, and their `RouteRule` cannot
   be changed in-place to a different type.
 
+### Removed
+
+  - `ArrayEntity`, an unexported and undocumented wrapper that presented an array of
+    `GeometryEntity` as a single entity. Use a plain `Vector` of entities instead.
+
 ## 1.18.1 (2026-09-07)
 
 ### Fixed

--- a/src/entities.jl
+++ b/src/entities.jl
@@ -44,18 +44,6 @@ Not all styles need be valid for any given entity type.
 """
 abstract type GeometryEntity{T} <: AbstractGeometry{T} end
 
-###### Array of GeometryEntity as a GeometryEntity
-"""
-    struct ArrayEntity{T, S} <: GeometryEntity{T}
-        a::S
-    end
-
-A wrapper `GeometryEntity` for an `AbstractArray` `a` of `GeometryEntity{T}`.
-"""
-struct ArrayEntity{T, S <: AbstractArray{<:GeometryEntity{T}}} <: GeometryEntity{T}
-    a::S
-end
-
 ######## GeometryEntity API
 # Include methods for ::Any to take arrays and iterators
 """
@@ -385,31 +373,6 @@ end
 (f::ScaledIsometry{T})(ent::AbstractGeometry) where {T} = transform(ent, f)
 # IdentityTransformation is always valid, never copies
 (f::IdentityTransformation)(ent::AbstractGeometry) = ent
-
-#### Interface methods for ArrayEntity
-# Iteration
-Base.iterate(aent::ArrayEntity) = iterate(aent.a)
-Base.iterate(aent::ArrayEntity, state) = iterate(aent.a, state)
-Base.IteratorSize(::Type{ArrayEntity{T, S}}) where {T, S} = Base.IteratorSize(S)
-Base.IteratorEltype(::Type{ArrayEntity{T, S}}) where {T, S} = Base.IteratorEltype(S)
-Base.eltype(::Type{ArrayEntity{T, S}}) where {T, S} = Base.eltype{S}
-Base.length(aent::ArrayEntity) = length(aent.a)
-Base.size(aent::ArrayEntity) = size(aent.a)
-Base.size(aent::ArrayEntity, dim) = size(aent.a, dim)
-Base.isdone(aent::ArrayEntity) = Base.isdone(aent.a)
-Base.isdone(aent::ArrayEntity, state) = Base.isdone(aent.a, state)
-# Indexing
-Base.getindex(aent::ArrayEntity, i) = getindex(aent.a, i)
-Base.setindex!(aent::ArrayEntity, v, i) = setindex!(aent.a, v, i)
-Base.firstindex(aent::ArrayEntity) = firstindex(aent.a)
-Base.lastindex(aent::ArrayEntity) = lastindex(aent.a)
-# GeometryEntity
-to_polygons(aent::ArrayEntity) = reduce(vcat, to_polygons.(aent.a))
-transform(aent::ArrayEntity, f::Transformation) = ArrayEntity(f.(aent.a))
-lowerleft(aent::ArrayEntity) = lowerleft(aent.a)
-upperright(aent::ArrayEntity) = upperright(aent.a)
-halo(aent::ArrayEntity, outer_delta, inner_delta=nothing) =
-    ArrayEntity(halo(aent.a, outer_delta, inner_delta))
 
 ######## Entity selection
 function SpatialIndexing.mbr(ent::AbstractGeometry{T}) where {T}

--- a/src/styles.jl
+++ b/src/styles.jl
@@ -102,14 +102,6 @@ function to_polygons(styled_ent::StyledEntity; kwargs...)
     return to_polygons(styled_ent.ent, styled_ent.sty; kwargs...)
 end
 
-# Dispatch directly on array entity to avoid ambiguity
-function to_polygons(
-    styled_ent::StyledEntity{T, U};
-    kwargs...
-) where {T, U <: ArrayEntity{T}}
-    return to_polygons.(styled_ent.ent.a, styled_ent.sty; kwargs...)
-end
-
 # If a style has no specialization for `ent`, convert `ent` to polygons first
 function to_polygons(ent::GeometryEntity, sty::GeometryEntityStyle; kwargs...)
     return to_polygons.(to_polygons(ent; kwargs...), sty; kwargs...)

--- a/test/test_entity.jl
+++ b/test/test_entity.jl
@@ -48,20 +48,6 @@
     @test halo(plus, 1) == OriginPlus(7, 4)
     @test length(halo(aplus, 1)) == 2 # separate halos
 
-    @testset "ArrayEntity" begin
-        r = Rectangle(Point(5, 5), Point(10, 10))
-        a = DeviceLayout.ArrayEntity(GeometryEntity{Int}[plus, r])
-        c = Cell{Float64}("ex")
-        render!(c, a)
-        @test length(elements(c)) == length(a)
-        ah = halo(a, 2)
-        @test ah[1] isa OriginPlus{Int}
-        @test ah[end] isa Polygon{Int}
-        @test footprint(a) == bounds(plus, r)
-        @test (Point(1, 1) + a) isa DeviceLayout.ArrayEntity
-        @test offset(plus, 2)[1] == to_polygons(ah[1])
-    end
-
     @testset "EntityStyle" begin
         pr = Polygons.Rounded(plus, 0.1)
         @test DeviceLayout.unstyled(pr) == plus
@@ -70,9 +56,6 @@
         ### Issue #85
         @test to_polygons(translate(pr, Point(1, 1))) ≈ translate(poly, Point(1, 1))
         ###
-        a = DeviceLayout.ArrayEntity([plus, plus])
-        pa = Polygons.Rounded(0.1)(a)
-        @test all(to_polygons(pa) .== poly)
 
         opt_plus = optional_entity(plus, :opt_ent; default=false)
         opt_round_plus = OptionalStyle(plus, Polygons.Rounded(0.1), :opt_round)


### PR DESCRIPTION
The wrapper type was never exported or documented and had no users outside its own tests. Its iteration interface also defined `eltype` incorrectly (`Base.eltype{S}`), so `collect` on an `ArrayEntity` threw a `TypeError`. Collections of entities are already handled by the generic `::Any` methods of the `GeometryEntity` API, so a plain `Vector` is the replacement.

Closes #310.