### PR TITLE
SemanticMeta: add Base.isless total ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The format of this changelog is based on
     that injects each group's vertices onto every other group's edges — the form needed to
     make adjacent physical groups conformal before `render_conformal!`. Curved edges are split
     natively via `Paths.split`; no discretization.
+  - `SemanticMeta` is now totally ordered (`Base.isless` on `(layer, index, level)`), so it can
+    key a sorted collection. In particular the all-pairs `split_t_junctions!(groups::AbstractDict)`
+    can be keyed directly by `SemanticMeta`, giving deterministic all-pairs ownership without a
+    caller-supplied `Symbol` key.
 
 ### Fixed
 

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -42,6 +42,15 @@ SemanticMeta(meta::SemanticMeta; index=layerindex(meta), level=level(meta)) =
 SemanticMeta(meta::Meta; index=layerindex(meta), level=level(meta)) =
     SemanticMeta(layername(meta); index=index, level=level)
 
+# Total ordering on the struct fields, so `SemanticMeta` can key a sorted
+# collection (e.g. `sort!(collect(keys(groups)))` in `split_t_junctions!`, where
+# a deterministic key order makes all-pairs ownership independent of `Dict`
+# iteration order). Ordered by `layer` first (the primary grouping), then
+# `index`, then `level`. `Symbol` is itself totally ordered, so the tuple
+# comparison is a total order consistent with the derived `==`.
+Base.isless(a::SemanticMeta, b::SemanticMeta) =
+    isless((a.layer, a.index, a.level), (b.layer, b.index, b.level))
+
 const UNDEF_META = SemanticMeta(:undefined)
 const NORENDER_META = SemanticMeta(:norender)
 

--- a/test/test_postrender.jl
+++ b/test/test_postrender.jl
@@ -958,4 +958,71 @@ end
         groups = Dict("a" => [A], "b" => [B])
         @test split_t_junctions!(groups) == 1
     end
+
+    @testset "Dict method works with SemanticMeta keys" begin
+        # SemanticMeta is totally ordered (Base.isless on (layer, index, level)),
+        # so it can key the all-pairs Dict directly — the shape the target-driven
+        # conformal orchestrator uses (levelwise metadata → regions).
+        T = typeof(1.0μm)
+        A = CurvilinearRegion(
+            CurvilinearPolygon(
+                Point{T}[p(0μm, 0μm), p(10μm, 0μm), p(10μm, 10μm), p(0μm, 10μm)]
+            )
+        )
+        B = CurvilinearRegion(
+            CurvilinearPolygon(
+                Point{T}[
+                    p(10μm, 0μm),
+                    p(20μm, 0μm),
+                    p(20μm, 10μm),
+                    p(10μm, 10μm),
+                    p(10μm, 5μm)
+                ]
+            )
+        )
+        groups = Dict(SemanticMeta(:metal) => [A], SemanticMeta(:ground) => [B])
+        @test split_t_junctions!(groups) == 1
+    end
+end
+
+@testitem "SemanticMeta ordering" setup = [CommonTestSetup] begin
+    import DeviceLayout: SemanticMeta
+
+    @testset "isless orders by (layer, index, level)" begin
+        # Primary key: layer (Symbols compare lexicographically)
+        @test SemanticMeta(:a) < SemanticMeta(:b)
+        @test !(SemanticMeta(:b) < SemanticMeta(:a))
+        # Secondary key: index, within the same layer
+        @test SemanticMeta(:a; index=1) < SemanticMeta(:a; index=2)
+        # Tertiary key: level, within the same (layer, index)
+        @test SemanticMeta(:a; index=1, level=1) < SemanticMeta(:a; index=1, level=2)
+        # layer dominates index and level
+        @test SemanticMeta(:a; index=9, level=9) < SemanticMeta(:b; index=1, level=1)
+    end
+
+    @testset "consistent with == (no strict-order ties for distinct values)" begin
+        x = SemanticMeta(:a; index=1, level=1)
+        @test !(x < x)                              # irreflexive
+        @test x == SemanticMeta(:a; index=1, level=1)
+        y = SemanticMeta(:a; index=1, level=2)
+        @test (x < y) ⊻ (y < x)                     # exactly one direction for x != y
+    end
+
+    @testset "sortable / deterministic key order" begin
+        ks = [
+            SemanticMeta(:ground),
+            SemanticMeta(:metal; index=2),
+            SemanticMeta(:metal; index=1),
+            SemanticMeta(:metal; index=1, level=2)
+        ]
+        s = sort(ks)
+        @test s == [
+            SemanticMeta(:ground),
+            SemanticMeta(:metal; index=1, level=1),
+            SemanticMeta(:metal; index=1, level=2),
+            SemanticMeta(:metal; index=2)
+        ]
+        # Sorting is stable regardless of starting permutation
+        @test sort(reverse(ks)) == s
+    end
 end


### PR DESCRIPTION
## What this adds

`Base.isless(::SemanticMeta, ::SemanticMeta)`, ordering by `(layer, index, level)`.

`SemanticMeta` is an immutable struct, so it already has a derived `==` and `hash`,
but no ordering — `sort([SemanticMeta(:a), SemanticMeta(:b)])` fails with
`MethodError: no method matching isless(::SemanticMeta, ::SemanticMeta)`.

## Why

The all-pairs `split_t_junctions!(groups::AbstractDict)` sorts its keys so that
group→owner assignment is deterministic across runs (independent of `Dict`
iteration order). Its docstring already states "the key type only needs to be
sortable." Today that means `Symbol` or `String` keys; a caller who wants to key
levelwise 2D-preprocessing output by `SemanticMeta` (layer + index + level, the
natural identity for a rendered group) can't, because `SemanticMeta` isn't
ordered.

This is the small enabling piece for keying that all-pairs noding — and the
conformal-render orchestrator built on top of it — directly by `SemanticMeta`,
instead of threading a parallel `Symbol` key.

## What it does

```julia
Base.isless(a::SemanticMeta, b::SemanticMeta) =
    isless((a.layer, a.index, a.level), (b.layer, b.index, b.level))
```

`layer` is the primary key (a `Symbol`, compared lexicographically), then `index`,
then `level`. `Symbol` is itself totally ordered, so this is a total order
consistent with the derived `==`.

## Verification

- New `SemanticMeta ordering` testitem: orders by each field in priority order,
  `layer` dominates `index`/`level`, irreflexive, trichotomy for distinct values,
  and `sort` is deterministic regardless of the input permutation.
- New `split_t_junctions!` test keying the all-pairs Dict by `SemanticMeta`
  (`Dict(SemanticMeta(:metal) => …, SemanticMeta(:ground) => …)`) — injects the
  expected shared-edge vertex, same as the `Symbol`/`String`-keyed cases.
- `scripts/format.jl check` clean; Postrender + split_t_junctions! + new testitem
  all pass.

Small and self-contained.
